### PR TITLE
ci: drop bun version floor, track latest only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,23 +25,16 @@ concurrency:
 
 jobs:
   verify:
-    name: Verify (bun ${{ matrix.bun-version }})
+    name: Verify
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        # Floor matches `engines.bun` in package.json. Bumping that floor MUST
-        # also bump this matrix so CI never silently ships green at "latest"
-        # while the declared minimum no longer compiles.
-        bun-version: ["1.1.0", "latest"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Bun ${{ matrix.bun-version }}
+      - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: ${{ matrix.bun-version }}
+          bun-version: latest
 
       - name: Set up Python (Hermes shim test only)
         uses: actions/setup-python@v5

--- a/package.json
+++ b/package.json
@@ -60,9 +60,6 @@
   "optionalDependencies": {
     "sqlite-vec": "^0.1.9"
   },
-  "engines": {
-    "bun": ">=1.1.0"
-  },
   "openclaw": {
     "extensions": [
       "./openclaw/index.js"


### PR DESCRIPTION
## Summary

Drops the bun version floor (`engines.bun: ">=1.1.0"`) and the parallel floor-testing matrix in `release.yml`. The verify job now runs on a single `bun-version: latest` rail.

The v0.15.0 release run ([26564029588](https://github.com/itechmeat/open-second-brain/actions/runs/26564029588)) failed because `bun 1.1.0` (the matrix floor) cannot read the JSON `bun.lock` format (`"lockfileVersion": 1`), which bun introduced in 1.2.0. `bun install --frozen-lockfile` exited immediately on `error: lockfile had changes, but lockfile is frozen`, and `fail-fast: true` cancelled the parallel `latest` job before it could prove the project actually builds.

Dev and runtime for this repo both track the current bun line (1.3.14 today). A separate floor-testing rail no longer earns its keep here, so the matrix and `engines.bun` block are removed.

## What ships

| File | Change |
|---|---|
| `package.json` | Removed `engines.bun: ">=1.1.0"` block |
| `.github/workflows/release.yml` | Removed `strategy.matrix.bun-version` and renamed the job to plain `Verify`; the verify step is now `bun-version: latest` |

## Verification

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` - YAML valid
- [x] `python3 -m json.tool package.json` - JSON valid
- [x] `bun install --frozen-lockfile` on bun 1.3.14 - clean, `no changes`
- [x] `grep -n 'engines\|matrix' .github/workflows/release.yml package.json` - no stale references

## Re-publishing v0.15.0

The v0.15.0 tag is already on origin (commit `feca6a72`) but no release was published because verify failed. After this fix lands on `main`, re-run via `gh workflow run release.yml -f version=0.15.0`. The verify step will check out the patched `main` and the release step will publish against the existing tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed minimum Bun version requirement from package configuration, simplifying installation constraints.
  * Updated continuous integration to verify with the latest Bun version instead of testing against multiple versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/itechmeat/open-second-brain/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->