### PR TITLE
chore(release): v0.14.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Plugin-first second brain package for AI agents and humans.",
   "author": {
     "name": "Open Second Brain contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "skills": "./skills",
   "hooks": "./hooks/hooks.json",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.1] - 2026-05-27
+
+Project-wide validation and formatting foundation. Open Second Brain gains
+a single, explicit green-path: `oxlint` for linting, `oxfmt` for
+reproducible formatting, and a `bun run validate` entrypoint that chains
+typecheck, lint, and the test suite. Formatting is now enforced across the
+TypeScript / JavaScript / JSON scope and lint errors are blocking, while
+the remaining pre-existing cleanup surface stays visible as non-blocking
+warnings. The same pass folds in the fixes required to keep the suite green
+under the stricter workflow. No runtime behaviour changes.
+
+### Added
+
+- `oxlint.json` and `.oxfmtrc.json` configs, plus `lint`, `lint:fix`,
+  `fmt`, `fmt:check`, `validate`, and `validate:fix` package scripts.
+  `bun run validate` is the main verification command; `bun run
+  validate:fix` is the single autofix path for lint and formatting.
+- `scripts/test` wrapper so `bun test` runs through the shared bun and
+  sqlite prechecks.
+- `tests/cli/coerce.test.ts`, `tests/core/validate.test.ts`, and
+  `tests/helpers/sqlite-vec.ts` covering the consolidated helpers and the
+  runtime-gated sqlite-vec path.
+
+### Changed
+
+- Applied a repository-wide formatting baseline across the TypeScript,
+  JavaScript, and JSON scope to lower diff noise for future changes.
+- Consolidated the shared input validation and coercion helpers used by
+  the CLI and MCP layers into one place.
+
+### Fixed
+
+- Removed the dream snapshot / workrun id collision that could occur when
+  both were generated within the same second.
+- Made the macOS sqlite shim-backed test execution path reliable.
+- Gated the sqlite-vec integration tests on actual runtime extension
+  loadability instead of package presence alone, so they no longer fail in
+  environments where the extension cannot load.
+
 ## [0.14.0] - 2026-05-27
 
 Semantic Brain Health and Self-Maintenance suite: `brain_doctor` grows
@@ -3059,6 +3098,7 @@ Hermes / Claude Code / Codex / OpenClaw configurations do not change.
 - Sandbox vault and plugin manifest fixtures for tests.
 - GitHub release workflow for tag-based and manually dispatched releases.
 
+[0.14.1]: https://github.com/itechmeat/open-second-brain/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/itechmeat/open-second-brain/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/itechmeat/open-second-brain/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/itechmeat/open-second-brain/compare/v0.11.0...v0.12.0

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "open-second-brain",
   "name": "Open Second Brain",
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults.",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "activation": { "onStartup": true },
   "skills": ["./skills"],
   "contracts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": false,
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults. Works with Hermes, Claude Code, Codex, and OpenClaw.",
   "keywords": [

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "0.14.0"
+version: "0.14.1"
 description: "Hermes plugin entrypoint for OpenSecondBrain vault health checks and the optional MCP tool server."
 author: "OpenSecondBrain contributors"
 kind: standalone

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "author": {
     "name": "Open Second Brain contributors",

--- a/plugins/hermes/plugin.yaml
+++ b/plugins/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "0.14.0"
+version: "0.14.1"
 description: "Hermes adapter for OpenSecondBrain vault health checks and optional MCP tool server."
 author: "OpenSecondBrain contributors"
 kind: standalone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 # CLI entry points (those moved to `package.json` `bin`).
 [project]
 name = "open-second-brain"
-version = "0.14.0"
+version = "0.14.1"
 description = "Hermes Python shim for Open Second Brain. Most of the project (CLI, MCP server, OpenClaw plugin) is TypeScript on Bun; see package.json."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Patch release cutting **v0.14.1**, which packages the validation and formatting foundation merged in #39. It bumps the canonical version in `package.json`, propagates it to the seven runtime manifests via `sync-version`, and adds the CHANGELOG entry. No source or runtime behaviour changes.

## What ships

| Area | Change |
|---|---|
| Version | `package.json` 0.14.0 → 0.14.1, synced to all 7 manifests |
| CHANGELOG | New `[0.14.1]` section + compare link |

## Verification

- [x] `bun run typecheck` — exit 0
- [x] `bun run lint` — 0 errors, 103 warnings
- [x] `bun run fmt:check` — clean (554 files)
- [x] `bun run sync-version:check` — all 7 manifests on 0.14.1
- [x] Full suite on identical code (#39): 2484 pass / 0 fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.14.1 across all package manifests and configurations.

* **Bug Fixes**
  * Resolved snapshot and workrun collision issues.
  * Enhanced macOS SQLite reliability.
  * Improved test coverage for SQLite vector functionality.

* **Documentation**
  * Updated changelog with validation and formatting improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/itechmeat/open-second-brain/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->