### PR TITLE
chore: align release version with v0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.1] - 2026-05-06
+## [0.3.0] - 2026-05-06
 
 ### Added
 
@@ -21,5 +21,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sandbox vault and plugin manifest fixtures for tests.
 - GitHub release workflow for tag-based and manually dispatched releases.
 
-[unreleased]: https://github.com/itechmeat/open-second-brain/compare/v0.0.1...HEAD
-[0.0.1]: https://github.com/itechmeat/open-second-brain/releases/tag/v0.0.1
+[unreleased]: https://github.com/itechmeat/open-second-brain/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/itechmeat/open-second-brain/releases/tag/v0.3.0

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ Automatic release from a tag:
 ```bash
 git switch main
 git pull --ff-only origin main
-git tag -a v0.0.1 -m "Release v0.0.1"
-git push origin v0.0.1
+git tag -a v0.3.0 -m "Release v0.3.0"
+git push origin v0.3.0
 ```
 
 Manual release from GitHub Actions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-second-brain"
-version = "0.0.1"
+version = "0.3.0"
 description = "Plugin-first second brain package for AI agents and humans."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- bump package/release metadata from v0.0.1 to v0.3.0
- update changelog comparison links and README release example

## Test Plan
- PYTHONPATH=src python3 -m unittest discover -s tests -v
- manifest, shell, workflow YAML, and doctor checks
- coderabbit review --agent --base origin/main: 0 findings