### PR TITLE
ci: add GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,111 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (with or without leading v). Defaults to pyproject.toml version."
+        required: false
+        type: string
+      prerelease:
+        description: "Mark the GitHub release as a prerelease."
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref_name }}-${{ github.event.inputs.version || '' }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Build and publish GitHub release
+    runs-on: ubuntu-latest
+    env:
+      VERSION_INPUT: ${{ github.event.inputs.version || '' }}
+      PRERELEASE_INPUT: ${{ github.event.inputs.prerelease || 'false' }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Resolve release version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          pyproject_version=$(python -c 'import pathlib, tomllib; data = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8")); print(data["project"]["version"])')
+
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            tag="${GITHUB_REF_NAME}"
+            version="${tag#v}"
+          elif [ -n "${VERSION_INPUT}" ]; then
+            version="${VERSION_INPUT#v}"
+            tag="v${version}"
+          else
+            version="${pyproject_version}"
+            tag="v${version}"
+          fi
+
+          if [ "${version}" != "${pyproject_version}" ]; then
+            echo "Release version ${version} does not match pyproject.toml version ${pyproject_version}" >&2
+            exit 1
+          fi
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Run test suite
+        run: PYTHONPATH=src python -m unittest discover -s tests -v
+
+      - name: Run packaging and manifest checks
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m json.tool .claude-plugin/plugin.json >/dev/null
+          python -m json.tool .codex-plugin/plugin.json >/dev/null
+          python -m py_compile plugins/hermes/__init__.py
+          bash -n scripts/o2b
+          bash -n scripts/vault-log
+          scripts/o2b doctor --vault . --repo .
+
+      - name: Build source and wheel distributions
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          prerelease_args=()
+          if [ "${PRERELEASE_INPUT}" = "true" ]; then
+            prerelease_args+=(--prerelease)
+          fi
+
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "Release ${TAG} already exists" >&2
+            exit 1
+          fi
+
+          gh release create "${TAG}" dist/* \
+            --target "${GITHUB_SHA}" \
+            --title "open-second-brain ${TAG}" \
+            --generate-notes \
+            "${prerelease_args[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 __pycache__/
 *.py[cod]
 .venv/
+build/
+dist/
+*.egg-info/
 
 # Node
 node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.1] - 2026-05-06
+
+### Added
+
+- Deterministic `o2b` CLI foundation with status, init, doctor, append-event, export-config, and index commands.
+- Append-only daily Markdown event log backend and `vault-log` compatibility wrapper.
+- Vault profile bootstrap for the `AI Wiki` structure and Open Second Brain operating manual.
+- Wiki helpers for frontmatter parsing, wikilink extraction, vault page listing, and index regeneration.
+- Runtime adapter manifests for Hermes, Claude Code, and Codex.
+- Hermes plugin health checks with safe best-effort registration.
+- Plugin manifest validation through `o2b doctor --repo`.
+- Sandbox vault and plugin manifest fixtures for tests.
+- GitHub release workflow for tag-based and manually dispatched releases.
+
+[unreleased]: https://github.com/itechmeat/open-second-brain/compare/v0.0.1...HEAD
+[0.0.1]: https://github.com/itechmeat/open-second-brain/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -120,6 +120,33 @@ Create disposable test vaults with `scripts/o2b init --vault /tmp/o2b-sandbox`.
 Keep secrets outside the vault and use `scripts/o2b export-config` when sharing
 debug snapshots so sensitive keys are redacted.
 
+## Releases
+
+Releases are published by GitHub Actions from `.github/workflows/release.yml`.
+
+Automatic release from a tag:
+
+```bash
+git switch main
+git pull --ff-only origin main
+git tag -a v0.0.1 -m "Release v0.0.1"
+git push origin v0.0.1
+```
+
+Manual release from GitHub Actions:
+
+1. Open **Actions → Release → Run workflow**.
+2. Leave `version` empty to use `pyproject.toml`, or enter the same version with or
+   without the leading `v`.
+3. Set `prerelease` only for prerelease builds.
+
+The release workflow verifies the test suite, plugin manifests, shell wrappers,
+Hermes plugin syntax, and `scripts/o2b doctor --vault . --repo .` before building
+source and wheel distributions and publishing a GitHub release.
+
+Before changing `pyproject.toml` version for a future release, update
+`CHANGELOG.md` using Keep a Changelog sections.
+
 ## Development
 
 Run the test suite with the Python standard library:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68"]
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,7 +8,7 @@ version = "0.0.1"
 description = "Plugin-first second brain package for AI agents and humans."
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "MIT" }
+license = "MIT"
 authors = [{ name = "Open Second Brain contributors" }]
 keywords = ["second-brain", "obsidian", "agents", "skills", "event-log"]
 dependencies = []


### PR DESCRIPTION
## Summary
- add tag/manual GitHub release workflow that runs tests and builds sdist/wheel artifacts
- add CHANGELOG.md for v0.0.1 and future release notes
- document automatic tag releases and manual workflow-dispatch releases
- modernize pyproject license metadata and ignore build artifacts

## Test Plan
- workflow YAML parsed with PyYAML
- PYTHONPATH=src python3 -m unittest discover -s tests -v
- python3 -m json.tool .claude-plugin/plugin.json >/dev/null
- python3 -m json.tool .codex-plugin/plugin.json >/dev/null
- python3 -m py_compile plugins/hermes/__init__.py
- bash -n scripts/o2b
- bash -n scripts/vault-log
- scripts/o2b doctor --vault . --repo .
- python3 -m build in a venv
- coderabbit review --agent --base origin/main (0 findings)