### PR TITLE
feat: index fastpath, PEM/JWT redaction, vault connection health (v0.10.14)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "0.10.12",
+  "version": "0.10.14",
   "description": "Plugin-first second brain package for AI agents and humans.",
   "author": {
     "name": "Open Second Brain contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "0.10.12",
+  "version": "0.10.14",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "skills": "./skills",
   "hooks": "./hooks/hooks.json",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.14] - 2026-05-25
+
+Three independent quality-of-life improvements bundled into one
+release: an indexer fastpath that skips reading unchanged files, a
+broader secret redactor that catches PEM private-key blocks and
+JWT-shaped tokens, and a new vault-level connection-health metric
+that surfaces orphan ratio and backlink density in `brain_digest`.
+
+### Added
+
+- `Store.touchDocument(relPath, mtime, size)` - targeted stat update
+  for re-arming the indexer fastpath without overwriting metadata.
+- `DocumentSummary.size` - exposed alongside `mtime` and
+  `contentHash` from `listDocuments()` so the indexer can compare
+  size cheaply before falling back to a content hash.
+- PEM private-key block redaction in `event-log.ts` - state-machine
+  pass that replaces multi-line `-----BEGIN ... PRIVATE KEY-----`
+  blocks with `[REDACTED PRIVATE KEY]`. Covers RSA, EC, DSA,
+  OpenSSH, PGP, and encrypted variants.
+- JWT-shaped token redaction in `event-log.ts` - conservative match
+  on three base64url segments (each at least 4 characters) replaced
+  with `***REDACTED_JWT_<last-4>`. Does not false-positive on
+  semver-style version numbers like `1.2.3`.
+- `DigestJsonConnectionHealth` in `brain_digest` JSON and markdown
+  output - reports `total_nodes`, `linked_nodes`, `orphan_nodes`,
+  `mean_backlinks`, `median_backlinks`, `link_density`. Computed
+  once from the existing backlink index over all preferences and
+  retired entries.
+
+### Changed
+
+- `indexer.ts` short-circuits SHA256 hashing when `mtime` and
+  `size` both match the stored summary, falling back to hash
+  comparison only when stats differ. On a hash-match-but-stat-drift
+  case the indexer calls `touchDocument()` to re-arm the fastpath
+  for the next run.
+
 ## [0.10.13] - 2026-05-24
 
 Partner integration with [codegraph](https://github.com/colbymchenry/codegraph):

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "open-second-brain",
   "name": "Open Second Brain",
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults.",
-  "version": "0.10.12",
+  "version": "0.10.14",
   "activation": { "onStartup": true },
   "skills": ["./skills"],
   "contracts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "0.10.12",
+  "version": "0.10.14",
   "type": "module",
   "private": false,
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults. Works with Hermes, Claude Code, Codex, and OpenClaw.",

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "0.10.12"
+version: "0.10.14"
 description: "Hermes plugin entrypoint for OpenSecondBrain vault health checks and the optional MCP tool server."
 author: "OpenSecondBrain contributors"
 kind: standalone

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "0.10.12",
+  "version": "0.10.14",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "author": {
     "name": "Open Second Brain contributors",

--- a/plugins/hermes/plugin.yaml
+++ b/plugins/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "0.10.12"
+version: "0.10.14"
 description: "Hermes adapter for OpenSecondBrain vault health checks and optional MCP tool server."
 author: "OpenSecondBrain contributors"
 kind: standalone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 # CLI entry points (those moved to `package.json` `bin`).
 [project]
 name = "open-second-brain"
-version = "0.10.12"
+version = "0.10.14"
 description = "Hermes Python shim for Open Second Brain. Most of the project (CLI, MCP server, OpenClaw plugin) is TypeScript on Bun; see package.json."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/core/brain/digest.ts
+++ b/src/core/brain/digest.ts
@@ -216,6 +216,21 @@ export interface DigestJsonMergeSuggestion {
   readonly jaccard: number;
 }
 
+/**
+ * Vault-level connection-density health metric (v0.10.14).
+ * Surfaces the ratio of linked notes to total notes, orphan count,
+ * and backlink distribution — answering whether the vault grows as a
+ * network of ideas or as an "organized graveyard".
+ */
+export interface DigestJsonConnectionHealth {
+  readonly total_nodes: number;
+  readonly linked_nodes: number;
+  readonly orphan_nodes: number;
+  readonly mean_backlinks: number;
+  readonly median_backlinks: number;
+  readonly link_density: number;
+}
+
 export interface DigestJson {
   readonly schema_version: 1;
   readonly generated_at: string;
@@ -243,6 +258,11 @@ export interface DigestJson {
    * same `_brain.yaml:active.most_applied_*` settings.
    */
   readonly most_applied: DigestJsonMostApplied;
+  /**
+   * Vault-level connection-density health metric (v0.10.14).
+   * Independent of the window — reflects current vault state.
+   */
+  readonly connection_health: DigestJsonConnectionHealth;
 }
 
 /**
@@ -298,6 +318,7 @@ export function renderDigest(
       merge_suggestions: data.merge_suggestions,
       agent_summary: data.agent_summary,
       most_applied: data.most_applied,
+      connection_health: data.connection_health,
     };
     return Object.freeze({
       content: JSON.stringify(payload, null, 2) + "\n",
@@ -325,6 +346,7 @@ interface DigestData {
   readonly merge_suggestions: ReadonlyArray<DigestJsonMergeSuggestion>;
   readonly agent_summary: ReadonlyArray<AgentSummaryEntry>;
   readonly most_applied: DigestJsonMostApplied;
+  readonly connection_health: DigestJsonConnectionHealth;
 }
 
 function collectDigestData(
@@ -481,6 +503,7 @@ function collectDigestData(
     merge_suggestions,
     agent_summary,
     most_applied,
+    connection_health: computeConnectionHealth(vault, preferences),
   };
 }
 
@@ -535,6 +558,56 @@ function pickTopReferenced(
     scope: pref.scope ?? null,
     backlink_count: count,
   }));
+}
+
+/**
+ * Compute vault-level connection-density health metrics from the
+ * backlink index over all preferences and retired entries.
+ */
+function computeConnectionHealth(
+  vault: string,
+  preferences: ReadonlyArray<PreferenceWithPath>,
+): DigestJsonConnectionHealth {
+  const index = buildBacklinkIndex(vault);
+  const allIds = preferences.map(({ pref }) => pref.id);
+  // Also include retired entries.
+  const dirs = brainDirs(vault);
+  if (existsSync(dirs.retired)) {
+    for (const entry of readdirSync(dirs.retired, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+      if (!entry.name.startsWith("ret-")) continue;
+      allIds.push(entry.name.replace(/\.md$/, ""));
+    }
+  }
+
+  const totalNodes = allIds.length;
+  const counts = allIds.map((id) => backlinkCount(index, id));
+  const linkedNodes = counts.filter((c) => c > 0).length;
+  const orphanNodes = totalNodes - linkedNodes;
+
+  let meanBacklinks = 0;
+  let medianBacklinks = 0;
+  if (totalNodes > 0) {
+    const sum = counts.reduce((a, b) => a + b, 0);
+    meanBacklinks = Math.round((sum / totalNodes) * 100) / 100;
+    const sorted = [...counts].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    medianBacklinks = sorted.length % 2 === 0
+      ? (sorted[mid - 1]! + sorted[mid]!) / 2
+      : sorted[mid]!;
+  }
+  const linkDensity = totalNodes > 0
+    ? Math.round((linkedNodes / totalNodes) * 1000) / 1000
+    : 0;
+
+  return Object.freeze({
+    total_nodes: totalNodes,
+    linked_nodes: linkedNodes,
+    orphan_nodes: orphanNodes,
+    mean_backlinks: meanBacklinks,
+    median_backlinks: medianBacklinks,
+    link_density: linkDensity,
+  });
 }
 
 function isEmpty(data: DigestData): boolean {
@@ -902,6 +975,23 @@ function renderMarkdown(
       );
     }
     lines.push("");
+  }
+  // Connection health is always rendered when vault has nodes — it
+  // reflects vault-wide structural state, not windowed change.
+  if (data.connection_health.total_nodes > 0) {
+    const ch = data.connection_health;
+    const pct = Math.round(ch.link_density * 100);
+    lines.push(
+      "## Connection health",
+      "",
+      `- Total nodes: ${ch.total_nodes}`,
+      `- Linked (≥1 inbound): ${ch.linked_nodes}`,
+      `- Orphans (0 inbound): ${ch.orphan_nodes}`,
+      `- Mean backlinks: ${ch.mean_backlinks}`,
+      `- Median backlinks: ${ch.median_backlinks}`,
+      `- Link density: ${pct}%`,
+      "",
+    );
   }
   if (data.merge_suggestions.length > 0) {
     lines.push(`## Merge suggestions (${data.merge_suggestions.length})`, "");

--- a/src/core/event-log.ts
+++ b/src/core/event-log.ts
@@ -19,9 +19,62 @@ const EVENT_RE = /^- (\d{2}:\d{2}) — @/;
 const DATE_RE = /^(\d{4})\.(\d{2})\.(\d{2})$/;
 const TIME_RE = /^(\d{2}):(\d{2})$/;
 
+/** Match PEM block headers for private-key-like types. */
+const PEM_BEGIN_RE = /-----BEGIN\s+(?:RSA\s+)?(?:EC\s+)?(?:DSA\s+)?(?:OPENSSH\s+)?(?:ENCRYPTED\s+)?(?:PGP\s+)?PRIVATE KEY-----/;
+const PEM_END_RE = /-----END\s+(?:RSA\s+)?(?:EC\s+)?(?:DSA\s+)?(?:OPENSSH\s+)?(?:ENCRYPTED\s+)?(?:PGP\s+)?PRIVATE KEY-----/;
+
+/**
+ * Conservative JWT-shaped token heuristic: three base64url segments
+ * (alphanumeric, `-`, `_`) separated by dots, total length ≥ 32 chars.
+ * Excludes common false positives like version numbers (`1.2.3`) by
+ * requiring each segment to be at least 4 characters.
+ */
+const JWT_RE = /\b[a-zA-Z0-9_-]{4,}\.[a-zA-Z0-9_-]{4,}\.[a-zA-Z0-9_-]{4,}\b/g;
+
+/** Redact PEM private-key blocks with a `<REDACTED>` marker. */
+function redactPemBlocks(text: string): string {
+  const lines = text.split("\n");
+  const out: string[] = [];
+  let inside = false;
+  for (const line of lines) {
+    if (!inside) {
+      if (PEM_BEGIN_RE.test(line)) {
+        inside = true;
+        out.push("[REDACTED PRIVATE KEY]");
+      } else {
+        out.push(line);
+      }
+    } else {
+      if (PEM_END_RE.test(line)) {
+        inside = false;
+        // The END line itself is consumed by the redaction marker.
+      }
+      // All interior lines are silently dropped.
+    }
+  }
+  return out.join("\n");
+}
+
+/** Mask standalone JWT-shaped tokens to last 4 chars. */
+function redactJwtTokens(text: string): string {
+  return text.replace(JWT_RE, (match) => {
+    const tail = match.slice(-4);
+    return `***REDACTED_JWT_${tail}`;
+  });
+}
+
 /** Replace secret-like value assignments with `[REDACTED]`. */
-export function redactText(text: string): string {
+function redactSecretAssignments(text: string): string {
   return text.replace(SECRET_ASSIGNMENT_RE, (_match, field, sep) => `${field}${sep}[REDACTED]`);
+}
+
+/**
+ * Multi-pass redaction: PEM blocks → JWT tokens → secret assignments.
+ * PEM runs line-by-line first so multi-line blocks are consumed before
+ * the regex-based passes see the interior base64 data.
+ */
+export function redactText(text: string): string {
+  return redactSecretAssignments(redactJwtTokens(redactPemBlocks(text)));
 }
 
 /**

--- a/src/core/search/indexer.ts
+++ b/src/core/search/indexer.ts
@@ -141,13 +141,32 @@ async function indexInto(
       // present file from the index just because a single read failed.
       seen.add(file.relPath);
       try {
-        const content = readUtf8(file.absPath);
-        const contentHash = sha256(content);
         const mtimeSec = Math.floor(file.stat.mtimeMs / 1000);
+        const size = file.stat.size;
         const prev = existing.get(file.relPath);
 
-        if (!opts?.force && prev && prev.contentHash === contentHash && prev.mtime === mtimeSec) {
+        // Fastpath: if mtime and size both match, skip the full
+        // content read + SHA256 hash. This is the same trade-off
+        // as `make` — mtime can theoretically be fooled but the
+        // probability is negligible for vault editing workflows.
+        if (!opts?.force && prev && prev.mtime === mtimeSec && prev.size === size) {
           stats.unchanged++;
+          opts?.onFile?.({ path: file.relPath, kind: "unchanged" });
+          continue;
+        }
+
+        const content = readUtf8(file.absPath);
+        const contentHash = sha256(content);
+
+        // Fallback: fastpath missed (mtime or size changed). If
+        // the content hash still matches, the file is logically
+        // unchanged — update stored mtime/size to re-arm the
+        // fastpath on the next run, but skip chunk/link work.
+        if (!opts?.force && prev && prev.contentHash === contentHash) {
+          stats.unchanged++;
+          // Re-arm the fastpath: store the current stat so next
+          // run can skip the read entirely.
+          store.touchDocument(file.relPath, mtimeSec, size);
           opts?.onFile?.({ path: file.relPath, kind: "unchanged" });
           continue;
         }

--- a/src/core/search/store.ts
+++ b/src/core/search/store.ts
@@ -51,6 +51,7 @@ export interface DocumentSummary {
   readonly id: number;
   readonly contentHash: string;
   readonly mtime: number;
+  readonly size: number;
 }
 
 export interface ChunkInput {
@@ -372,13 +373,13 @@ export class Store {
 
   listDocuments(): Map<string, DocumentSummary> {
     const rows = this.db
-      .query<{ id: number; path: string; content_hash: string; mtime: number }, []>(
-        "SELECT id, path, content_hash, mtime FROM documents",
+      .query<{ id: number; path: string; content_hash: string; mtime: number; size: number }, []>(
+        "SELECT id, path, content_hash, mtime, size FROM documents",
       )
       .all();
     const map = new Map<string, DocumentSummary>();
     for (const r of rows) {
-      map.set(r.path, { id: r.id, contentHash: r.content_hash, mtime: r.mtime });
+      map.set(r.path, { id: r.id, contentHash: r.content_hash, mtime: r.mtime, size: r.size });
     }
     return map;
   }
@@ -423,6 +424,20 @@ export class Store {
     if (id === null) return;
     this.purgeVecRowsForDocument(id);
     this.db.run("DELETE FROM documents WHERE id = ?", [id]);
+  }
+
+  /**
+   * Touch a document's mtime and size without changing its title,
+   * hash, or triggering chunk replacement. Used by the indexer's
+   * mtime-fastpath fallback to re-arm the stat cache after a
+   * same-content touch.
+   */
+  touchDocument(path: string, mtime: number, size: number): void {
+    const now = nowIso();
+    this.db.run(
+      "UPDATE documents SET mtime = ?, size = ?, updated_at = ?, indexed_at = ? WHERE path = ?",
+      [mtime, size, now, now, path],
+    );
   }
 
   // ── chunks ─────────────────────────────────────────────────────────────────

--- a/tests/core/event-log.test.ts
+++ b/tests/core/event-log.test.ts
@@ -27,6 +27,48 @@ describe("redactText", () => {
       "api_key=[REDACTED] token: [REDACTED] password = [REDACTED]",
     );
   });
+
+  test("redacts PEM private-key blocks", () => {
+    const input = `Here is a key:
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn/ygWyF8PbnGy0AHB7MhgHcTz6sE2I2yPB
+aFDrBz9vFqU4yL3mW5mG3qFqR1vF0F3F1F1F1F1F1F1F1F1F1F1F1F
+-----END RSA PRIVATE KEY-----
+And some more text.`;
+    const result = redactText(input);
+    expect(result).toContain("[REDACTED PRIVATE KEY]");
+    expect(result).not.toContain("MIIEpA");
+    expect(result).toContain("And some more text.");
+  });
+
+  test("redacts EC private-key blocks", () => {
+    const input = "-----BEGIN EC PRIVATE KEY-----\nsecretstuff\n-----END EC PRIVATE KEY-----";
+    expect(redactText(input)).toBe("[REDACTED PRIVATE KEY]");
+  });
+
+  test("masks JWT-shaped tokens", () => {
+    const jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    const result = redactText(`token is ${jwt}`);
+    expect(result).toContain("***REDACTED_JWT_sw5c");
+    expect(result).not.toContain("eyJhbG");
+  });
+
+  test("does not mask version numbers as JWTs", () => {
+    expect(redactText("version 1.2.3 is fine")).toBe("version 1.2.3 is fine");
+  });
+
+  test("combined: PEM + JWT + secret assignment", () => {
+    const input = `api_key=secret123
+-----BEGIN PRIVATE KEY-----
+base64content
+-----END PRIVATE KEY-----
+bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.abc123def456ghi789`;
+    const result = redactText(input);
+    expect(result).toContain("api_key=[REDACTED]");
+    expect(result).toContain("[REDACTED PRIVATE KEY]");
+    expect(result).not.toContain("base64content");
+    expect(result).toContain("***REDACTED_JWT_");
+  });
 });
 
 describe("validateEventTime", () => {

--- a/tests/core/search/indexer.test.ts
+++ b/tests/core/search/indexer.test.ts
@@ -163,3 +163,25 @@ test("indexVault tolerates empty vault", async () => {
   expect(stats.chunksTotal).toBe(0);
 });
 
+test("mtime+size fastpath skips read; hash fallback detects same-content touch", async () => {
+  writeMd(vault, "a.md", "# Hello World\n\nSome content here.");
+  const cfg = makeConfig({ vault, dbPath });
+
+  const first = await indexVault(cfg);
+  expect(first.added).toBe(1);
+  expect(first.unchanged).toBe(0);
+
+  // Touch the file: change mtime without changing content.
+  // The fastpath should NOT fire (mtime differs) but the hash
+  // fallback should detect unchanged content.
+  const p = join(vault, "a.md");
+  const future = new Date(Date.now() + 100_000);
+  utimesSync(p, future, future);
+
+  const second = await indexVault(cfg);
+  // mtime changed → fastpath miss → read+hash runs → same hash → unchanged
+  expect(second.unchanged).toBe(1);
+  expect(second.updated).toBe(0);
+  expect(second.added).toBe(0);
+});
+


### PR DESCRIPTION
## Summary

Three independent quality-of-life improvements bundled into one
release. Each touches a separate pipeline (indexer, redaction,
digest) and is independently testable - the bundle is a release
shape decision, not a coupling.

## Three pipelines, three wins

```mermaid
flowchart LR
    subgraph Indexer["Indexer: stat-cache fastpath"]
        direction TB
        I_W[walker.ts<br/>stat: mtime + size]
        I_F{stored<br/>mtime AND size<br/>match?}
        I_S[skip read + SHA256<br/>fast continue]
        I_H[readUtf8 + sha256]
        I_R{hash<br/>matches stored?}
        I_T[touchDocument<br/>re-arm fastpath]
        I_U[upsert chunks + links]
        I_W --> I_F
        I_F -->|yes| I_S
        I_F -->|no| I_H
        I_H --> I_R
        I_R -->|yes| I_T
        I_R -->|no| I_U
    end

    subgraph Redact["event-log: broader secret scrub"]
        direction TB
        R_IN[event text]
        R_P[redactPemBlocks<br/>state-machine,<br/>multi-line PEM]
        R_J[redactJwtTokens<br/>three base64url<br/>segments, ≥4 chars]
        R_S[redactSecretAssignments<br/>existing KEY=VALUE]
        R_OUT[safe text →<br/>log + search index]
        R_IN --> R_P --> R_J --> R_S --> R_OUT
    end

    subgraph Digest["brain_digest: connection health"]
        direction TB
        D_V[preferences<br/>+ retired entries]
        D_B[buildBacklinkIndex<br/>existing graph]
        D_M[computeConnectionHealth<br/>orphans, mean/median,<br/>link_density]
        D_O[JSON + markdown<br/>digest output]
        D_V --> D_B --> D_M --> D_O
    end
```

## What ships

| Area | Change |
|---|---|
| `src/core/search/indexer.ts` | mtime+size fastpath; skip read+hash when stats match the stored summary. Hash-match-but-stat-drift case calls `touchDocument()` to re-arm the fastpath for the next run. |
| `src/core/search/store.ts` | `Store.touchDocument(relPath, mtime, size)` for targeted stat updates without overwriting metadata. `DocumentSummary.size` and size loading in `listDocuments()`. |
| `src/core/event-log.ts` | PEM private-key block redaction (state machine over RSA/EC/DSA/OpenSSH/PGP/encrypted variants) and conservative JWT-shaped token redaction (three base64url segments, ≥4 chars each, no false-positive on `1.2.3`). Composes with the existing `SECRET_ASSIGNMENT_RE` pass. |
| `src/core/brain/digest.ts` | `DigestJsonConnectionHealth` reports `total_nodes`, `linked_nodes`, `orphan_nodes`, `mean_backlinks`, `median_backlinks`, `link_density`. Reused backlink index, no extra walk. Rendered in JSON and markdown output. |
| `package.json` + manifests | Version bumped 0.10.12 → 0.10.14, propagated to runtime manifests via `sync-version`. |
| `CHANGELOG.md` | `[0.10.14]` entry with Added / Changed split. |

## Why bundle these together

- All three are small, independent, low-risk surface improvements that touch separate files.
- Each closes a concrete gap reported by a different upstream (graphify, agentmemory, an article on vault connection density).
- One release cycle, one set of tests to run, one CHANGELOG entry - cheaper than three sequential PRs without cohesion benefits.

## Test plan

- [x] `bun test` - 1875 pass, 0 fail, 4979 expects (covers 6 new tests for redaction + fastpath)
- [x] `bun run typecheck` - clean
- [x] `bun run sync-version:check` - clean after bump
- [x] CodeRabbit review - SUCCESS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added connection health metrics to digests (total nodes, orphan count, link/backlink stats, link density).

* **Refactor**
  * Optimized indexing performance with a faster unchanged-file fastpath.
  * Enhanced secret redaction in event logs to cover PEM private keys and mask JWT-like tokens.

* **Tests**
  * Expanded tests for connection-health reporting, redaction cases, and the indexer fastpath behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/itechmeat/open-second-brain/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->