### PR TITLE
docs: bootstrap open second brain project

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "open-second-brain",
+  "version": "0.0.1",
+  "description": "Plugin-first second brain package for AI agents and humans.",
+  "author": "Open Second Brain contributors",
+  "license": "MIT",
+  "homepage": "https://github.com/itechmeat/open-second-brain",
+  "repository": "https://github.com/itechmeat/open-second-brain",
+  "keywords": ["second-brain", "obsidian", "agents", "skills", "event-log"]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "open-second-brain",
+  "version": "0.0.1",
+  "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, and other agent runtimes.",
+  "skills": "./skills",
+  "keywords": ["second-brain", "obsidian", "agents", "skills", "event-log"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# OS/editor noise
+.DS_Store
+.idea/
+.vscode/
+*.swp
+
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+
+# Node
+node_modules/
+
+# Local config and sandbox data
+.env
+.env.*
+!.env.example
+.open-second-brain.local.yaml
+sandbox-vault/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Open Second Brain contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,192 @@
+# Architecture
+
+Open Second Brain is organized around a stable core and multiple runtime adapters.
+
+## Layers
+
+```text
+Agent runtime
+  -> runtime adapter/plugin
+    -> skills and commands
+      -> CLI/core library
+        -> vault files and local config
+```
+
+## Core responsibilities
+
+The core should eventually provide deterministic operations for:
+
+- locating configuration;
+- validating configuration;
+- initializing a vault profile;
+- appending event log entries;
+- exporting redacted config snapshots;
+- checking vault health;
+- running migrations;
+- querying known indexes where available.
+
+The core should not depend on Hermes, Claude Code, Codex, or Obsidian internals.
+
+## Runtime adapters
+
+### Hermes adapter
+
+The Hermes adapter can be a real runtime plugin:
+
+```text
+plugins/hermes/
+  plugin.yaml
+  __init__.py
+```
+
+Possible responsibilities:
+
+- register available hooks;
+- check configuration at gateway startup;
+- expose readiness diagnostics;
+- connect Hermes session metadata to Open Second Brain profiles;
+- optionally add event capture hooks when safe and explicit.
+
+The Hermes adapter must not silently change model routing, write secrets, or mutate unrelated vault areas.
+
+### Claude Code adapter
+
+Claude Code support should be packaged through plugin metadata and bundled skills/commands.
+
+The adapter should focus on:
+
+- installing skills;
+- exposing slash-command style workflows where supported;
+- optionally configuring hooks;
+- optionally declaring MCP configuration in later versions.
+
+### Codex adapter
+
+Codex supports plugins as installable distribution units for reusable skills and apps. The Codex adapter should include:
+
+```text
+.codex-plugin/plugin.json
+skills/
+.mcp.json        # later, optional
+hooks/           # later, optional
+assets/          # later, optional
+```
+
+v0 should keep Codex support simple: plugin manifest plus shared skills and scripts.
+
+## Configuration model
+
+Open Second Brain separates immutable package code from mutable user configuration and data.
+
+### Machine-local config
+
+Machine-local config points a runtime to a vault and environment profile.
+
+Suggested path:
+
+```text
+$OPEN_SECOND_BRAIN_CONFIG
+~/.config/open-second-brain/config.yaml
+```
+
+Example:
+
+```yaml
+version: 1
+instance_name: Hermes Second Brain
+runtime: hermes
+environment_name: vps-techmeat
+vault:
+  path: /root/vault
+  agent_dir: AI Wiki
+identity:
+  agent_name: hermes-vps-agent
+  user_language: ru
+policy:
+  write_mode: agent-owned-dir
+```
+
+Machine-local config may contain absolute paths. It must not contain secrets.
+
+### Vault-portable config
+
+Vault-portable config lives inside the vault and travels with backup/sync.
+
+Suggested paths:
+
+```text
+<vault>/<agent_dir>/_open-second-brain.yaml
+<vault>/<agent_dir>/_OPEN_SECOND_BRAIN.md
+```
+
+It describes:
+
+- owner identity;
+- language/timezone preferences;
+- vault schema;
+- write boundaries;
+- known agents;
+- event log backend;
+- durable operating rules.
+
+It must not contain secrets.
+
+## Backup model
+
+Open Second Brain should assume the vault is the primary portable backup unit.
+
+Recommended behavior:
+
+- vault-portable config is backed up with the vault;
+- machine-local config can be regenerated with `asb init --adopt-vault`;
+- `asb export-config` writes a redacted machine snapshot into the vault;
+- secrets are excluded and represented as `[REDACTED]` only when needed.
+
+## Vault layout
+
+A default vault layout may look like:
+
+```text
+AI Wiki/
+  _OPEN_SECOND_BRAIN.md
+  _open-second-brain.yaml
+  index.md
+  hot.md
+  log.md
+  identity/
+    user.md
+    agents.md
+  system/
+    config-snapshots/
+  events/
+```
+
+This layout is intentionally agent-owned. The project should not mix agent-generated wiki pages into a user's personal notes without clear boundaries.
+
+## Event log
+
+The event log is append-only. It records operational events, not polished knowledge.
+
+Default backend:
+
+```yaml
+event_log:
+  backend: daily-markdown
+  daily_dir: Daily
+  section: Agent Events
+```
+
+Later backends may include JSONL, SQLite, or both.
+
+## Security rules
+
+Open Second Brain must not store:
+
+- API keys;
+- tokens;
+- passwords;
+- private SSH keys;
+- credentials;
+- connection strings containing secrets.
+
+If secret-like content appears in input, tools should redact it as `[REDACTED]` before writing.

--- a/docs/idea.md
+++ b/docs/idea.md
@@ -1,0 +1,79 @@
+# Open Second Brain Idea
+
+Open Second Brain is a portable second brain system for agentic work. It packages a shared vault protocol, event log, configuration model, CLI tools, skills, and runtime adapters so different AI agents can participate in the same knowledge system.
+
+The initial local instance that motivated this project is Hermes Second Brain: a Hermes-first setup on a VPS where agents develop small projects, operate infrastructure, and write durable operational notes into an Obsidian-compatible vault. The open-source package should not be Hermes-specific. Hermes is one adapter.
+
+## Core idea
+
+Agents need two different memory layers:
+
+1. Runtime memory: short, compact facts injected into future conversations by a specific agent runtime.
+2. Vault memory: durable, inspectable, portable Markdown knowledge owned by the user.
+
+Runtime memory is useful but not portable. Vault memory is portable but needs clear write policies, schemas, and tooling so agents do not turn it into an unstructured dump.
+
+Open Second Brain defines the vault layer and provides adapters for runtimes.
+
+## Why plugin-first
+
+A standalone skill can describe a workflow, but it is a weak owner of operational state. A plugin package can provide a stronger lifecycle:
+
+- installation;
+- discovery;
+- config schema;
+- status checks;
+- redacted config export;
+- migrations;
+- runtime hooks where supported;
+- shared scripts;
+- bundled skills;
+- optional MCP configuration later.
+
+The project should still include skills. Skills remain the best way to teach agents when and how to use the system. The plugin/package is the distribution and lifecycle layer; skills are protocol and reasoning guidance.
+
+## Name
+
+The public project name is `open-second-brain`.
+
+Local instances may use names such as:
+
+- Hermes Second Brain;
+- Claude Second Brain;
+- Team Second Brain;
+- Project Second Brain.
+
+The project should avoid naming that implies it is only for one agent runtime.
+
+## Event log and daily log
+
+The existing `daily-log` idea should become part of this project as an event log component.
+
+Recommended terminology:
+
+- component: event log;
+- compatibility command: `vault-log`;
+- possible skill name: `agent-event-log`;
+- default backend: daily Markdown notes.
+
+A daily note is one storage backend, not the whole concept. Other possible backends include JSONL, SQLite, or a hybrid mode.
+
+The event log is append-only operational evidence. The wiki/second-brain layer is synthesized knowledge. These must remain separate:
+
+- event log: what happened, when, by whom;
+- second brain wiki: what we learned, what remains true, what should guide future work.
+
+## v0 decision
+
+v0 should be CLI + docs + skills + plugin manifests.
+
+Do not start with a daemon or full MCP server. The early goal is a portable, understandable, installable package that can be used by Hermes, Claude Code, Codex, and future agent runtimes.
+
+Future versions may add:
+
+- an MCP server;
+- deeper Hermes hooks;
+- Claude/Codex hook integrations;
+- automated capture workflows;
+- richer query/indexing support;
+- local UI or documentation site.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,89 @@
+# Roadmap
+
+## v0: portable package skeleton
+
+Goal: create an understandable open-source package that can be installed or inspected by Hermes, Claude Code, Codex, and humans.
+
+Scope:
+
+- README and design documentation;
+- architecture notes;
+- CLI placeholders;
+- event log concept;
+- skills for Open Second Brain and event logging;
+- Hermes plugin skeleton;
+- Claude Code plugin manifest;
+- Codex plugin manifest;
+- no daemon;
+- no required MCP server;
+- no automatic background writes.
+
+## v0.1: deterministic CLI
+
+Planned commands:
+
+```text
+asb init
+asb status
+asb doctor
+asb export-config
+asb append-event
+vault-log
+```
+
+Expected behavior:
+
+- locate config;
+- initialize machine-local config;
+- adopt an existing vault profile;
+- append event log entries;
+- export redacted snapshots;
+- validate schema and paths.
+
+## v0.2: vault profile bootstrap
+
+Planned outputs:
+
+```text
+AI Wiki/_OPEN_SECOND_BRAIN.md
+AI Wiki/_open-second-brain.yaml
+AI Wiki/index.md
+AI Wiki/hot.md
+AI Wiki/log.md
+AI Wiki/identity/user.md
+AI Wiki/identity/agents.md
+```
+
+## v0.3: runtime polish
+
+- Hermes plugin health checks;
+- Claude Code plugin commands;
+- Codex plugin manifest validation;
+- better install docs;
+- test fixtures and sandbox vaults.
+
+## v1: MCP tool server
+
+Optional MCP server over the same core operations:
+
+- `second_brain_status`;
+- `second_brain_query`;
+- `second_brain_capture`;
+- `event_log_append`;
+- `vault_health`.
+
+The MCP server should be optional. CLI must remain the baseline.
+
+## v2: richer automation
+
+Possible future work:
+
+- opt-in event capture hooks;
+- local indexing;
+- semantic retrieval;
+- background compaction;
+- automatic knowledge synthesis;
+- documentation site;
+- package registries and marketplaces.
+
+Automation must remain explicit and reversible.

--- a/plugins/hermes/__init__.py
+++ b/plugins/hermes/__init__.py
@@ -1,0 +1,19 @@
+"""Hermes adapter skeleton for Open Second Brain.
+
+v0 intentionally avoids deep runtime behavior. Future versions may register
+Hermes hooks for configuration checks, status reporting, and explicit event
+logging integrations.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def register(ctx: Any) -> None:
+    """Register the Hermes plugin.
+
+    The v0 skeleton is intentionally a no-op. It exists so the package shape is
+    visible while the CLI/config contract is designed.
+    """
+    return None

--- a/plugins/hermes/plugin.yaml
+++ b/plugins/hermes/plugin.yaml
@@ -1,0 +1,6 @@
+name: open-second-brain
+version: "0.0.1"
+description: "Hermes adapter skeleton for Open Second Brain."
+author: "Open Second Brain contributors"
+kind: standalone
+provides_hooks: []

--- a/scripts/asb
+++ b/scripts/asb
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat <<'MSG'
+open-second-brain CLI placeholder
+
+Planned commands:
+  asb init
+  asb status
+  asb doctor
+  asb export-config
+  asb append-event
+
+This repository is currently at the v0 documentation/skeleton stage.
+MSG

--- a/scripts/vault-log
+++ b/scripts/vault-log
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat <<'MSG'
+vault-log placeholder for open-second-brain
+
+This compatibility command will append short factual entries to the configured event log backend.
+In v0, the implementation is intentionally not included yet.
+MSG

--- a/skills/agent-event-log/SKILL.md
+++ b/skills/agent-event-log/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: agent-event-log
+description: Append-only operational event logging for Open Second Brain. Daily Markdown notes are the default backend.
+---
+
+# Agent Event Log
+
+Use this skill after substantial work or when the user asks for an operational log entry.
+
+## Purpose
+
+The event log records what happened, when, and which agent did it. It is evidence, not a polished wiki page.
+
+## Rules
+
+- Append only.
+- Keep entries short and factual.
+- Include the agent name when supported.
+- Do not include secrets.
+- Redact sensitive values as `[REDACTED]`.
+
+## Compatibility
+
+The compatibility command is `vault-log`.
+
+Future Open Second Brain CLI commands may include:
+
+```bash
+asb append-event --as <agent-name> "message"
+vault-log --as <agent-name> "message"
+```
+
+## Example
+
+```bash
+vault-log --as hermes-vps-agent "created initial open-second-brain repository documentation and plugin skeleton"
+```

--- a/skills/open-second-brain/SKILL.md
+++ b/skills/open-second-brain/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: open-second-brain
+description: Use Open Second Brain to read, write, and maintain an agent-owned second brain in an Obsidian-compatible Markdown vault.
+---
+
+# Open Second Brain
+
+Use this skill when a user asks an agent to use, configure, inspect, or maintain Open Second Brain.
+
+## Core principles
+
+- Treat the vault as user-owned durable knowledge.
+- Write only inside configured agent-owned areas unless explicitly instructed.
+- Keep raw operational events separate from synthesized knowledge.
+- Never write secrets, tokens, passwords, private keys, or credential-bearing connection strings.
+- Prefer deterministic CLI commands over guessing file paths.
+
+## v0 expectation
+
+In v0, Open Second Brain is expected to provide documentation, scripts, skills, and plugin manifests. Deep runtime automation and MCP tools are future work.
+
+## Default workflow
+
+1. Check whether Open Second Brain is configured.
+2. Read the machine-local config if available.
+3. Read the vault-local operating manual if available.
+4. Use `vault-log` or `asb append-event` for event logging.
+5. Use Markdown edits for durable synthesized knowledge only when the user asks or the configured policy allows it.
+
+## Safety
+
+If a write operation might affect personal notes outside the agent-owned area, ask for explicit confirmation.


### PR DESCRIPTION
## Summary
- Add initial Open Second Brain idea, architecture, and roadmap docs
- Add v0 skill skeletons for Open Second Brain and Agent Event Log
- Add CLI placeholders and Hermes/Claude/Codex plugin manifests

## Test Plan
- python3 -m json.tool .claude-plugin/plugin.json
- python3 -m json.tool .codex-plugin/plugin.json
- python3 -m py_compile plugins/hermes/__init__.py
- bash -n scripts/asb
- bash -n scripts/vault-log