### PR TITLE
feat: add v0.3 runtime polish

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,5 +6,49 @@
   "license": "MIT",
   "homepage": "https://github.com/itechmeat/open-second-brain",
   "repository": "https://github.com/itechmeat/open-second-brain",
-  "keywords": ["second-brain", "obsidian", "agents", "skills", "event-log"]
+  "keywords": ["second-brain", "obsidian", "agents", "skills", "event-log"],
+  "commands": [
+    {
+      "name": "status",
+      "description": "Show Open Second Brain configuration status.",
+      "command": "scripts/o2b",
+      "args": ["status"]
+    },
+    {
+      "name": "doctor",
+      "description": "Run vault, config, and plugin manifest health checks.",
+      "command": "scripts/o2b",
+      "args": ["doctor"]
+    },
+    {
+      "name": "init",
+      "description": "Initialize a sandbox or production vault profile.",
+      "command": "scripts/o2b",
+      "args": ["init"]
+    },
+    {
+      "name": "index",
+      "description": "Regenerate the vault wiki index from Markdown pages.",
+      "command": "scripts/o2b",
+      "args": ["index"]
+    },
+    {
+      "name": "append-event",
+      "description": "Append an agent event to the daily Markdown event log.",
+      "command": "scripts/o2b",
+      "args": ["append-event"]
+    },
+    {
+      "name": "export-config",
+      "description": "Write a redacted configuration snapshot as JSON.",
+      "command": "scripts/o2b",
+      "args": ["export-config"]
+    },
+    {
+      "name": "vault-log",
+      "description": "Compatibility wrapper for appending event log entries.",
+      "command": "scripts/vault-log",
+      "args": []
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Open Second Brain is an open-source, plugin-first second brain package for AI ag
 
 It is designed to give Hermes Agent, Claude Code, OpenAI Codex, and other agentic runtimes a shared, portable way to remember durable project knowledge, append operational event logs, query an Obsidian-compatible vault, and carry the same workflow across machines without locking knowledge into one agent runtime.
 
-Status: experimental v0. The repository currently includes documentation, a tested Python CLI foundation, skills, and plugin manifests. Deeper runtime integrations and MCP support are planned for later versions.
+Status: experimental v0.3. The repository currently includes documentation, a tested Python CLI foundation, skills, plugin manifests, and lightweight runtime health checks. Deeper runtime integrations and MCP support are planned for later versions.
 
 ## Goals
 
@@ -64,6 +64,9 @@ Run the local CLI without installing the package:
 
 ```bash
 scripts/o2b status
+scripts/o2b init --vault /path/to/vault --name "My Second Brain"
+scripts/o2b doctor --vault /path/to/vault --repo .
+scripts/o2b index --vault /path/to/vault
 scripts/o2b append-event --vault /path/to/vault --as agent-name --date 2026.05.06 --time 10:15 "created first entry"
 scripts/o2b export-config --config ~/.config/open-second-brain/config.yaml --output /tmp/open-second-brain-config.json
 scripts/vault-log --vault /path/to/vault --as agent-name "compatibility event entry"
@@ -72,9 +75,50 @@ scripts/vault-log --vault /path/to/vault --as agent-name "compatibility event en
 The current CLI is intentionally small and dependency-free. It supports:
 
 - config path discovery through `OPEN_SECOND_BRAIN_CONFIG`, `XDG_CONFIG_HOME`, or `~/.config/open-second-brain/config.yaml`;
+- vault bootstrap with an agent-owned `AI Wiki` profile;
+- vault, config, and plugin manifest health checks;
+- wiki index regeneration for Markdown pages;
 - redacted config export;
 - append-only daily Markdown event logging;
 - a `vault-log` compatibility wrapper.
+
+Common setup flow:
+
+```bash
+git clone https://github.com/itechmeat/open-second-brain.git
+cd open-second-brain
+scripts/o2b init --vault ~/SecondBrainSandbox --name "Sandbox Brain"
+scripts/o2b doctor --vault ~/SecondBrainSandbox --repo .
+scripts/o2b append-event --vault ~/SecondBrainSandbox --as setup "initialized sandbox vault"
+scripts/o2b index --vault ~/SecondBrainSandbox
+```
+
+The CLI is safe to run directly from the checkout. For shell use, add the repo's
+`scripts` directory to `PATH`, or call `scripts/o2b` and `scripts/vault-log`
+explicitly. For Python module use, set `PYTHONPATH=src` and run
+`python3 -m open_second_brain.cli ...`.
+
+## Plugin and runtime install notes
+
+The runtime adapters are intentionally thin. They advertise deterministic CLI
+commands and health checks; they do not start daemons, MCP servers, or background
+automation.
+
+- Claude Code: `.claude-plugin/plugin.json` contains command metadata for
+  `status`, `doctor`, `init`, `index`, `append-event`, `export-config`, and the
+  `vault-log` compatibility wrapper. Commands point at portable repo-relative
+  scripts.
+- Codex: `.codex-plugin/plugin.json` declares package metadata and the skills
+  directory. `scripts/o2b doctor --repo .` validates required Codex manifest
+  fields.
+- Hermes: `plugins/hermes/__init__.py` exposes `health(repo_root=None)` and
+  `check_health(repo_root=None)`. `register(ctx)` makes a best-effort attachment
+  to common context shapes such as `register_health_check(...)`,
+  `add_health_check(...)`, or a `health_checks` dict/list.
+
+Create disposable test vaults with `scripts/o2b init --vault /tmp/o2b-sandbox`.
+Keep secrets outside the vault and use `scripts/o2b export-config` when sharing
+debug snapshots so sensitive keys are redacted.
 
 ## Development
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,7 +40,7 @@ vault-log
 
 All commands are dependency-free and tested with Python `unittest` (34 tests).
 
-## v0.2: vault profile bootstrap ✅ (in-progress)
+## v0.2: vault profile bootstrap ✅
 
 `o2b init` creates:
 
@@ -54,17 +54,20 @@ AI Wiki/identity/user.md
 AI Wiki/identity/agents.md
 ```
 
-Remaining v0.2 work:
+Implemented:
 - vault-local operating manual (`_OPEN_SECOND_BRAIN.md`) to drive agent behavior;
-- query helpers for the wiki layer.
+- query helpers for the wiki layer (`parse_frontmatter`, `extract_wikilinks`, `list_vault_pages`);
+- `o2b index` to regenerate `AI Wiki/index.md` from discovered vault pages.
 
-## v0.3: runtime polish
+## v0.3: runtime polish ✅
 
-- Hermes plugin health checks;
-- Claude Code plugin commands;
-- Codex plugin manifest validation;
-- better install docs;
-- test fixtures and sandbox vaults.
+Implemented:
+
+- Hermes plugin health checks with safe best-effort registration;
+- Claude Code plugin command metadata for `status`, `doctor`, `init`, `index`, `append-event`, `export-config`, and `vault-log`;
+- Codex, Claude, and Hermes plugin manifest validation in `o2b doctor --repo`;
+- better install and runtime notes in README;
+- test fixtures for sandbox vaults and plugin manifest repos.
 
 ## v1: MCP tool server
 

--- a/plugins/hermes/__init__.py
+++ b/plugins/hermes/__init__.py
@@ -1,19 +1,124 @@
-"""Hermes adapter skeleton for Open Second Brain.
+"""Hermes adapter for Open Second Brain runtime health checks.
 
-v0 intentionally avoids deep runtime behavior. Future versions may register
-Hermes hooks for configuration checks, status reporting, and explicit event
-logging integrations.
+The adapter intentionally avoids depending on Hermes internals. It exposes small,
+deterministic health helpers that Hermes (or any other runtime) can call directly,
+and ``register(ctx)`` makes a best-effort attempt to attach the health check to
+common plugin context shapes.
 """
 
 from __future__ import annotations
 
-from typing import Any
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Callable
+
+
+HealthReport = dict[str, Any]
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _check_file(path: Path, *, executable: bool = False) -> HealthReport:
+    ok = path.is_file()
+    message = "present" if ok else "missing"
+    if ok and executable and not os.access(path, os.X_OK):
+        ok = False
+        message = "not executable"
+    return {"ok": ok, "path": str(path), "message": message}
+
+
+def _check_json(path: Path) -> HealthReport:
+    base = _check_file(path)
+    if not base["ok"]:
+        return base
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return {"ok": False, "path": str(path), "message": f"invalid JSON: {exc}"}
+    if isinstance(data, dict):
+        return {"ok": True, "path": str(path), "message": "valid JSON object"}
+    return {"ok": False, "path": str(path), "message": "JSON is not an object"}
+
+
+def _check_text_manifest(path: Path) -> HealthReport:
+    base = _check_file(path)
+    if not base["ok"]:
+        return base
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return {"ok": False, "path": str(path), "message": f"unreadable: {exc}"}
+    required = ("name", "version", "description")
+    missing = [field for field in required if not re.search(rf"^{field}\s*:", text, re.MULTILINE)]
+    if missing:
+        return {"ok": False, "path": str(path), "message": "missing fields: " + ", ".join(missing)}
+    return {"ok": True, "path": str(path), "message": "readable manifest"}
+
+
+def health(repo_root: str | Path | None = None) -> HealthReport:
+    """Return deterministic Open Second Brain plugin health.
+
+    The report is data-only so it is safe to serialize in runtimes that do not
+    know this package. No background processes are started and no files are
+    written.
+    """
+
+    root = Path(repo_root) if repo_root is not None else _repo_root()
+    checks = {
+        "hermes_manifest": _check_text_manifest(root / "plugins" / "hermes" / "plugin.yaml"),
+        "claude_manifest": _check_json(root / ".claude-plugin" / "plugin.json"),
+        "codex_manifest": _check_json(root / ".codex-plugin" / "plugin.json"),
+        "o2b_script": _check_file(root / "scripts" / "o2b", executable=True),
+        "vault_log_script": _check_file(root / "scripts" / "vault-log", executable=True),
+    }
+    ok = all(bool(check["ok"]) for check in checks.values())
+    return {"name": "open-second-brain", "ok": ok, "checks": checks}
+
+
+def check_health(repo_root: str | Path | None = None) -> HealthReport:
+    """Compatibility alias for runtimes expecting a check_health callable."""
+
+    return health(repo_root=repo_root)
+
+
+def _attach_health(ctx: Any, callback: Callable[[], HealthReport]) -> bool:
+    for method_name in ("register_health_check", "add_health_check", "register_check"):
+        method = getattr(ctx, method_name, None)
+        if callable(method):
+            try:
+                method("open-second-brain", callback)
+            except TypeError:
+                method(callback)
+            return True
+
+    health_checks = getattr(ctx, "health_checks", None)
+    if isinstance(health_checks, dict):
+        health_checks["open-second-brain"] = callback
+        return True
+    if isinstance(health_checks, list):
+        health_checks.append(("open-second-brain", callback))
+        return True
+
+    try:
+        setattr(ctx, "open_second_brain_health", callback)
+    except Exception:
+        return False
+    return True
 
 
 def register(ctx: Any) -> None:
-    """Register the Hermes plugin.
+    """Register the Hermes plugin health check when the context supports it.
 
-    The v0 skeleton is intentionally a no-op. It exists so the package shape is
-    visible while the CLI/config contract is designed.
+    This remains safe/no-op-ish: unsupported context objects are ignored and no
+    exception is raised for registration incompatibilities.
     """
+
+    try:
+        _attach_health(ctx, check_health)
+    except Exception:
+        return None
     return None

--- a/src/open_second_brain/doctor.py
+++ b/src/open_second_brain/doctor.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -39,14 +41,105 @@ def check_config_writeable(config: Path) -> CheckResult:
     return CheckResult("config_writeable", True, f"config writable: {config}")
 
 
-def check_json_manifest(path: Path, description: str) -> CheckResult:
+def _load_json_manifest(path: Path, description: str) -> tuple[CheckResult, dict[str, Any] | None]:
     if not path.is_file():
-        return CheckResult(description, False, f"missing: {path}")
+        return CheckResult(description, False, f"missing: {path}"), None
     try:
-        json.loads(path.read_text(encoding="utf-8"))
+        data = json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, UnicodeDecodeError) as exc:
-        return CheckResult(description, False, f"invalid JSON: {path} ({exc})")
-    return CheckResult(description, True, f"valid: {path}")
+        return CheckResult(description, False, f"invalid JSON: {path} ({exc})"), None
+    if not isinstance(data, dict):
+        return CheckResult(description, False, f"invalid manifest object: {path}"), None
+    return CheckResult(description, True, f"valid: {path}"), data
+
+
+def check_json_manifest(path: Path, description: str) -> CheckResult:
+    result, _ = _load_json_manifest(path, description)
+    return result
+
+
+def _validate_required_fields(data: dict[str, Any], required: dict[str, type | tuple[type, ...]]) -> list[str]:
+    problems: list[str] = []
+    for field, expected_type in required.items():
+        if field not in data:
+            problems.append(f"missing {field}")
+            continue
+        value = data[field]
+        if not isinstance(value, expected_type):
+            if isinstance(expected_type, tuple):
+                type_names = "/".join(t.__name__ for t in expected_type)
+            else:
+                type_names = expected_type.__name__
+            problems.append(f"{field} must be {type_names}")
+        elif isinstance(value, str) and not value.strip():
+            problems.append(f"{field} must not be empty")
+        elif isinstance(value, list) and not value:
+            problems.append(f"{field} must not be empty")
+    return problems
+
+
+def check_codex_manifest(path: Path) -> CheckResult:
+    result, data = _load_json_manifest(path, "codex_manifest")
+    if data is None:
+        return result
+    required = {
+        "name": str,
+        "version": str,
+        "description": str,
+        "skills": str,
+        "keywords": list,
+    }
+    problems = _validate_required_fields(data, required)
+    if problems:
+        return CheckResult("codex_manifest", False, f"schema invalid: {path} ({'; '.join(problems)})")
+    return CheckResult("codex_manifest", True, f"valid Codex manifest: {path}")
+
+
+def check_claude_manifest(path: Path) -> CheckResult:
+    result, data = _load_json_manifest(path, "claude_manifest")
+    if data is None:
+        return result
+    required = {
+        "name": str,
+        "version": str,
+        "description": str,
+        "author": str,
+        "license": str,
+        "repository": str,
+        "keywords": list,
+        "commands": list,
+    }
+    problems = _validate_required_fields(data, required)
+    commands = data.get("commands")
+    if isinstance(commands, list):
+        for index, command in enumerate(commands):
+            if not isinstance(command, dict):
+                problems.append(f"commands[{index}] must be object")
+                continue
+            for field in ("name", "description", "command"):
+                value = command.get(field)
+                if not isinstance(value, str) or not value.strip():
+                    problems.append(f"commands[{index}].{field} must be non-empty string")
+            args = command.get("args")
+            if args is not None and not (isinstance(args, list) and all(isinstance(arg, str) for arg in args)):
+                problems.append(f"commands[{index}].args must be list of strings")
+    if problems:
+        return CheckResult("claude_manifest", False, f"schema invalid: {path} ({'; '.join(problems)})")
+    return CheckResult("claude_manifest", True, f"valid Claude manifest: {path}")
+
+
+def check_hermes_manifest(path: Path) -> CheckResult:
+    if not path.is_file():
+        return CheckResult("hermes_manifest", False, f"missing: {path}")
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        return CheckResult("hermes_manifest", False, f"invalid text: {path} ({exc})")
+    required = ("name", "version", "description")
+    missing = [field for field in required if not re.search(rf"^{field}\s*:", text, re.MULTILINE)]
+    if missing:
+        return CheckResult("hermes_manifest", False, f"schema invalid: {path} (missing {', '.join(missing)})")
+    return CheckResult("hermes_manifest", True, f"readable Hermes manifest: {path}")
 
 
 def doctor(
@@ -66,7 +159,8 @@ def doctor(
 
     # Plugin manifest checks (only if in repo context)
     if repo_root is not None:
-        results.append(check_json_manifest(repo_root / ".claude-plugin" / "plugin.json", "claude_manifest"))
-        results.append(check_json_manifest(repo_root / ".codex-plugin" / "plugin.json", "codex_manifest"))
+        results.append(check_claude_manifest(repo_root / ".claude-plugin" / "plugin.json"))
+        results.append(check_codex_manifest(repo_root / ".codex-plugin" / "plugin.json"))
+        results.append(check_hermes_manifest(repo_root / "plugins" / "hermes" / "plugin.yaml"))
 
     return results

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def create_sandbox_vault(root: Path, *, name: str = "Sandbox Brain") -> Path:
+    """Create a small Obsidian-compatible sandbox vault for tests."""
+
+    vault = root / "sandbox-vault"
+    (vault / "AI Wiki").mkdir(parents=True, exist_ok=True)
+    (vault / "Daily").mkdir(parents=True, exist_ok=True)
+    (vault / "AI Wiki" / "_OPEN_SECOND_BRAIN.md").write_text(
+        f"---\ntitle: {name}\ntype: operating-manual\n---\n\n# {name}\n",
+        encoding="utf-8",
+    )
+    (vault / "AI Wiki" / "Concept.md").write_text(
+        "---\ntitle: Sandbox Concept\n---\n\nLinked to [[Other]].\n",
+        encoding="utf-8",
+    )
+    (vault / "Other.md").write_text("# Other\n", encoding="utf-8")
+    return vault
+
+
+def create_plugin_repo(root: Path, *, valid: bool = True) -> Path:
+    """Create a minimal repo fixture containing plugin manifests."""
+
+    repo = root / "plugin-repo"
+    (repo / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+    (repo / ".codex-plugin").mkdir(parents=True, exist_ok=True)
+    (repo / "plugins" / "hermes").mkdir(parents=True, exist_ok=True)
+    if valid:
+        (repo / ".claude-plugin" / "plugin.json").write_text(
+            """{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "test manifest",
+  "author": "tests",
+  "license": "MIT",
+  "repository": "https://example.invalid/test",
+  "keywords": ["test"],
+  "commands": [
+    {"name": "status", "description": "status", "command": "scripts/o2b", "args": ["status"]}
+  ]
+}
+""",
+            encoding="utf-8",
+        )
+        (repo / ".codex-plugin" / "plugin.json").write_text(
+            """{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "test manifest",
+  "skills": "./skills",
+  "keywords": ["test"]
+}
+""",
+            encoding="utf-8",
+        )
+        (repo / "plugins" / "hermes" / "plugin.yaml").write_text(
+            "name: test\nversion: \"1.0.0\"\ndescription: test manifest\n",
+            encoding="utf-8",
+        )
+    else:
+        (repo / ".claude-plugin" / "plugin.json").write_text("{\"name\": \"test\"}", encoding="utf-8")
+        (repo / ".codex-plugin" / "plugin.json").write_text("{\"name\": \"test\"}", encoding="utf-8")
+        (repo / "plugins" / "hermes" / "plugin.yaml").write_text("name: test\n", encoding="utf-8")
+    return repo

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 ENV = {**os.environ, "PYTHONPATH": str(ROOT / "src")}
 
+from tests.fixtures import create_plugin_repo, create_sandbox_vault
+
 
 def run_module(module, *args, env=None):
     return subprocess.run(
@@ -91,17 +93,22 @@ class CliTests(unittest.TestCase):
 
     def test_doctor_with_repo_checks_manifests(self):
         with tempfile.TemporaryDirectory() as tmp:
-            vault = Path(tmp) / "vault"
-            vault.mkdir()
-            repo = Path(tmp) / "repo"
-            (repo / ".claude-plugin").mkdir(parents=True)
-            (repo / ".codex-plugin").mkdir(parents=True)
-            (repo / ".claude-plugin" / "plugin.json").write_text('{"name":"test"}', encoding="utf-8")
-            (repo / ".codex-plugin" / "plugin.json").write_text('{"name":"test"}', encoding="utf-8")
+            vault = create_sandbox_vault(Path(tmp))
+            repo = create_plugin_repo(Path(tmp), valid=True)
             result = run_cli("doctor", "--vault", str(vault), "--repo", str(repo))
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn("claude_manifest", result.stdout)
             self.assertIn("codex_manifest", result.stdout)
+            self.assertIn("hermes_manifest", result.stdout)
+
+    def test_doctor_with_repo_rejects_invalid_manifest_schema(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = create_sandbox_vault(Path(tmp))
+            repo = create_plugin_repo(Path(tmp), valid=False)
+            result = run_cli("doctor", "--vault", str(vault), "--repo", str(repo))
+            self.assertEqual(result.returncode, 1, result.stderr)
+            self.assertIn("[FAIL] claude_manifest", result.stdout)
+            self.assertIn("[FAIL] codex_manifest", result.stdout)
 
     def test_append_event_writes_daily_note(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -4,11 +4,16 @@ from pathlib import Path
 
 from open_second_brain.doctor import (
     CheckResult,
+    check_claude_manifest,
     check_config_writeable,
+    check_codex_manifest,
+    check_hermes_manifest,
     check_json_manifest,
     check_vault_writeable,
     doctor,
 )
+
+from tests.fixtures import create_plugin_repo, create_sandbox_vault
 
 
 class DoctorTests(unittest.TestCase):
@@ -62,13 +67,33 @@ class DoctorTests(unittest.TestCase):
 
     def test_doctor_aggregates_results(self):
         with tempfile.TemporaryDirectory() as tmp:
-            vault = Path(tmp)
+            vault = create_sandbox_vault(Path(tmp))
             config = Path(tmp) / "config.yaml"
             config.write_text("vault_path: /tmp", encoding="utf-8")
             results = doctor(vault=vault, config=config)
             self.assertGreater(len(results), 0)
             for r in results:
                 self.assertIsInstance(r, CheckResult)
+
+    def test_manifest_schema_checks_accept_valid_fixture(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_plugin_repo(Path(tmp), valid=True)
+            self.assertTrue(check_claude_manifest(repo / ".claude-plugin" / "plugin.json").ok)
+            self.assertTrue(check_codex_manifest(repo / ".codex-plugin" / "plugin.json").ok)
+            self.assertTrue(check_hermes_manifest(repo / "plugins" / "hermes" / "plugin.yaml").ok)
+
+    def test_manifest_schema_checks_reject_missing_required_fields(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_plugin_repo(Path(tmp), valid=False)
+            claude = check_claude_manifest(repo / ".claude-plugin" / "plugin.json")
+            codex = check_codex_manifest(repo / ".codex-plugin" / "plugin.json")
+            hermes = check_hermes_manifest(repo / "plugins" / "hermes" / "plugin.yaml")
+            self.assertFalse(claude.ok)
+            self.assertFalse(codex.ok)
+            self.assertFalse(hermes.ok)
+            self.assertIn("schema invalid", claude.message)
+            self.assertIn("skills", codex.message)
+            self.assertIn("missing", hermes.message)
 
 
 if __name__ == "__main__":

--- a/tests/test_hermes_plugin.py
+++ b/tests/test_hermes_plugin.py
@@ -1,0 +1,43 @@
+import unittest
+from pathlib import Path
+
+from plugins.hermes import check_health, health, register
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class HermesPluginTests(unittest.TestCase):
+    def test_health_report_checks_repo_artifacts(self):
+        report = health(ROOT)
+        self.assertTrue(report["ok"], report)
+        self.assertIn("claude_manifest", report["checks"])
+        self.assertIn("codex_manifest", report["checks"])
+        self.assertIn("o2b_script", report["checks"])
+
+    def test_check_health_alias(self):
+        self.assertEqual(check_health(ROOT)["name"], "open-second-brain")
+
+    def test_register_attaches_to_method_context(self):
+        calls = []
+
+        class Context:
+            def register_health_check(self, name, callback):
+                calls.append((name, callback))
+
+        register(Context())
+        self.assertEqual(calls[0][0], "open-second-brain")
+        self.assertTrue(calls[0][1](ROOT)["ok"])
+
+    def test_register_attaches_to_dict_context(self):
+        class Context:
+            def __init__(self):
+                self.health_checks = {}
+
+        ctx = Context()
+        register(ctx)
+        self.assertIn("open-second-brain", ctx.health_checks)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add Hermes plugin health checks with safe best-effort registration
- add Claude Code command metadata and stronger plugin manifest validation in doctor
- document setup/runtime usage and add sandbox fixture coverage
- mark v0.2/v0.3 roadmap items complete

## Test Plan
- PYTHONPATH=src python3 -m unittest discover -s tests -v
- PYTHONPATH=src python3 -m unittest tests.test_doctor tests.test_cli tests.test_hermes_plugin -v
- python3 -m json.tool .claude-plugin/plugin.json >/dev/null
- python3 -m json.tool .codex-plugin/plugin.json >/dev/null
- python3 -m py_compile plugins/hermes/__init__.py
- bash -n scripts/o2b
- bash -n scripts/vault-log
- scripts/o2b doctor --vault . --repo .
- coderabbit review --agent --base origin/main (0 findings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added seven new CLI commands (status, doctor, init, index, append-event, export-config, vault-log)
  * Introduced runtime health checks for system diagnostics

* **Documentation**
  * Updated documentation to reflect v0.3 release with expanded CLI usage examples and common setup flow instructions

* **Tests**
  * Enhanced test suite with manifest validation and health check coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->