### PR TITLE
Feat/procedural attention suite

### DIFF
--- a/docs/brainstorm/procedural-attention-suite/cli-output/claude.md
+++ b/docs/brainstorm/procedural-attention-suite/cli-output/claude.md
@@ -1,0 +1,38 @@
+### Variant 1: Additive In-Place Extension
+- **Approach**: Extend each existing module directly — `procedural-memory.ts` gains a sibling edge/entity index alongside its flat JSON, `recurrence.ts`/`context-pack.ts` emit prospective recall hints at write time, and a new `attention-recipes.ts` module plus new CLI verbs and MCP tools expose ingest scoping, filtered write, export, and introspection. Each capability is a discrete cohesive function wired through the surfaces that already exist, with no new cross-cutting abstraction.
+- **Trade-offs**:
+  - Pro: Smallest diff, each task maps to a self-contained change set ideal for atomic TDD commits.
+  - Pro: Lowest risk to existing public CLI/MCP APIs — everything is purely additive.
+  - Pro: Stays closest to current conventions; reviewers compare narrow, local deltas against main.
+  - Con: Provider-readiness is implicit — the Hermes adapter PR must later extract a port from scattered functions, i.e. some rework.
+  - Con: Graph/entity logic risks duplication across procedural-memory, recall hints, and recipes (DRY pressure).
+  - Con: Introspection/export surfaces read several ad-hoc shapes rather than one model.
+- **Complexity**: medium
+- **Risk**: low
+
+### Variant 2: Memory-Graph Kernel Behind a Provider Port
+- **Approach**: Introduce a single unified memory-graph core (nodes, edges, entities) with a formal provider interface (port), and re-express procedural memory, recall hints, and attention recipes as operations on that graph; OpenSecondBrain becomes the local-first adapter implementing the port. The Hermes-compatible provider later slots in behind the identical interface with no consumer changes.
+- **Trade-offs**:
+  - Pro: Maximally provider-ready — the next PR is a new adapter, zero consumer rework.
+  - Pro: One canonical model satisfies DRY; export/introspection are first-class graph reads.
+  - Pro: Strong SOLID dependency-inversion alignment.
+  - Con: Largest refactor; touches modules behind existing public APIs, raising regression and API-compat risk.
+  - Con: Builds an abstraction for a provider that does not yet exist (YAGNI / KISS tension) within a single release.
+  - Con: Harder to keep atomic — the port and its first adapter must land together to stay green.
+- **Complexity**: large
+- **Risk**: high
+
+### Variant 3: Derived Graph Projection + Declarative Recipe Engine
+- **Approach**: Leave the flat markdown/frontmatter as the canonical source of truth and add a deterministically-derived graph projection sidecar (entity links and edges computed from existing files), plus a declarative recipe engine that renders open-loop/learning attention flows and write-time recall hints as derived, auditable artifacts. Export and introspection read the projection through one stable, documented read/write contract that a future provider maps onto.
+- **Trade-offs**:
+  - Pro: Append-only derivation preserves determinism, local-first behavior, and full auditability (rebuildable from source).
+  - Pro: The projection contract is a clean seam a provider adapter can implement without rewriting core modules — provider-ready without a full kernel rewrite.
+  - Pro: Recipes are declarative data, keeping logic DRY and feeding context surfaces uniformly; existing APIs stay untouched.
+  - Con: Two-layer (source + projection) model adds a rebuild/reconcile step to reason about.
+  - Con: Projection staleness must be handled explicitly (deterministic regeneration on write).
+  - Con: More moving parts than Variant 1, though far less invasive than Variant 2.
+- **Complexity**: medium
+- **Risk**: medium
+
+### Recommended: Variant 3
+**Rationale**: It satisfies provider-readiness through an explicit, documented projection contract — the exact seam a Hermes adapter needs — without the large, high-risk kernel rewrite of Variant 2 or the implicit "extract it later" rework debt of Variant 1. The derived-projection model is the strongest fit for the project's deterministic, local-first, auditable conventions, and its declarative recipes plus additive surfaces let each task land as atomic, backwards-compatible, TDD-friendly commits.

--- a/docs/brainstorm/procedural-attention-suite/cli-output/prompt.md
+++ b/docs/brainstorm/procedural-attention-suite/cli-output/prompt.md
@@ -1,0 +1,87 @@
+You are brainstorming architectural variants for the following task. Do not write code. Do not write a final design. Only produce variants and a recommendation.
+
+# Task
+
+Implement a single cohesive release scope that fully completes these kanban tasks together:
+
+- t_ee819f4b
+- t_02e22d4e
+- t_2fe5cffa
+- t_25d4dbfb
+- t_5d63937b
+- t_f935fe84
+
+Operator constraints:
+
+- Full completion for the selected tasks, not partial delivery.
+- Keep architecture provider-ready so a next PR can adapt OpenSecondBrain as a Hermes-compatible memory provider without rework.
+- Follow SOLID, KISS, DRY.
+- Implementation by TDD with atomic commits.
+- Run formatter and linter before each commit.
+- Self-review must compare all changes to main.
+- Version must be bumped before push.
+
+Task intent summary:
+
+- Extend procedural memory from flat index to graph/entity-linked memory with export/introspection surfaces.
+- Add prospective recall hints generated at write time.
+- Add scoped ingest context and filtered write mode.
+- Add declarative attention flow recipes for open loops and learnings that can feed context surfaces.
+- Preserve deterministic/local-first behavior and auditability.
+
+# Project context
+
+open-second-brain; TypeScript + Bun; Obsidian-native markdown brain with CLI+MCP surfaces.
+
+Recent commits:
+
+- 1f3a218 Feat/self learning skill proposals (#57)
+- 0162d13 feat(brain): add context continuity and receipts suite (#56)
+- 3b7b3a5 feat(brain): add safety governance foundations (#55)
+- 794ee45 feat(search): ship recall control and trust surfaces (#54)
+
+Related files:
+
+- src/core/brain/skill-proposals.ts
+- src/core/brain/procedural-memory.ts
+- src/core/brain/recurrence.ts
+- src/core/brain/context-pack.ts
+- src/core/search/search.ts
+- src/mcp/brain-tools.ts
+- src/cli/brain/verbs/\*
+- tests/core/brain/\*
+- tests/mcp/\*
+
+Conventions:
+
+- Deterministic, local-first core behavior is preferred.
+- CLI and MCP both need first-class surfaces for new capabilities.
+- Tests are required for core/CLI/MCP paths.
+- Changelog versioned releases are maintained in CHANGELOG.md.
+- Bun toolchain (fmt/lint/test/typecheck) is standard.
+
+Constraints:
+
+- Do not break existing public CLI/MCP APIs unless additive and backwards-compatible.
+- Keep feature scope cohesive around procedural memory + attention/recall readiness.
+- Avoid introducing unnecessary external dependencies.
+- Keep migration paths explicit and auditable.
+
+# Required output format
+
+Produce exactly 3 distinct architectural variants. For each variant:
+
+### Variant N: <short name>
+
+- **Approach**: 2-3 sentences describing the variant.
+- **Trade-offs**: bullet list of pros and cons.
+- **Complexity**: small | medium | large
+- **Risk**: low | medium | high
+
+After the three variants, add exactly one recommendation:
+
+### Recommended: Variant N
+
+**Rationale**: 2-3 sentences explaining why this variant over the others, considering the project context and constraints above.
+
+Output nothing outside of these sections.

--- a/docs/brainstorm/procedural-attention-suite/design.md
+++ b/docs/brainstorm/procedural-attention-suite/design.md
@@ -1,0 +1,73 @@
+# Procedural Attention Suite - derived graph and scoped ingest
+
+**Status:** draft
+**Author:** GitHub Copilot (feature-release-playbook)
+**Audience:** implementation
+
+## Problem statement
+
+Open Second Brain shipped procedural-learning foundations in v0.30.0, but the selected scope still lacks full graph/entity surfaces for procedural memory, write-time prospective recall hints, scoped ingest filtering, and declarative attention flows that can feed context outputs. The operator requires full delivery for six related tasks in one cohesive release and wants architecture that avoids rework when adding Hermes memory-provider compatibility in the next PR. The implementation must remain deterministic, local-first, additive, and auditable.
+
+## Scope
+
+- Add a derived procedural graph projection built from canonical procedural/proposal artifacts.
+- Add deterministic entity/link extraction for procedural entries and include links in projection/export.
+- Add CLI and MCP export/introspection surfaces for the procedural graph.
+- Add write-time prospective recall hints as derived artifacts.
+- Add scoped ingest context and filtered write mode for import/synthesis pipelines.
+- Add declarative attention-flow recipes (open loops/learnings) with evaluation + context-pack integration.
+- Add tests for core, CLI, and MCP for all new flows.
+
+## Out of scope
+
+- Full Hermes memory-provider plugin compatibility lifecycle (separate PR).
+- Non-deterministic/LLM-required hint or recipe generation.
+- Breaking changes to existing CLI/MCP contracts.
+
+## Chosen approach
+
+Use a deterministic derived-projection architecture: markdown/frontmatter artifacts remain canonical source-of-truth, while a derived projection persists graph nodes/edges/entities/hints for fast introspection and export. Declarative attention recipes read from the same projection and known runtime indexes. This creates a stable provider-ready seam (projection contract) without a high-risk kernel rewrite.
+
+## Design decisions
+
+- Projection-first seam: add a single read/write contract for procedural graph/hints so the next provider-adapter PR can target one boundary.
+- Deterministic derivation: projection can be rebuilt from canonical artifacts; no hidden remote state.
+- Additive CLI/MCP: new verbs/tools are appended; existing commands retain behavior.
+- Scoped ingest context as explicit input contract: filters and context-hints are optional, default behavior unchanged.
+- Declarative recipes as data: YAML recipes compiled/executed by bounded deterministic evaluator.
+- Backwards compatibility: existing procedural-memory index and skill-proposal flows remain valid.
+
+## File changes
+
+- Core
+  - src/core/brain/procedural-graph.ts (new)
+  - src/core/brain/procedural-hints.ts (new)
+  - src/core/brain/attention-flows.ts (new)
+  - src/core/brain/procedural-memory.ts (update)
+  - src/core/brain/skill-proposals.ts (update)
+  - src/core/brain/context-pack.ts (update)
+  - src/core/brain/paths.ts (update)
+  - src/core/brain/sessions/import.ts (update)
+- CLI
+  - src/cli/brain/verbs/procedural-graph.ts (new)
+  - src/cli/brain/verbs/attention-flows.ts (new)
+  - src/cli/brain/verbs/index.ts (update)
+  - src/cli/brain/help-text.ts (update)
+- MCP
+  - src/mcp/brain-tools.ts (update)
+- Tests
+  - tests/core/brain/procedural-graph.test.ts (new)
+  - tests/core/brain/procedural-hints.test.ts (new)
+  - tests/core/brain/attention-flows.test.ts (new)
+  - tests/cli/brain-procedural-graph.test.ts (new)
+  - tests/mcp/procedural-graph-tools.test.ts (new)
+  - existing related tests updated as needed
+
+## Risks and open questions
+
+- Risk: projection drift if updates are not triggered consistently.
+  - Mitigation: explicit reconcile hooks + tests for rebuild/idempotence.
+- Risk: over-broad ingest filters can hide required context.
+  - Mitigation: explicit diagnostics in JSON outputs and safe defaults.
+- Risk: recipe complexity creep.
+  - Mitigation: small bounded action set in v1 and strict schema validation.

--- a/docs/brainstorm/procedural-attention-suite/plan.md
+++ b/docs/brainstorm/procedural-attention-suite/plan.md
@@ -1,0 +1,51 @@
+# Procedural Attention Suite - implementation plan
+
+## Tasks
+
+### Task 1: Projection contract and paths
+
+- **Files**: src/core/brain/paths.ts, src/core/brain/procedural-graph.ts
+- **Acceptance**: projection read/write/rebuild primitives exist with deterministic ordering and schema version.
+- **Depends on**: none
+
+### Task 2: Procedural graph/entity linking
+
+- **Files**: src/core/brain/procedural-memory.ts, src/core/brain/skill-proposals.ts, src/core/brain/procedural-graph.ts
+- **Acceptance**: reconcile emits graph nodes/edges/entities; entity links appear in projection.
+- **Depends on**: Task 1
+
+### Task 3: Graph export and introspection surfaces
+
+- **Files**: src/cli/brain/verbs/procedural-graph.ts, src/cli/brain/verbs/index.ts, src/cli/brain/help-text.ts, src/mcp/brain-tools.ts
+- **Acceptance**: CLI/MCP expose list/show/export/rebuild operations for procedural graph.
+- **Depends on**: Task 2
+
+### Task 4: Prospective recall hints at write time
+
+- **Files**: src/core/brain/procedural-hints.ts, src/core/brain/procedural-memory.ts, src/core/brain/skill-proposals.ts, src/mcp/brain-tools.ts
+- **Acceptance**: derived hints are generated deterministically on writes/reconcile and queryable.
+- **Depends on**: Task 2
+
+### Task 5: Scoped ingest context and filtered write mode
+
+- **Files**: src/core/brain/sessions/import.ts, src/core/brain/context-pack.ts, src/mcp/brain-tools.ts, CLI import surfaces
+- **Acceptance**: ingest path accepts scoped filters/hints and reports applied filters; default behavior unchanged.
+- **Depends on**: Task 1
+
+### Task 6: Declarative attention flows
+
+- **Files**: src/core/brain/attention-flows.ts, src/core/brain/context-pack.ts, src/cli/brain/verbs/attention-flows.ts, src/mcp/brain-tools.ts
+- **Acceptance**: YAML recipes validate and execute bounded actions for open loops/learnings; outputs consumable by context-pack.
+- **Depends on**: Task 1, Task 2
+
+### Task 7: Test suite and compatibility hardening
+
+- **Files**: tests/core/brain/_, tests/cli/_, tests/mcp/\*
+- **Acceptance**: new core/CLI/MCP tests pass; existing procedural-learning tests remain green.
+- **Depends on**: Tasks 2-6
+
+### Task 8: Release/docs/version
+
+- **Files**: README.md, CHANGELOG.md, package.json + synced version files
+- **Acceptance**: docs updated, changelog entry added, version bumped and sync check passes.
+- **Depends on**: Task 7

--- a/docs/brainstorm/procedural-attention-suite/variants.md
+++ b/docs/brainstorm/procedural-attention-suite/variants.md
@@ -1,0 +1,38 @@
+# Variants audit - procedural-attention-suite
+
+## Source
+
+- Prompt: docs/brainstorm/procedural-attention-suite/cli-output/prompt.md
+- Consultant output: docs/brainstorm/procedural-attention-suite/cli-output/claude.md
+
+## Variant 1: Additive In-Place Extension
+
+- Extend existing modules directly with minimal abstraction.
+- Pros: smallest diff, low API risk, fast landing.
+- Cons: provider-readiness becomes implicit, higher duplication risk.
+- Complexity: medium
+- Risk: low
+
+## Variant 2: Memory-Graph Kernel Behind a Provider Port
+
+- Introduce full graph kernel + provider port and adapt all features on top.
+- Pros: strongest DIP/provider seam.
+- Cons: biggest refactor and regression risk for one release.
+- Complexity: large
+- Risk: high
+
+## Variant 3: Derived Graph Projection + Declarative Recipe Engine
+
+- Keep canonical artifacts, add deterministic derived projection and declarative attention recipes.
+- Pros: provider-ready seam without full rewrite, deterministic and auditable, additive APIs.
+- Cons: requires projection reconcile discipline and bounded recipe design.
+- Complexity: medium
+- Risk: medium
+
+## Decision
+
+Chosen variant: Variant 3.
+
+### Rationale
+
+Variant 3 gives the best balance for the required six-task full scope: it enables graph/export and attention/hints flows on a shared projection contract while preserving local-first deterministic behavior and minimizing rewrite risk. It is explicitly provider-ready for the next PR by introducing a stable projection seam, but avoids the high-risk kernel refactor from Variant 2.

--- a/src/cli/brain.ts
+++ b/src/cli/brain.ts
@@ -79,9 +79,7 @@ import {
   cmdBrainWeekly,
 } from "./brain/verbs/index.ts";
 
-export async function handleBrainSubcommand(
-  argv: ReadonlyArray<string>,
-): Promise<number> {
+export async function handleBrainSubcommand(argv: ReadonlyArray<string>): Promise<number> {
   if (argv.length === 0 || argv[0] === "-h" || argv[0] === "--help") {
     process.stdout.write(BRAIN_HELP);
     return argv.length === 0 ? 2 : 0;

--- a/src/cli/brain.ts
+++ b/src/cli/brain.ts
@@ -60,7 +60,9 @@ import {
   cmdBrainRecallTelemetry,
   cmdBrainSkillProposals,
   cmdBrainProceduralMemory,
+  cmdBrainProceduralGraph,
   cmdBrainRecurrence,
+  cmdBrainAttentionFlows,
   cmdBrainSessionDescribe,
   cmdBrainSessionExpand,
   cmdBrainSessionGrep,
@@ -77,7 +79,9 @@ import {
   cmdBrainWeekly,
 } from "./brain/verbs/index.ts";
 
-export async function handleBrainSubcommand(argv: ReadonlyArray<string>): Promise<number> {
+export async function handleBrainSubcommand(
+  argv: ReadonlyArray<string>,
+): Promise<number> {
   if (argv.length === 0 || argv[0] === "-h" || argv[0] === "--help") {
     process.stdout.write(BRAIN_HELP);
     return argv.length === 0 ? 2 : 0;
@@ -199,8 +203,12 @@ export async function handleBrainSubcommand(argv: ReadonlyArray<string>): Promis
         return await cmdBrainSkillProposals(rest);
       case "procedural-memory":
         return await cmdBrainProceduralMemory(rest);
+      case "procedural-graph":
+        return await cmdBrainProceduralGraph(rest);
       case "recurrence":
         return await cmdBrainRecurrence(rest);
+      case "attention-flows":
+        return await cmdBrainAttentionFlows(rest);
       case "session-grep":
         return await cmdBrainSessionGrep(rest);
       case "session-describe":

--- a/src/cli/brain/help-text.ts
+++ b/src/cli/brain/help-text.ts
@@ -62,7 +62,9 @@ Brain verbs (observing memory):
   recall-telemetry    List/summarize opt-in recall telemetry records
   skill-proposals     Learn/list/review deterministic skill proposals
   procedural-memory   Reconcile/list procedural memory index and usage
+  procedural-graph    Rebuild/show procedural graph and hint projections
   recurrence          Inspect and update recurrence/support diagnostics
+  attention-flows     Declarative attention recipes for open loops and learnings
   session-grep        Search imported session recall turns and summaries
   session-describe    Describe an imported session recall DAG
   session-expand      Expand a session recall node to source turns
@@ -266,6 +268,7 @@ export const VERB_HELP: Record<string, string> = {
     "usage: o2b brain import-session <path> [--vault <vault>]\n" +
     "                                [--format auto|<registered-adapter>]\n" +
     "                                [--agent <name>] [--since <ISO>] [--dry-run] [--recall]\n" +
+    "                                [--ingest-scope <label>] [--filter-role <role> ...] [--filter-text <substring>]\n" +
     "                                [--recall-session-id <id>] [--recall-summary-group-size <n>] [--json]\n" +
     "Extract signals from a registered agent session .jsonl file (or\n" +
     "directory of .jsonl files). Two extraction paths run in parallel:\n" +
@@ -377,6 +380,12 @@ export const VERB_HELP: Record<string, string> = {
     "  reconcile [--root <path> ...] [--vault <path>] [--json]\n" +
     "  list [--vault <path>] [--json]\n" +
     "  mark-used <entry-id> [--vault <path>] [--json]\n",
+  "procedural-graph":
+    "usage: o2b brain procedural-graph <rebuild|show|hints> [args]\n" +
+    "Read/write procedural graph and prospective-hints projections.\n" +
+    "  rebuild [--vault <path>] [--json]\n" +
+    "  show [--vault <path>] [--json]\n" +
+    "  hints [--vault <path>] [--json]\n",
   recurrence:
     "usage: o2b brain recurrence <list|show|learn|forget|purge-source> [args]\n" +
     "Recurrence/support diagnostics and reference-counted updates.\n" +
@@ -385,6 +394,12 @@ export const VERB_HELP: Record<string, string> = {
     "  learn --hash <h> --scope <scope> --source <id> [--vault <path>] [--json]\n" +
     "  forget --hash <h> --scope <scope> --source <id> [--vault <path>] [--json]\n" +
     "  purge-source --source <id> [--vault <path>] [--json]\n",
+  "attention-flows":
+    "usage: o2b brain attention-flows <list|evaluate|render> [args]\n" +
+    "Declarative attention-flow recipes and evaluation surfaces.\n" +
+    "  list [--vault <path>] [--json]\n" +
+    "  evaluate <flow-id> [--vault <path>] [--json]\n" +
+    "  render <flow-id> [--vault <path>] [--json]\n",
   "session-grep":
     "usage: o2b brain session-grep --query <text> [--session-id <id>] [--limit <n>] [--snippet-chars <n>] [--vault <path>] [--json]\n" +
     "Search imported session recall raw turns and summary nodes.\n",

--- a/src/cli/brain/verbs/attention-flows.ts
+++ b/src/cli/brain/verbs/attention-flows.ts
@@ -85,6 +85,6 @@ function render(argv: string[]): number {
     );
     return 0;
   }
-  process.stdout.write(text);
+  process.stdout.write(text.endsWith("\n") ? text : text + "\n");
   return 0;
 }

--- a/src/cli/brain/verbs/attention-flows.ts
+++ b/src/cli/brain/verbs/attention-flows.ts
@@ -1,0 +1,90 @@
+import { defaultConfigPath } from "../../../core/config.ts";
+import {
+  evaluateAttentionFlow,
+  listAttentionFlows,
+  renderAttentionFlow,
+} from "../../../core/brain/attention-flows.ts";
+import { CliError, parse, resolveBrainVault } from "../helpers.ts";
+
+export async function cmdBrainAttentionFlows(argv: string[]): Promise<number> {
+  const sub = argv[0];
+  const rest = argv.slice(1);
+  if (sub === "list") return list(rest);
+  if (sub === "evaluate") return evaluate(rest);
+  if (sub === "render") return render(rest);
+  throw new CliError(
+    "brain attention-flows: expected list, evaluate, or render",
+  );
+}
+
+function list(argv: string[]): number {
+  const { flags } = parse(argv, {
+    vault: { type: "string" },
+    json: { type: "boolean" },
+  });
+  const vault = resolveBrainVault(
+    flags["vault"] as string | undefined,
+    defaultConfigPath(),
+  );
+  const flows = listAttentionFlows(vault);
+  if (flags["json"]) {
+    process.stdout.write(
+      JSON.stringify({ total: flows.length, flows }, null, 2) + "\n",
+    );
+    return 0;
+  }
+  process.stdout.write(`${flows.length} attention flow(s):\n`);
+  for (const flow of flows) {
+    process.stdout.write(
+      `  ${flow.id}  actions=${flow.actions.join(",") || "-"}\n`,
+    );
+  }
+  return 0;
+}
+
+function evaluate(argv: string[]): number {
+  const { flags, positional } = parse(argv, {
+    vault: { type: "string" },
+    json: { type: "boolean" },
+  });
+  const flowId = positional[0];
+  if (!flowId)
+    throw new CliError("brain attention-flows evaluate: flow id is required");
+  const vault = resolveBrainVault(
+    flags["vault"] as string | undefined,
+    defaultConfigPath(),
+  );
+  const report = evaluateAttentionFlow(vault, flowId);
+  if (flags["json"]) {
+    process.stdout.write(JSON.stringify(report, null, 2) + "\n");
+    return 0;
+  }
+  process.stdout.write(`${report.flow_id}: ${report.title}\n`);
+  for (const section of report.sections) {
+    process.stdout.write(`  ${section.action}: ${section.items.length}\n`);
+  }
+  return 0;
+}
+
+function render(argv: string[]): number {
+  const { flags, positional } = parse(argv, {
+    vault: { type: "string" },
+    json: { type: "boolean" },
+  });
+  const flowId = positional[0];
+  if (!flowId)
+    throw new CliError("brain attention-flows render: flow id is required");
+  const vault = resolveBrainVault(
+    flags["vault"] as string | undefined,
+    defaultConfigPath(),
+  );
+  const text = renderAttentionFlow(vault, flowId);
+  if (flags["json"]) {
+    process.stdout.write(
+      JSON.stringify({ flow_id: flowId, text }, null, 2) + "\n",
+    );
+    return 0;
+  }
+  process.stdout.write(text);
+  return 0;
+}

--- a/src/cli/brain/verbs/attention-flows.ts
+++ b/src/cli/brain/verbs/attention-flows.ts
@@ -54,7 +54,12 @@ function evaluate(argv: string[]): number {
     flags["vault"] as string | undefined,
     defaultConfigPath(),
   );
-  const report = evaluateAttentionFlow(vault, flowId);
+  let report;
+  try {
+    report = evaluateAttentionFlow(vault, flowId);
+  } catch (error) {
+    throw mapAttentionFlowError(error, flowId);
+  }
   if (flags["json"]) {
     process.stdout.write(JSON.stringify(report, null, 2) + "\n");
     return 0;
@@ -78,7 +83,12 @@ function render(argv: string[]): number {
     flags["vault"] as string | undefined,
     defaultConfigPath(),
   );
-  const text = renderAttentionFlow(vault, flowId);
+  let text: string;
+  try {
+    text = renderAttentionFlow(vault, flowId);
+  } catch (error) {
+    throw mapAttentionFlowError(error, flowId);
+  }
   if (flags["json"]) {
     process.stdout.write(
       JSON.stringify({ flow_id: flowId, text }, null, 2) + "\n",
@@ -87,4 +97,14 @@ function render(argv: string[]): number {
   }
   process.stdout.write(text.endsWith("\n") ? text : text + "\n");
   return 0;
+}
+
+function mapAttentionFlowError(error: unknown, flowId: string): CliError {
+  if (error instanceof Error) {
+    if (error.message.startsWith("attention flow not found:")) {
+      return new CliError(`brain attention-flows: unknown flow id: ${flowId}`);
+    }
+    return new CliError(error.message);
+  }
+  return new CliError("brain attention-flows: failed to evaluate flow");
 }

--- a/src/cli/brain/verbs/import-session.ts
+++ b/src/cli/brain/verbs/import-session.ts
@@ -1,13 +1,7 @@
 import { statSync } from "node:fs";
 import { defaultConfigPath, resolveAgentName } from "../../../core/config.ts";
-import {
-  importSession,
-  importSessionPath,
-} from "../../../core/brain/sessions/import.ts";
-import {
-  SessionImportError,
-  type SessionAdapterId,
-} from "../../../core/brain/sessions/types.ts";
+import { importSession, importSessionPath } from "../../../core/brain/sessions/import.ts";
+import { SessionImportError, type SessionAdapterId } from "../../../core/brain/sessions/types.ts";
 import {
   isSessionAdapterId,
   sessionAdapterFormatChoices,
@@ -42,8 +36,7 @@ export async function cmdBrainImportSession(argv: string[]): Promise<number> {
     "filter-text": { type: "string" },
     json: { type: "boolean" },
   });
-  if (positional.length < 1)
-    return fail("brain import-session requires a <path> argument");
+  if (positional.length < 1) return fail("brain import-session requires a <path> argument");
   const sessionPath = positional[0]!;
   const config = defaultConfigPath();
   const vault = resolveBrainVault(flags["vault"] as string | undefined, config);
@@ -60,30 +53,19 @@ export async function cmdBrainImportSession(argv: string[]): Promise<number> {
     flags["recall-summary-group-size"],
     "--recall-summary-group-size",
   );
-  const ingestScope = normalizeFlagString(
-    flags["ingest-scope"] as string | undefined,
-  );
-  const filterRoles = normalizeRoleFilter(
-    flags["filter-role"] as string[] | undefined,
-  );
-  const filterText = normalizeFlagString(
-    flags["filter-text"] as string | undefined,
-  );
+  const ingestScope = normalizeFlagString(flags["ingest-scope"] as string | undefined);
+  const filterRoles = normalizeRoleFilter(flags["filter-role"] as string[] | undefined);
+  const filterText = normalizeFlagString(flags["filter-text"] as string | undefined);
 
   const formatRaw = flags["format"] as string | undefined;
   let format: SessionAdapterId | undefined;
   if (formatRaw !== undefined && formatRaw !== "auto") {
     if (!isSessionAdapterId(formatRaw))
-      return fail(
-        `--format must be one of ${sessionAdapterFormatChoices()}; got ${formatRaw}`,
-      );
+      return fail(`--format must be one of ${sessionAdapterFormatChoices()}; got ${formatRaw}`);
     format = formatRaw;
   }
 
-  const { value: since, error: sinceErr } = parseOptionalIsoDate(
-    flags,
-    "since",
-  );
+  const { value: since, error: sinceErr } = parseOptionalIsoDate(flags, "since");
   if (sinceErr) return fail(sinceErr);
 
   let stat;
@@ -123,9 +105,7 @@ export async function cmdBrainImportSession(argv: string[]): Promise<number> {
                 : {}),
               ...(ingestScope !== null ? { ingestScope } : {}),
               ...(filterRoles.length > 0 ? { filterRoles } : {}),
-              ...(filterText !== null
-                ? { filterTextIncludes: filterText }
-                : {}),
+              ...(filterText !== null ? { filterTextIncludes: filterText } : {}),
             }),
           ],
           warnings: [],
@@ -189,8 +169,7 @@ export async function cmdBrainImportSession(argv: string[]): Promise<number> {
         if (f.malformed > 0) ok(`  malformed: ${f.malformed}`);
         for (const e of f.errors) info(`  error: ${e.path}: ${e.message}`);
       }
-      for (const w of result.warnings)
-        info(`  warning: ${w.path}: ${w.message}`);
+      for (const w of result.warnings) info(`  warning: ${w.path}: ${w.message}`);
     }
     return 0;
   } catch (exc) {
@@ -207,13 +186,7 @@ function normalizeRoleFilter(
   raw: string[] | undefined,
 ): Array<"user" | "assistant" | "system" | "tool" | "meta"> {
   if (!raw || raw.length === 0) return [];
-  const allowed = new Set([
-    "user",
-    "assistant",
-    "system",
-    "tool",
-    "meta",
-  ] as const);
+  const allowed = new Set(["user", "assistant", "system", "tool", "meta"] as const);
   const out: Array<"user" | "assistant" | "system" | "tool" | "meta"> = [];
   for (const value of raw) {
     const normalized = value.trim().toLowerCase() as

--- a/src/cli/brain/verbs/import-session.ts
+++ b/src/cli/brain/verbs/import-session.ts
@@ -1,7 +1,13 @@
 import { statSync } from "node:fs";
 import { defaultConfigPath, resolveAgentName } from "../../../core/config.ts";
-import { importSession, importSessionPath } from "../../../core/brain/sessions/import.ts";
-import { SessionImportError, type SessionAdapterId } from "../../../core/brain/sessions/types.ts";
+import {
+  importSession,
+  importSessionPath,
+} from "../../../core/brain/sessions/import.ts";
+import {
+  SessionImportError,
+  type SessionAdapterId,
+} from "../../../core/brain/sessions/types.ts";
 import {
   isSessionAdapterId,
   sessionAdapterFormatChoices,
@@ -31,9 +37,13 @@ export async function cmdBrainImportSession(argv: string[]): Promise<number> {
     recall: { type: "boolean" },
     "recall-session-id": { type: "string" },
     "recall-summary-group-size": { type: "string" },
+    "ingest-scope": { type: "string" },
+    "filter-role": { type: "string-array" },
+    "filter-text": { type: "string" },
     json: { type: "boolean" },
   });
-  if (positional.length < 1) return fail("brain import-session requires a <path> argument");
+  if (positional.length < 1)
+    return fail("brain import-session requires a <path> argument");
   const sessionPath = positional[0]!;
   const config = defaultConfigPath();
   const vault = resolveBrainVault(flags["vault"] as string | undefined, config);
@@ -50,16 +60,30 @@ export async function cmdBrainImportSession(argv: string[]): Promise<number> {
     flags["recall-summary-group-size"],
     "--recall-summary-group-size",
   );
+  const ingestScope = normalizeFlagString(
+    flags["ingest-scope"] as string | undefined,
+  );
+  const filterRoles = normalizeRoleFilter(
+    flags["filter-role"] as string[] | undefined,
+  );
+  const filterText = normalizeFlagString(
+    flags["filter-text"] as string | undefined,
+  );
 
   const formatRaw = flags["format"] as string | undefined;
   let format: SessionAdapterId | undefined;
   if (formatRaw !== undefined && formatRaw !== "auto") {
     if (!isSessionAdapterId(formatRaw))
-      return fail(`--format must be one of ${sessionAdapterFormatChoices()}; got ${formatRaw}`);
+      return fail(
+        `--format must be one of ${sessionAdapterFormatChoices()}; got ${formatRaw}`,
+      );
     format = formatRaw;
   }
 
-  const { value: since, error: sinceErr } = parseOptionalIsoDate(flags, "since");
+  const { value: since, error: sinceErr } = parseOptionalIsoDate(
+    flags,
+    "since",
+  );
   if (sinceErr) return fail(sinceErr);
 
   let stat;
@@ -81,6 +105,9 @@ export async function cmdBrainImportSession(argv: string[]): Promise<number> {
           ...(recallSummaryGroupSize !== undefined
             ? { recallSummaryGroupSize: recallSummaryGroupSize }
             : {}),
+          ...(ingestScope !== null ? { ingestScope } : {}),
+          ...(filterRoles.length > 0 ? { filterRoles } : {}),
+          ...(filterText !== null ? { filterTextIncludes: filterText } : {}),
         })
       : {
           files: [
@@ -93,6 +120,11 @@ export async function cmdBrainImportSession(argv: string[]): Promise<number> {
               ...(recallSessionId !== null ? { recallSessionId } : {}),
               ...(recallSummaryGroupSize !== undefined
                 ? { recallSummaryGroupSize: recallSummaryGroupSize }
+                : {}),
+              ...(ingestScope !== null ? { ingestScope } : {}),
+              ...(filterRoles.length > 0 ? { filterRoles } : {}),
+              ...(filterText !== null
+                ? { filterTextIncludes: filterText }
                 : {}),
             }),
           ],
@@ -134,6 +166,7 @@ export async function cmdBrainImportSession(argv: string[]): Promise<number> {
           signals_deduped: f.signals_deduped,
           tool_replays: f.tool_replays,
           malformed: f.malformed,
+          filtered_turns: f.filtered_turns,
           recall_turns_imported: f.recall_turns_imported,
           recall_summary_nodes: f.recall_summary_nodes,
           errors: f.errors,
@@ -148,6 +181,7 @@ export async function cmdBrainImportSession(argv: string[]): Promise<number> {
         ok(`  signals_created: ${f.signals_created}`);
         ok(`  signals_deduped: ${f.signals_deduped}`);
         ok(`  tool_replays: ${f.tool_replays}`);
+        ok(`  filtered_turns: ${f.filtered_turns}`);
         if (flags["recall"]) {
           ok(`  recall_turns_imported: ${f.recall_turns_imported}`);
           ok(`  recall_summary_nodes: ${f.recall_summary_nodes}`);
@@ -155,7 +189,8 @@ export async function cmdBrainImportSession(argv: string[]): Promise<number> {
         if (f.malformed > 0) ok(`  malformed: ${f.malformed}`);
         for (const e of f.errors) info(`  error: ${e.path}: ${e.message}`);
       }
-      for (const w of result.warnings) info(`  warning: ${w.path}: ${w.message}`);
+      for (const w of result.warnings)
+        info(`  warning: ${w.path}: ${w.message}`);
     }
     return 0;
   } catch (exc) {
@@ -166,6 +201,33 @@ export async function cmdBrainImportSession(argv: string[]): Promise<number> {
     }
     return fail(`import-session failed: ${(exc as Error).message ?? exc}`);
   }
+}
+
+function normalizeRoleFilter(
+  raw: string[] | undefined,
+): Array<"user" | "assistant" | "system" | "tool" | "meta"> {
+  if (!raw || raw.length === 0) return [];
+  const allowed = new Set([
+    "user",
+    "assistant",
+    "system",
+    "tool",
+    "meta",
+  ] as const);
+  const out: Array<"user" | "assistant" | "system" | "tool" | "meta"> = [];
+  for (const value of raw) {
+    const normalized = value.trim().toLowerCase() as
+      | "user"
+      | "assistant"
+      | "system"
+      | "tool"
+      | "meta";
+    if (!allowed.has(normalized)) {
+      throw new CliError(`--filter-role contains unsupported value: ${value}`);
+    }
+    out.push(normalized);
+  }
+  return [...new Set(out)];
 }
 
 function parsePositiveIntegerFlag(

--- a/src/cli/brain/verbs/index.ts
+++ b/src/cli/brain/verbs/index.ts
@@ -33,7 +33,10 @@ export { cmdBrainMerge } from "./merge.ts";
 export { cmdBrainExplorer } from "./explorer.ts";
 export { cmdBrainExport } from "./export.ts";
 export { cmdBrainUpgrade } from "./upgrade.ts";
-export { cmdBrainSnapshotDiff, handleBrainSnapshotSubcommand } from "./snapshot.ts";
+export {
+  cmdBrainSnapshotDiff,
+  handleBrainSnapshotSubcommand,
+} from "./snapshot.ts";
 export { cmdBrainScanInline } from "./scan-inline.ts";
 export { cmdBrainImportSession } from "./import-session.ts";
 export { cmdBrainSessionHook } from "./session-hook.ts";
@@ -47,7 +50,9 @@ export { cmdBrainPreCompactExtract } from "./pre-compact-extract.ts";
 export { cmdBrainRecallTelemetry } from "./recall-telemetry.ts";
 export { cmdBrainSkillProposals } from "./skill-proposals.ts";
 export { cmdBrainProceduralMemory } from "./procedural-memory.ts";
+export { cmdBrainProceduralGraph } from "./procedural-graph.ts";
 export { cmdBrainRecurrence } from "./recurrence.ts";
+export { cmdBrainAttentionFlows } from "./attention-flows.ts";
 export {
   cmdBrainSessionDescribe,
   cmdBrainSessionExpand,

--- a/src/cli/brain/verbs/index.ts
+++ b/src/cli/brain/verbs/index.ts
@@ -33,10 +33,7 @@ export { cmdBrainMerge } from "./merge.ts";
 export { cmdBrainExplorer } from "./explorer.ts";
 export { cmdBrainExport } from "./export.ts";
 export { cmdBrainUpgrade } from "./upgrade.ts";
-export {
-  cmdBrainSnapshotDiff,
-  handleBrainSnapshotSubcommand,
-} from "./snapshot.ts";
+export { cmdBrainSnapshotDiff, handleBrainSnapshotSubcommand } from "./snapshot.ts";
 export { cmdBrainScanInline } from "./scan-inline.ts";
 export { cmdBrainImportSession } from "./import-session.ts";
 export { cmdBrainSessionHook } from "./session-hook.ts";

--- a/src/cli/brain/verbs/procedural-graph.ts
+++ b/src/cli/brain/verbs/procedural-graph.ts
@@ -15,9 +15,7 @@ export async function cmdBrainProceduralGraph(argv: string[]): Promise<number> {
   if (sub === "rebuild") return rebuild(rest);
   if (sub === "show") return show(rest);
   if (sub === "hints") return hints(rest);
-  throw new CliError(
-    "brain procedural-graph: expected rebuild, show, or hints",
-  );
+  throw new CliError("brain procedural-graph: expected rebuild, show, or hints");
 }
 
 function rebuild(argv: string[]): number {
@@ -25,10 +23,7 @@ function rebuild(argv: string[]): number {
     vault: { type: "string" },
     json: { type: "boolean" },
   });
-  const vault = resolveBrainVault(
-    flags["vault"] as string | undefined,
-    defaultConfigPath(),
-  );
+  const vault = resolveBrainVault(flags["vault"] as string | undefined, defaultConfigPath());
   const graph = rebuildProceduralGraph(vault);
   const hintProjection = rebuildProceduralHints(vault, { graph });
 
@@ -65,15 +60,9 @@ function show(argv: string[]): number {
     vault: { type: "string" },
     json: { type: "boolean" },
   });
-  const vault = resolveBrainVault(
-    flags["vault"] as string | undefined,
-    defaultConfigPath(),
-  );
+  const vault = resolveBrainVault(flags["vault"] as string | undefined, defaultConfigPath());
   const graph = readProceduralGraph(vault);
-  if (!graph)
-    throw new CliError(
-      "brain procedural-graph show: graph projection not found",
-    );
+  if (!graph) throw new CliError("brain procedural-graph show: graph projection not found");
 
   if (flags["json"]) {
     process.stdout.write(JSON.stringify(graph, null, 2) + "\n");
@@ -91,15 +80,9 @@ function hints(argv: string[]): number {
     vault: { type: "string" },
     json: { type: "boolean" },
   });
-  const vault = resolveBrainVault(
-    flags["vault"] as string | undefined,
-    defaultConfigPath(),
-  );
+  const vault = resolveBrainVault(flags["vault"] as string | undefined, defaultConfigPath());
   const projection = readProceduralHints(vault);
-  if (!projection)
-    throw new CliError(
-      "brain procedural-graph hints: hints projection not found",
-    );
+  if (!projection) throw new CliError("brain procedural-graph hints: hints projection not found");
 
   if (flags["json"]) {
     process.stdout.write(JSON.stringify(projection, null, 2) + "\n");

--- a/src/cli/brain/verbs/procedural-graph.ts
+++ b/src/cli/brain/verbs/procedural-graph.ts
@@ -1,0 +1,113 @@
+import { defaultConfigPath } from "../../../core/config.ts";
+import {
+  readProceduralGraph,
+  rebuildProceduralGraph,
+} from "../../../core/brain/procedural-graph.ts";
+import {
+  readProceduralHints,
+  rebuildProceduralHints,
+} from "../../../core/brain/procedural-hints.ts";
+import { CliError, parse, resolveBrainVault } from "../helpers.ts";
+
+export async function cmdBrainProceduralGraph(argv: string[]): Promise<number> {
+  const sub = argv[0];
+  const rest = argv.slice(1);
+  if (sub === "rebuild") return rebuild(rest);
+  if (sub === "show") return show(rest);
+  if (sub === "hints") return hints(rest);
+  throw new CliError(
+    "brain procedural-graph: expected rebuild, show, or hints",
+  );
+}
+
+function rebuild(argv: string[]): number {
+  const { flags } = parse(argv, {
+    vault: { type: "string" },
+    json: { type: "boolean" },
+  });
+  const vault = resolveBrainVault(
+    flags["vault"] as string | undefined,
+    defaultConfigPath(),
+  );
+  const graph = rebuildProceduralGraph(vault);
+  const hintProjection = rebuildProceduralHints(vault, { graph });
+
+  if (flags["json"]) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          operation: "rebuild",
+          graph: {
+            nodes: graph.nodes.length,
+            edges: graph.edges.length,
+            generated_at: graph.generated_at,
+          },
+          hints: {
+            entries: hintProjection.entries.length,
+            generated_at: hintProjection.generated_at,
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    return 0;
+  }
+
+  process.stdout.write(
+    `procedural-graph rebuilt: nodes=${graph.nodes.length} edges=${graph.edges.length} hints=${hintProjection.entries.length}\n`,
+  );
+  return 0;
+}
+
+function show(argv: string[]): number {
+  const { flags } = parse(argv, {
+    vault: { type: "string" },
+    json: { type: "boolean" },
+  });
+  const vault = resolveBrainVault(
+    flags["vault"] as string | undefined,
+    defaultConfigPath(),
+  );
+  const graph = readProceduralGraph(vault);
+  if (!graph)
+    throw new CliError(
+      "brain procedural-graph show: graph projection not found",
+    );
+
+  if (flags["json"]) {
+    process.stdout.write(JSON.stringify(graph, null, 2) + "\n");
+    return 0;
+  }
+
+  process.stdout.write(
+    `procedural-graph: nodes=${graph.nodes.length} edges=${graph.edges.length} generated_at=${graph.generated_at}\n`,
+  );
+  return 0;
+}
+
+function hints(argv: string[]): number {
+  const { flags } = parse(argv, {
+    vault: { type: "string" },
+    json: { type: "boolean" },
+  });
+  const vault = resolveBrainVault(
+    flags["vault"] as string | undefined,
+    defaultConfigPath(),
+  );
+  const projection = readProceduralHints(vault);
+  if (!projection)
+    throw new CliError(
+      "brain procedural-graph hints: hints projection not found",
+    );
+
+  if (flags["json"]) {
+    process.stdout.write(JSON.stringify(projection, null, 2) + "\n");
+    return 0;
+  }
+
+  process.stdout.write(
+    `procedural-hints: entries=${projection.entries.length} generated_at=${projection.generated_at}\n`,
+  );
+  return 0;
+}

--- a/src/cli/brain/verbs/procedural-memory.ts
+++ b/src/cli/brain/verbs/procedural-memory.ts
@@ -7,17 +7,13 @@ import {
 import { CliError, parse, resolveBrainVault } from "../helpers.ts";
 import { join } from "node:path";
 
-export async function cmdBrainProceduralMemory(
-  argv: string[],
-): Promise<number> {
+export async function cmdBrainProceduralMemory(argv: string[]): Promise<number> {
   const sub = argv[0];
   const rest = argv.slice(1);
   if (sub === "reconcile") return reconcile(rest);
   if (sub === "list") return list(rest);
   if (sub === "mark-used") return markUsed(rest);
-  throw new CliError(
-    "brain procedural-memory: expected reconcile, list, or mark-used",
-  );
+  throw new CliError("brain procedural-memory: expected reconcile, list, or mark-used");
 }
 
 function reconcile(argv: string[]): number {
@@ -26,10 +22,7 @@ function reconcile(argv: string[]): number {
     json: { type: "boolean" },
     root: { type: "string-array" },
   });
-  const vault = resolveBrainVault(
-    flags["vault"] as string | undefined,
-    defaultConfigPath(),
-  );
+  const vault = resolveBrainVault(flags["vault"] as string | undefined, defaultConfigPath());
   const roots = normalizeRoots(vault, flags["root"]);
   const result = reconcileProceduralMemory(vault, { roots });
 
@@ -49,16 +42,11 @@ function list(argv: string[]): number {
     vault: { type: "string" },
     json: { type: "boolean" },
   });
-  const vault = resolveBrainVault(
-    flags["vault"] as string | undefined,
-    defaultConfigPath(),
-  );
+  const vault = resolveBrainVault(flags["vault"] as string | undefined, defaultConfigPath());
   const entries = listProceduralMemory(vault);
 
   if (flags["json"]) {
-    process.stdout.write(
-      JSON.stringify({ total: entries.length, entries }, null, 2) + "\n",
-    );
+    process.stdout.write(JSON.stringify({ total: entries.length, entries }, null, 2) + "\n");
     return 0;
   }
 
@@ -77,46 +65,26 @@ function markUsed(argv: string[]): number {
     json: { type: "boolean" },
   });
   const id = trim(positional[0]);
-  if (!id)
-    throw new CliError(
-      "brain procedural-memory mark-used: entry id is required",
-    );
-  const vault = resolveBrainVault(
-    flags["vault"] as string | undefined,
-    defaultConfigPath(),
-  );
+  if (!id) throw new CliError("brain procedural-memory mark-used: entry id is required");
+  const vault = resolveBrainVault(flags["vault"] as string | undefined, defaultConfigPath());
   const updated = markProceduralMemoryUsed(vault, id);
-  if (!updated)
-    throw new CliError(
-      `brain procedural-memory mark-used: unknown entry: ${id}`,
-    );
+  if (!updated) throw new CliError(`brain procedural-memory mark-used: unknown entry: ${id}`);
 
   if (flags["json"]) {
     process.stdout.write(JSON.stringify(updated, null, 2) + "\n");
     return 0;
   }
 
-  process.stdout.write(
-    `marked used: ${updated.id} count=${updated.usedCount}\n`,
-  );
+  process.stdout.write(`marked used: ${updated.id} count=${updated.usedCount}\n`);
   return 0;
 }
 
-function normalizeRoots(
-  vault: string,
-  raw: string | boolean | string[] | undefined,
-): string[] {
+function normalizeRoots(vault: string, raw: string | boolean | string[] | undefined): string[] {
   if (Array.isArray(raw)) {
-    const roots = raw
-      .map((value) => value.trim())
-      .filter((value) => value.length > 0);
+    const roots = raw.map((value) => value.trim()).filter((value) => value.length > 0);
     if (roots.length > 0) return roots;
   }
-  return [
-    join(vault, "Brain", "procedures"),
-    join(vault, "skills"),
-    join(vault, "runbooks"),
-  ];
+  return [join(vault, "Brain", "procedures"), join(vault, "skills"), join(vault, "runbooks")];
 }
 
 function trim(value: string | undefined): string | undefined {

--- a/src/core/brain/attention-flows.ts
+++ b/src/core/brain/attention-flows.ts
@@ -1,0 +1,179 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { parseFrontmatter, writeFrontmatterAtomic } from "../vault.ts";
+import { attentionFlowsDir } from "./paths.ts";
+import { listProceduralMemory } from "./procedural-memory.ts";
+import { listPendingSkillProposals } from "./skill-proposals.ts";
+import { listRecurrenceEntries } from "./recurrence.ts";
+
+export type AttentionFlowAction =
+  | "open_proposals"
+  | "high_recurrence"
+  | "active_procedures";
+
+export interface AttentionFlowRecipe {
+  readonly id: string;
+  readonly title: string;
+  readonly actions: ReadonlyArray<AttentionFlowAction>;
+  readonly sourcePath: string;
+}
+
+export interface AttentionFlowSection {
+  readonly action: AttentionFlowAction;
+  readonly items: ReadonlyArray<string>;
+}
+
+export interface AttentionFlowEvaluation {
+  readonly flow_id: string;
+  readonly title: string;
+  readonly sections: ReadonlyArray<AttentionFlowSection>;
+}
+
+export function ensureDefaultAttentionFlows(vault: string): void {
+  const dir = attentionFlowsDir(vault);
+  mkdirSync(dir, { recursive: true });
+  const defaultPath = join(dir, "open-loops.md");
+  if (existsSync(defaultPath)) return;
+  writeFrontmatterAtomic(
+    defaultPath,
+    {
+      kind: "brain-attention-flow",
+      id: "open-loops",
+      title: "Open loops and learnings",
+      actions: ["open_proposals", "high_recurrence", "active_procedures"],
+      status: "active",
+    },
+    [
+      "# Open loops and learnings",
+      "",
+      "Declarative flow for context surfaces:",
+      "- open proposals needing review",
+      "- strong recurrence candidates",
+      "- active procedural memory entries",
+    ].join("\n"),
+    {
+      overwrite: false,
+      existsErrorKind: "attention flow",
+      vaultForRelativePath: vault,
+    },
+  );
+}
+
+export function listAttentionFlows(
+  vault: string,
+): ReadonlyArray<AttentionFlowRecipe> {
+  ensureDefaultAttentionFlows(vault);
+  const dir = attentionFlowsDir(vault);
+  if (!existsSync(dir)) return Object.freeze([]);
+  const out: AttentionFlowRecipe[] = [];
+  for (const name of readdirSync(dir).toSorted()) {
+    if (!name.endsWith(".md")) continue;
+    const path = join(dir, name);
+    try {
+      const [fm] = parseFrontmatter(path);
+      if (fm["kind"] !== "brain-attention-flow") continue;
+      const actions = normalizeActions(fm["actions"]);
+      out.push({
+        id: typeof fm["id"] === "string" ? fm["id"] : name.replace(/\.md$/, ""),
+        title:
+          typeof fm["title"] === "string"
+            ? fm["title"]
+            : name.replace(/\.md$/, ""),
+        actions,
+        sourcePath: path,
+      });
+    } catch {
+      continue;
+    }
+  }
+  return Object.freeze(out);
+}
+
+export function evaluateAttentionFlow(
+  vault: string,
+  flowId: string,
+): AttentionFlowEvaluation {
+  const flow = listAttentionFlows(vault).find((item) => item.id === flowId);
+  if (!flow) throw new Error(`attention flow not found: ${flowId}`);
+
+  const sections: AttentionFlowSection[] = [];
+  for (const action of flow.actions) {
+    if (action === "open_proposals") {
+      const items = listPendingSkillProposals(vault).map(
+        (item) => `${item.slug} (${item.patternKind})`,
+      );
+      sections.push({ action, items: Object.freeze(items) });
+      continue;
+    }
+    if (action === "high_recurrence") {
+      const items = listRecurrenceEntries(vault)
+        .filter((entry) => entry.supportCount >= 3)
+        .map((entry) => `${entry.contentHash} (${entry.supportCount})`);
+      sections.push({ action, items: Object.freeze(items) });
+      continue;
+    }
+    if (action === "active_procedures") {
+      const items = listProceduralMemory(vault)
+        .filter((entry) => entry.kind === "procedure" || entry.kind === "skill")
+        .map((entry) => `${entry.title} [${entry.kind}]`);
+      sections.push({ action, items: Object.freeze(items) });
+    }
+  }
+
+  return {
+    flow_id: flow.id,
+    title: flow.title,
+    sections: Object.freeze(sections.map((item) => Object.freeze(item))),
+  };
+}
+
+export function renderAttentionFlow(vault: string, flowId: string): string {
+  const report = evaluateAttentionFlow(vault, flowId);
+  const lines: string[] = [`# ${report.title}`, ""];
+  for (const section of report.sections) {
+    lines.push(`## ${section.action}`);
+    if (section.items.length === 0) {
+      lines.push("- (empty)");
+    } else {
+      for (const item of section.items) lines.push(`- ${item}`);
+    }
+    lines.push("");
+  }
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+function normalizeActions(value: unknown): ReadonlyArray<AttentionFlowAction> {
+  const allowed = new Set<AttentionFlowAction>([
+    "open_proposals",
+    "high_recurrence",
+    "active_procedures",
+  ]);
+  const out: AttentionFlowAction[] = [];
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (typeof item !== "string") continue;
+      const action = item.trim() as AttentionFlowAction;
+      if (allowed.has(action)) out.push(action);
+    }
+  }
+  if (out.length === 0)
+    return Object.freeze(["open_proposals", "high_recurrence"]);
+  return Object.freeze([...new Set(out)]);
+}
+
+export function buildAttentionContextBlock(
+  vault: string,
+  flowIds: ReadonlyArray<string>,
+): string | null {
+  const chunks: string[] = [];
+  for (const id of flowIds) {
+    try {
+      chunks.push(renderAttentionFlow(vault, id));
+    } catch {
+      continue;
+    }
+  }
+  if (chunks.length === 0) return null;
+  return chunks.join("\n");
+}

--- a/src/core/brain/attention-flows.ts
+++ b/src/core/brain/attention-flows.ts
@@ -7,10 +7,7 @@ import { listProceduralMemory } from "./procedural-memory.ts";
 import { listPendingSkillProposals } from "./skill-proposals.ts";
 import { listRecurrenceEntries } from "./recurrence.ts";
 
-export type AttentionFlowAction =
-  | "open_proposals"
-  | "high_recurrence"
-  | "active_procedures";
+export type AttentionFlowAction = "open_proposals" | "high_recurrence" | "active_procedures";
 
 export interface AttentionFlowRecipe {
   readonly id: string;
@@ -60,9 +57,7 @@ export function ensureDefaultAttentionFlows(vault: string): void {
   );
 }
 
-export function listAttentionFlows(
-  vault: string,
-): ReadonlyArray<AttentionFlowRecipe> {
+export function listAttentionFlows(vault: string): ReadonlyArray<AttentionFlowRecipe> {
   ensureDefaultAttentionFlows(vault);
   const dir = attentionFlowsDir(vault);
   if (!existsSync(dir)) return Object.freeze([]);
@@ -76,10 +71,7 @@ export function listAttentionFlows(
       const actions = normalizeActions(fm["actions"]);
       out.push({
         id: typeof fm["id"] === "string" ? fm["id"] : name.replace(/\.md$/, ""),
-        title:
-          typeof fm["title"] === "string"
-            ? fm["title"]
-            : name.replace(/\.md$/, ""),
+        title: typeof fm["title"] === "string" ? fm["title"] : name.replace(/\.md$/, ""),
         actions,
         sourcePath: path,
       });
@@ -90,10 +82,7 @@ export function listAttentionFlows(
   return Object.freeze(out);
 }
 
-export function evaluateAttentionFlow(
-  vault: string,
-  flowId: string,
-): AttentionFlowEvaluation {
+export function evaluateAttentionFlow(vault: string, flowId: string): AttentionFlowEvaluation {
   const flow = listAttentionFlows(vault).find((item) => item.id === flowId);
   if (!flow) throw new Error(`attention flow not found: ${flowId}`);
 
@@ -157,8 +146,7 @@ function normalizeActions(value: unknown): ReadonlyArray<AttentionFlowAction> {
       if (allowed.has(action)) out.push(action);
     }
   }
-  if (out.length === 0)
-    return Object.freeze(["open_proposals", "high_recurrence"]);
+  if (out.length === 0) return Object.freeze(["open_proposals", "high_recurrence"]);
   return Object.freeze([...new Set(out)]);
 }
 

--- a/src/core/brain/context-pack.ts
+++ b/src/core/brain/context-pack.ts
@@ -27,14 +27,8 @@ import { PAGE_TIER, readTier, type PageTier } from "./page-meta/tier.ts";
 import { estimateTokens } from "./text/tokenizer.ts";
 import { normalizeForDedup } from "./text/normalize.ts";
 import { applyCharBudget } from "./recall-budget.ts";
-import {
-  emitContextReceipt,
-  type ContextReceiptOptions,
-} from "./context-receipts.ts";
-import {
-  emitRecallTelemetry,
-  type RecallTelemetryOptions,
-} from "./recall-telemetry.ts";
+import { emitContextReceipt, type ContextReceiptOptions } from "./context-receipts.ts";
+import { emitRecallTelemetry, type RecallTelemetryOptions } from "./recall-telemetry.ts";
 import {
   applyContextTransforms,
   type ContextTransformOptions,
@@ -162,11 +156,9 @@ function collectCandidates(vault: string): Candidate[] {
       } catch {
         continue;
       }
-      const id =
-        typeof meta["id"] === "string" ? meta["id"] : name.replace(/\.md$/, "");
+      const id = typeof meta["id"] === "string" ? meta["id"] : name.replace(/\.md$/, "");
       const tier = readTier(meta);
-      const created =
-        typeof meta["created_at"] === "string" ? meta["created_at"] : "";
+      const created = typeof meta["created_at"] === "string" ? meta["created_at"] : "";
       let fallbackMtimeMs = 0;
       if (!created) {
         try {
@@ -177,8 +169,7 @@ function collectCandidates(vault: string): Candidate[] {
       }
       const createdAtMs = created ? Date.parse(created) : fallbackMtimeMs;
       const topic = typeof meta["topic"] === "string" ? meta["topic"] : "";
-      const principle =
-        typeof meta["principle"] === "string" ? meta["principle"] : "";
+      const principle = typeof meta["principle"] === "string" ? meta["principle"] : "";
       const contextLane = normalizeContextLane(meta["context_lane"]);
       const guarded = guardBrainContextSnippet(body, {
         source: { id, path: full, metadata: meta },
@@ -201,19 +192,14 @@ function collectCandidates(vault: string): Candidate[] {
         contextLane,
         body: guarded.safeText,
         tokens: estimateTokens(guarded.safeText),
-        ...(contextSafetyReport(guarded)
-          ? { safety: contextSafetyReport(guarded) }
-          : {}),
+        ...(contextSafetyReport(guarded) ? { safety: contextSafetyReport(guarded) } : {}),
       });
     }
   }
   return out;
 }
 
-export function packContext(
-  vault: string,
-  opts: ContextPackOptions,
-): ContextPackReport {
+export function packContext(vault: string, opts: ContextPackOptions): ContextPackReport {
   const startedAtMs = Date.now();
   if (!Number.isFinite(opts.maxTokens) || opts.maxTokens <= 0) {
     return finalizeContextPackReport(
@@ -280,10 +266,7 @@ export function packContext(
   }
 
   if (opts.attentionFlowIds && opts.attentionFlowIds.length > 0) {
-    const attentionBody = buildAttentionContextBlock(
-      vault,
-      opts.attentionFlowIds,
-    );
+    const attentionBody = buildAttentionContextBlock(vault, opts.attentionFlowIds);
     if (attentionBody && attentionBody.trim()) {
       const tokens = estimateTokens(attentionBody);
       if (used + tokens <= opts.maxTokens) {
@@ -350,10 +333,7 @@ export function packContext(
   }
 
   const finalItems = applyContextTransforms(items, opts.transforms);
-  const finalTokensUsed = finalItems.reduce(
-    (sum, item) => sum + item.tokens,
-    0,
-  );
+  const finalTokensUsed = finalItems.reduce((sum, item) => sum + item.tokens, 0);
   return finalizeContextPackReport(
     vault,
     opts,
@@ -406,9 +386,7 @@ function finalizeContextPackReport(
       status: report.items.length > 0 ? "ok" : "empty",
       durationMs: Date.now() - startedAtMs,
       resultCount: report.items.length,
-      topArtifacts: report.items
-        .slice(0, 10)
-        .map((item) => ({ id: item.id, path: item.path })),
+      topArtifacts: report.items.slice(0, 10).map((item) => ({ id: item.id, path: item.path })),
       gaps: contextPackGaps(report),
       metadata: {
         ...(opts.telemetry.metadata ?? {}),
@@ -433,17 +411,13 @@ function contextPackBudgetMetadata(
     ...(opts.maxCharsPerMemory !== undefined
       ? { max_chars_per_memory: opts.maxCharsPerMemory }
       : {}),
-    ...(opts.maxTotalChars !== undefined
-      ? { max_total_chars: opts.maxTotalChars }
-      : {}),
+    ...(opts.maxTotalChars !== undefined ? { max_total_chars: opts.maxTotalChars } : {}),
   };
 }
 
 function contextPackGaps(report: ContextPackReport): ReadonlyArray<string> {
   const gaps = new Set<string>();
-  if (report.items.length === 0 && report.skipped.length === 0)
-    gaps.add("no_matching_context");
-  for (const skipped of report.skipped)
-    gaps.add(skipped.reason.replace(/-/g, "_"));
+  if (report.items.length === 0 && report.skipped.length === 0) gaps.add("no_matching_context");
+  for (const skipped of report.skipped) gaps.add(skipped.reason.replace(/-/g, "_"));
   return [...gaps];
 }

--- a/src/core/brain/context-pack.ts
+++ b/src/core/brain/context-pack.ts
@@ -27,8 +27,14 @@ import { PAGE_TIER, readTier, type PageTier } from "./page-meta/tier.ts";
 import { estimateTokens } from "./text/tokenizer.ts";
 import { normalizeForDedup } from "./text/normalize.ts";
 import { applyCharBudget } from "./recall-budget.ts";
-import { emitContextReceipt, type ContextReceiptOptions } from "./context-receipts.ts";
-import { emitRecallTelemetry, type RecallTelemetryOptions } from "./recall-telemetry.ts";
+import {
+  emitContextReceipt,
+  type ContextReceiptOptions,
+} from "./context-receipts.ts";
+import {
+  emitRecallTelemetry,
+  type RecallTelemetryOptions,
+} from "./recall-telemetry.ts";
 import {
   applyContextTransforms,
   type ContextTransformOptions,
@@ -65,7 +71,11 @@ export interface ContextPackItem extends ContextTransformAnnotations {
 export interface ContextPackSkipped {
   readonly id: string;
   readonly tokens: number;
-  readonly reason: "over-budget" | "filter-miss" | "over-char-budget";
+  readonly reason:
+    | "over-budget"
+    | "filter-miss"
+    | "guard-blocked"
+    | "over-char-budget";
 }
 
 export interface ContextPackReport {
@@ -156,9 +166,11 @@ function collectCandidates(vault: string): Candidate[] {
       } catch {
         continue;
       }
-      const id = typeof meta["id"] === "string" ? meta["id"] : name.replace(/\.md$/, "");
+      const id =
+        typeof meta["id"] === "string" ? meta["id"] : name.replace(/\.md$/, "");
       const tier = readTier(meta);
-      const created = typeof meta["created_at"] === "string" ? meta["created_at"] : "";
+      const created =
+        typeof meta["created_at"] === "string" ? meta["created_at"] : "";
       let fallbackMtimeMs = 0;
       if (!created) {
         try {
@@ -169,7 +181,8 @@ function collectCandidates(vault: string): Candidate[] {
       }
       const createdAtMs = created ? Date.parse(created) : fallbackMtimeMs;
       const topic = typeof meta["topic"] === "string" ? meta["topic"] : "";
-      const principle = typeof meta["principle"] === "string" ? meta["principle"] : "";
+      const principle =
+        typeof meta["principle"] === "string" ? meta["principle"] : "";
       const contextLane = normalizeContextLane(meta["context_lane"]);
       const guarded = guardBrainContextSnippet(body, {
         source: { id, path: full, metadata: meta },
@@ -192,14 +205,19 @@ function collectCandidates(vault: string): Candidate[] {
         contextLane,
         body: guarded.safeText,
         tokens: estimateTokens(guarded.safeText),
-        ...(contextSafetyReport(guarded) ? { safety: contextSafetyReport(guarded) } : {}),
+        ...(contextSafetyReport(guarded)
+          ? { safety: contextSafetyReport(guarded) }
+          : {}),
       });
     }
   }
   return out;
 }
 
-export function packContext(vault: string, opts: ContextPackOptions): ContextPackReport {
+export function packContext(
+  vault: string,
+  opts: ContextPackOptions,
+): ContextPackReport {
   const startedAtMs = Date.now();
   if (!Number.isFinite(opts.maxTokens) || opts.maxTokens <= 0) {
     return finalizeContextPackReport(
@@ -266,27 +284,44 @@ export function packContext(vault: string, opts: ContextPackOptions): ContextPac
   }
 
   if (opts.attentionFlowIds && opts.attentionFlowIds.length > 0) {
-    const attentionBody = buildAttentionContextBlock(vault, opts.attentionFlowIds);
+    const attentionBody = buildAttentionContextBlock(
+      vault,
+      opts.attentionFlowIds,
+    );
     if (attentionBody && attentionBody.trim()) {
-      const tokens = estimateTokens(attentionBody);
-      if (used + tokens <= opts.maxTokens) {
-        items.unshift({
-          id: "attention-flows",
-          path: join(vault, "Brain", "attention", "flows"),
-          tier: PAGE_TIER.core,
-          tokens,
-          body: attentionBody,
-          principle: "Declarative attention flow output",
-          contextLane: "directive",
-          trimmed: false,
-        });
-        used += tokens;
-      } else {
+      const guarded = guardBrainContextSnippet(attentionBody, {
+        path: join(vault, "Brain", "attention", "flows"),
+        contextLane: "directive",
+      });
+      if (!guarded.allowed) {
         skipped.push({
           id: "attention-flows",
-          tokens,
-          reason: "over-budget",
+          tokens: estimateTokens(attentionBody),
+          reason: "guard-blocked",
         });
+      } else {
+        const safeAttentionBody = guarded.sanitized;
+        const tokens = estimateTokens(safeAttentionBody);
+        if (used + tokens <= opts.maxTokens) {
+          items.unshift({
+            id: "attention-flows",
+            path: join(vault, "Brain", "attention", "flows"),
+            tier: PAGE_TIER.core,
+            tokens,
+            body: safeAttentionBody,
+            principle: "Declarative attention flow output",
+            contextLane: "directive",
+            trimmed: false,
+            ...(guarded.report ? { safety: guarded.report } : {}),
+          });
+          used += tokens;
+        } else {
+          skipped.push({
+            id: "attention-flows",
+            tokens,
+            reason: "over-budget",
+          });
+        }
       }
     }
   }
@@ -333,7 +368,10 @@ export function packContext(vault: string, opts: ContextPackOptions): ContextPac
   }
 
   const finalItems = applyContextTransforms(items, opts.transforms);
-  const finalTokensUsed = finalItems.reduce((sum, item) => sum + item.tokens, 0);
+  const finalTokensUsed = finalItems.reduce(
+    (sum, item) => sum + item.tokens,
+    0,
+  );
   return finalizeContextPackReport(
     vault,
     opts,
@@ -386,7 +424,9 @@ function finalizeContextPackReport(
       status: report.items.length > 0 ? "ok" : "empty",
       durationMs: Date.now() - startedAtMs,
       resultCount: report.items.length,
-      topArtifacts: report.items.slice(0, 10).map((item) => ({ id: item.id, path: item.path })),
+      topArtifacts: report.items
+        .slice(0, 10)
+        .map((item) => ({ id: item.id, path: item.path })),
       gaps: contextPackGaps(report),
       metadata: {
         ...(opts.telemetry.metadata ?? {}),
@@ -411,13 +451,17 @@ function contextPackBudgetMetadata(
     ...(opts.maxCharsPerMemory !== undefined
       ? { max_chars_per_memory: opts.maxCharsPerMemory }
       : {}),
-    ...(opts.maxTotalChars !== undefined ? { max_total_chars: opts.maxTotalChars } : {}),
+    ...(opts.maxTotalChars !== undefined
+      ? { max_total_chars: opts.maxTotalChars }
+      : {}),
   };
 }
 
 function contextPackGaps(report: ContextPackReport): ReadonlyArray<string> {
   const gaps = new Set<string>();
-  if (report.items.length === 0 && report.skipped.length === 0) gaps.add("no_matching_context");
-  for (const skipped of report.skipped) gaps.add(skipped.reason.replace(/-/g, "_"));
+  if (report.items.length === 0 && report.skipped.length === 0)
+    gaps.add("no_matching_context");
+  for (const skipped of report.skipped)
+    gaps.add(skipped.reason.replace(/-/g, "_"));
   return [...gaps];
 }

--- a/src/core/brain/context-pack.ts
+++ b/src/core/brain/context-pack.ts
@@ -27,8 +27,14 @@ import { PAGE_TIER, readTier, type PageTier } from "./page-meta/tier.ts";
 import { estimateTokens } from "./text/tokenizer.ts";
 import { normalizeForDedup } from "./text/normalize.ts";
 import { applyCharBudget } from "./recall-budget.ts";
-import { emitContextReceipt, type ContextReceiptOptions } from "./context-receipts.ts";
-import { emitRecallTelemetry, type RecallTelemetryOptions } from "./recall-telemetry.ts";
+import {
+  emitContextReceipt,
+  type ContextReceiptOptions,
+} from "./context-receipts.ts";
+import {
+  emitRecallTelemetry,
+  type RecallTelemetryOptions,
+} from "./recall-telemetry.ts";
 import {
   applyContextTransforms,
   type ContextTransformOptions,
@@ -40,6 +46,7 @@ import {
   type ContextLaneName,
   type ContextLanesReport,
 } from "./context-lanes.ts";
+import { buildAttentionContextBlock } from "./attention-flows.ts";
 
 const TIER_ORDER: ReadonlyArray<PageTier> = [
   PAGE_TIER.core,
@@ -102,6 +109,8 @@ export interface ContextPackOptions {
   readonly telemetry?: RecallTelemetryOptions;
   /** Opt-in post-selection context transforms. Defaults preserve legacy order and bodies. */
   readonly transforms?: ContextTransformOptions;
+  /** Optional declarative attention-flow ids to include as a synthetic context item. */
+  readonly attentionFlowIds?: ReadonlyArray<string>;
 }
 
 interface Candidate {
@@ -153,9 +162,11 @@ function collectCandidates(vault: string): Candidate[] {
       } catch {
         continue;
       }
-      const id = typeof meta["id"] === "string" ? meta["id"] : name.replace(/\.md$/, "");
+      const id =
+        typeof meta["id"] === "string" ? meta["id"] : name.replace(/\.md$/, "");
       const tier = readTier(meta);
-      const created = typeof meta["created_at"] === "string" ? meta["created_at"] : "";
+      const created =
+        typeof meta["created_at"] === "string" ? meta["created_at"] : "";
       let fallbackMtimeMs = 0;
       if (!created) {
         try {
@@ -166,7 +177,8 @@ function collectCandidates(vault: string): Candidate[] {
       }
       const createdAtMs = created ? Date.parse(created) : fallbackMtimeMs;
       const topic = typeof meta["topic"] === "string" ? meta["topic"] : "";
-      const principle = typeof meta["principle"] === "string" ? meta["principle"] : "";
+      const principle =
+        typeof meta["principle"] === "string" ? meta["principle"] : "";
       const contextLane = normalizeContextLane(meta["context_lane"]);
       const guarded = guardBrainContextSnippet(body, {
         source: { id, path: full, metadata: meta },
@@ -189,14 +201,19 @@ function collectCandidates(vault: string): Candidate[] {
         contextLane,
         body: guarded.safeText,
         tokens: estimateTokens(guarded.safeText),
-        ...(contextSafetyReport(guarded) ? { safety: contextSafetyReport(guarded) } : {}),
+        ...(contextSafetyReport(guarded)
+          ? { safety: contextSafetyReport(guarded) }
+          : {}),
       });
     }
   }
   return out;
 }
 
-export function packContext(vault: string, opts: ContextPackOptions): ContextPackReport {
+export function packContext(
+  vault: string,
+  opts: ContextPackOptions,
+): ContextPackReport {
   const startedAtMs = Date.now();
   if (!Number.isFinite(opts.maxTokens) || opts.maxTokens <= 0) {
     return finalizeContextPackReport(
@@ -262,6 +279,35 @@ export function packContext(vault: string, opts: ContextPackOptions): ContextPac
     used += tokens;
   }
 
+  if (opts.attentionFlowIds && opts.attentionFlowIds.length > 0) {
+    const attentionBody = buildAttentionContextBlock(
+      vault,
+      opts.attentionFlowIds,
+    );
+    if (attentionBody && attentionBody.trim()) {
+      const tokens = estimateTokens(attentionBody);
+      if (used + tokens <= opts.maxTokens) {
+        items.unshift({
+          id: "attention-flows",
+          path: join(vault, "Brain", "attention", "flows"),
+          tier: PAGE_TIER.core,
+          tokens,
+          body: attentionBody,
+          principle: "Declarative attention flow output",
+          contextLane: "directive",
+          trimmed: false,
+        });
+        used += tokens;
+      } else {
+        skipped.push({
+          id: "attention-flows",
+          tokens,
+          reason: "over-budget",
+        });
+      }
+    }
+  }
+
   // Total recall character cap (v0.20.0): a second ceiling over the
   // token-budgeted set. Applied via the shared primitive on the emitted
   // items only (so query-missed pages never count), dropping the
@@ -304,7 +350,10 @@ export function packContext(vault: string, opts: ContextPackOptions): ContextPac
   }
 
   const finalItems = applyContextTransforms(items, opts.transforms);
-  const finalTokensUsed = finalItems.reduce((sum, item) => sum + item.tokens, 0);
+  const finalTokensUsed = finalItems.reduce(
+    (sum, item) => sum + item.tokens,
+    0,
+  );
   return finalizeContextPackReport(
     vault,
     opts,
@@ -357,7 +406,9 @@ function finalizeContextPackReport(
       status: report.items.length > 0 ? "ok" : "empty",
       durationMs: Date.now() - startedAtMs,
       resultCount: report.items.length,
-      topArtifacts: report.items.slice(0, 10).map((item) => ({ id: item.id, path: item.path })),
+      topArtifacts: report.items
+        .slice(0, 10)
+        .map((item) => ({ id: item.id, path: item.path })),
       gaps: contextPackGaps(report),
       metadata: {
         ...(opts.telemetry.metadata ?? {}),
@@ -382,13 +433,17 @@ function contextPackBudgetMetadata(
     ...(opts.maxCharsPerMemory !== undefined
       ? { max_chars_per_memory: opts.maxCharsPerMemory }
       : {}),
-    ...(opts.maxTotalChars !== undefined ? { max_total_chars: opts.maxTotalChars } : {}),
+    ...(opts.maxTotalChars !== undefined
+      ? { max_total_chars: opts.maxTotalChars }
+      : {}),
   };
 }
 
 function contextPackGaps(report: ContextPackReport): ReadonlyArray<string> {
   const gaps = new Set<string>();
-  if (report.items.length === 0 && report.skipped.length === 0) gaps.add("no_matching_context");
-  for (const skipped of report.skipped) gaps.add(skipped.reason.replace(/-/g, "_"));
+  if (report.items.length === 0 && report.skipped.length === 0)
+    gaps.add("no_matching_context");
+  for (const skipped of report.skipped)
+    gaps.add(skipped.reason.replace(/-/g, "_"));
   return [...gaps];
 }

--- a/src/core/brain/paths.ts
+++ b/src/core/brain/paths.ts
@@ -45,27 +45,12 @@ export const BRAIN_INBOX_REL = posix.join(BRAIN_ROOT_REL, "inbox");
 export const BRAIN_PROCESSED_REL = posix.join(BRAIN_INBOX_REL, "processed");
 export const BRAIN_PREFERENCES_REL = posix.join(BRAIN_ROOT_REL, "preferences");
 export const BRAIN_RETIRED_REL = posix.join(BRAIN_ROOT_REL, "retired");
-export const BRAIN_SKILL_PROPOSALS_REL = posix.join(
-  BRAIN_ROOT_REL,
-  "skill-proposals",
-);
-export const BRAIN_SKILL_PROPOSALS_PENDING_REL = posix.join(
-  BRAIN_SKILL_PROPOSALS_REL,
-  "pending",
-);
-export const BRAIN_SKILL_PROPOSALS_ACCEPTED_REL = posix.join(
-  BRAIN_SKILL_PROPOSALS_REL,
-  "accepted",
-);
-export const BRAIN_SKILL_PROPOSALS_REJECTED_REL = posix.join(
-  BRAIN_SKILL_PROPOSALS_REL,
-  "rejected",
-);
+export const BRAIN_SKILL_PROPOSALS_REL = posix.join(BRAIN_ROOT_REL, "skill-proposals");
+export const BRAIN_SKILL_PROPOSALS_PENDING_REL = posix.join(BRAIN_SKILL_PROPOSALS_REL, "pending");
+export const BRAIN_SKILL_PROPOSALS_ACCEPTED_REL = posix.join(BRAIN_SKILL_PROPOSALS_REL, "accepted");
+export const BRAIN_SKILL_PROPOSALS_REJECTED_REL = posix.join(BRAIN_SKILL_PROPOSALS_REL, "rejected");
 export const BRAIN_PROCEDURES_REL = posix.join(BRAIN_ROOT_REL, "procedures");
-export const BRAIN_PROCEDURAL_MEMORY_REL = posix.join(
-  BRAIN_ROOT_REL,
-  "procedural-memory",
-);
+export const BRAIN_PROCEDURAL_MEMORY_REL = posix.join(BRAIN_ROOT_REL, "procedural-memory");
 export const BRAIN_ATTENTION_REL = posix.join(BRAIN_ROOT_REL, "attention");
 export const BRAIN_LOG_REL = posix.join(BRAIN_ROOT_REL, "log");
 export const BRAIN_SNAPSHOTS_REL = posix.join(BRAIN_ROOT_REL, ".snapshots");
@@ -93,8 +78,7 @@ const ISO_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
 // shape check for the date-time stem.
 const RUN_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 
-const WINDOWS_RESERVED_BASENAME_RE =
-  /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$/i;
+const WINDOWS_RESERVED_BASENAME_RE = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$/i;
 
 export interface BrainDirs {
   readonly brain: string;
@@ -128,18 +112,12 @@ export function brainDirs(vault: string): BrainDirs {
 
 /** Path of `Brain/_brain.yaml`. */
 export function brainConfigPath(vault: string): string {
-  return ensureInsideVault(
-    join(brainDirs(vault).brain, BRAIN_CONFIG_FILE),
-    vault,
-  );
+  return ensureInsideVault(join(brainDirs(vault).brain, BRAIN_CONFIG_FILE), vault);
 }
 
 /** Path of the Brain operating manual rendered into the vault. */
 export function brainManualPath(vault: string): string {
-  return ensureInsideVault(
-    join(brainDirs(vault).brain, BRAIN_MANUAL_FILE),
-    vault,
-  );
+  return ensureInsideVault(join(brainDirs(vault).brain, BRAIN_MANUAL_FILE), vault);
 }
 
 /**
@@ -149,51 +127,32 @@ export function brainManualPath(vault: string): string {
  * `osb://preferences/active`.
  */
 export function brainActivePath(vault: string): string {
-  return ensureInsideVault(
-    join(brainDirs(vault).brain, BRAIN_ACTIVE_FILE),
-    vault,
-  );
+  return ensureInsideVault(join(brainDirs(vault).brain, BRAIN_ACTIVE_FILE), vault);
 }
 
 /** Path of the transient current-task scratchpad read by `brain_context`. */
 export function brainPinnedPath(vault: string): string {
-  return ensureInsideVault(
-    join(brainDirs(vault).brain, BRAIN_PINNED_FILE),
-    vault,
-  );
+  return ensureInsideVault(join(brainDirs(vault).brain, BRAIN_PINNED_FILE), vault);
 }
 
 /** Active-signal path: `Brain/inbox/sig-<date>-<slug>.md`. */
 export function signalPath(vault: string, date: string, slug: string): string {
   const d = validateIsoDate(date);
   const s = validateSlug(slug);
-  return ensureInsideVault(
-    join(brainDirs(vault).inbox, `sig-${d}-${s}.md`),
-    vault,
-  );
+  return ensureInsideVault(join(brainDirs(vault).inbox, `sig-${d}-${s}.md`), vault);
 }
 
 /** Processed-signal path: `Brain/inbox/processed/sig-<date>-<slug>.md`. */
-export function processedSignalPath(
-  vault: string,
-  date: string,
-  slug: string,
-): string {
+export function processedSignalPath(vault: string, date: string, slug: string): string {
   const d = validateIsoDate(date);
   const s = validateSlug(slug);
-  return ensureInsideVault(
-    join(brainDirs(vault).processed, `sig-${d}-${s}.md`),
-    vault,
-  );
+  return ensureInsideVault(join(brainDirs(vault).processed, `sig-${d}-${s}.md`), vault);
 }
 
 /** Preference path: `Brain/preferences/pref-<slug>.md`. */
 export function preferencePath(vault: string, slug: string): string {
   const s = validateSlug(slug);
-  return ensureInsideVault(
-    join(brainDirs(vault).preferences, `pref-${s}.md`),
-    vault,
-  );
+  return ensureInsideVault(join(brainDirs(vault).preferences, `pref-${s}.md`), vault);
 }
 
 /**
@@ -203,87 +162,57 @@ export function preferencePath(vault: string, slug: string): string {
  */
 export function preferenceHistoryPath(vault: string, slug: string): string {
   const s = validateSlug(slug);
-  return ensureInsideVault(
-    join(brainDirs(vault).preferences, `pref-${s}.history.jsonl`),
-    vault,
-  );
+  return ensureInsideVault(join(brainDirs(vault).preferences, `pref-${s}.history.jsonl`), vault);
 }
 
 /** Retired-preference path: `Brain/retired/ret-<slug>.md`. */
 export function retiredPath(vault: string, slug: string): string {
   const s = validateSlug(slug);
-  return ensureInsideVault(
-    join(brainDirs(vault).retired, `ret-${s}.md`),
-    vault,
-  );
+  return ensureInsideVault(join(brainDirs(vault).retired, `ret-${s}.md`), vault);
 }
 
 /** Pending skill-proposal path: `Brain/skill-proposals/pending/prop-<slug>.md`. */
 export function skillProposalPendingPath(vault: string, slug: string): string {
   const s = validateSlug(slug);
-  return ensureInsideVault(
-    join(vault, BRAIN_SKILL_PROPOSALS_PENDING_REL, `prop-${s}.md`),
-    vault,
-  );
+  return ensureInsideVault(join(vault, BRAIN_SKILL_PROPOSALS_PENDING_REL, `prop-${s}.md`), vault);
 }
 
 /** Accepted skill-proposal archive path: `Brain/skill-proposals/accepted/prop-<slug>.md`. */
 export function skillProposalAcceptedPath(vault: string, slug: string): string {
   const s = validateSlug(slug);
-  return ensureInsideVault(
-    join(vault, BRAIN_SKILL_PROPOSALS_ACCEPTED_REL, `prop-${s}.md`),
-    vault,
-  );
+  return ensureInsideVault(join(vault, BRAIN_SKILL_PROPOSALS_ACCEPTED_REL, `prop-${s}.md`), vault);
 }
 
 /** Rejected skill-proposal archive path: `Brain/skill-proposals/rejected/prop-<slug>.md`. */
 export function skillProposalRejectedPath(vault: string, slug: string): string {
   const s = validateSlug(slug);
-  return ensureInsideVault(
-    join(vault, BRAIN_SKILL_PROPOSALS_REJECTED_REL, `prop-${s}.md`),
-    vault,
-  );
+  return ensureInsideVault(join(vault, BRAIN_SKILL_PROPOSALS_REJECTED_REL, `prop-${s}.md`), vault);
 }
 
 /** Accepted procedure reference path: `Brain/procedures/proc-<slug>.md`. */
 export function procedurePath(vault: string, slug: string): string {
   const s = validateSlug(slug);
-  return ensureInsideVault(
-    join(vault, BRAIN_PROCEDURES_REL, `proc-${s}.md`),
-    vault,
-  );
+  return ensureInsideVault(join(vault, BRAIN_PROCEDURES_REL, `proc-${s}.md`), vault);
 }
 
 /** Procedural-memory index path: `Brain/procedural-memory/index.json`. */
 export function proceduralMemoryIndexPath(vault: string): string {
-  return ensureInsideVault(
-    join(vault, BRAIN_PROCEDURAL_MEMORY_REL, "index.json"),
-    vault,
-  );
+  return ensureInsideVault(join(vault, BRAIN_PROCEDURAL_MEMORY_REL, "index.json"), vault);
 }
 
 /** Procedural-memory usage sidecar path: `Brain/procedural-memory/usage.jsonl`. */
 export function proceduralMemoryUsagePath(vault: string): string {
-  return ensureInsideVault(
-    join(vault, BRAIN_PROCEDURAL_MEMORY_REL, "usage.jsonl"),
-    vault,
-  );
+  return ensureInsideVault(join(vault, BRAIN_PROCEDURAL_MEMORY_REL, "usage.jsonl"), vault);
 }
 
 /** Procedural graph projection path: `Brain/procedural-memory/graph.json`. */
 export function proceduralGraphPath(vault: string): string {
-  return ensureInsideVault(
-    join(vault, BRAIN_PROCEDURAL_MEMORY_REL, "graph.json"),
-    vault,
-  );
+  return ensureInsideVault(join(vault, BRAIN_PROCEDURAL_MEMORY_REL, "graph.json"), vault);
 }
 
 /** Prospective recall hints path: `Brain/procedural-memory/hints.json`. */
 export function proceduralHintsPath(vault: string): string {
-  return ensureInsideVault(
-    join(vault, BRAIN_PROCEDURAL_MEMORY_REL, "hints.json"),
-    vault,
-  );
+  return ensureInsideVault(join(vault, BRAIN_PROCEDURAL_MEMORY_REL, "hints.json"), vault);
 }
 
 /** Declarative attention-flows directory: `Brain/attention/flows/`. */
@@ -301,10 +230,7 @@ export function proposalWatermarkPath(vault: string): string {
 
 /** Recurrence support ledger path: `Brain/log/recurrence-support.jsonl`. */
 export function proceduralRecurrencePath(vault: string): string {
-  return ensureInsideVault(
-    join(vault, BRAIN_LOG_REL, "recurrence-support.jsonl"),
-    vault,
-  );
+  return ensureInsideVault(join(vault, BRAIN_LOG_REL, "recurrence-support.jsonl"), vault);
 }
 
 /** Log file for the given UTC date: `Brain/log/<YYYY-MM-DD>.md`. */
@@ -373,10 +299,7 @@ export function snapshotsDir(vault: string): string {
 /** Snapshot archive path: `Brain/.snapshots/<run_id>.tar.zst`. */
 export function snapshotPath(vault: string, runId: string): string {
   const id = validateRunId(runId);
-  return ensureInsideVault(
-    join(brainDirs(vault).snapshots, `${id}.tar.zst`),
-    vault,
-  );
+  return ensureInsideVault(join(brainDirs(vault).snapshots, `${id}.tar.zst`), vault);
 }
 
 /** Artifacts root: `Brain/.artifacts/`. */
@@ -396,16 +319,9 @@ export function artifactRunDir(vault: string, runId: string): string {
  * contract: no separators, no traversal, no Windows reservation), so a
  * malicious `artifact_id` from an MCP argument cannot escape the run dir.
  */
-export function artifactPath(
-  vault: string,
-  runId: string,
-  artifactId: string,
-): string {
+export function artifactPath(vault: string, runId: string, artifactId: string): string {
   const aid = validateRunId(artifactId);
-  return ensureInsideVault(
-    join(artifactRunDir(vault, runId), `${aid}.json`),
-    vault,
-  );
+  return ensureInsideVault(join(artifactRunDir(vault, runId), `${aid}.json`), vault);
 }
 
 // ----- Validators -----------------------------------------------------------
@@ -429,17 +345,11 @@ export function validateSlug(slug: string): string {
   if (/[:*?"<>|\x00-\x1F]/.test(trimmed)) {
     throw new Error(`slug contains invalid character: ${JSON.stringify(slug)}`);
   }
-  if (
-    trimmed === ".." ||
-    trimmed === "." ||
-    /(?:^|[^\w])\.\.(?:$|[^\w])/.test(trimmed)
-  ) {
+  if (trimmed === ".." || trimmed === "." || /(?:^|[^\w])\.\.(?:$|[^\w])/.test(trimmed)) {
     throw new Error(`slug must not contain '..' traversal: ${slug}`);
   }
   if (/[. ]$/.test(trimmed)) {
-    throw new Error(
-      `slug must not end with '.' or whitespace (Windows-incompatible): ${slug}`,
-    );
+    throw new Error(`slug must not end with '.' or whitespace (Windows-incompatible): ${slug}`);
   }
   if (WINDOWS_RESERVED_BASENAME_RE.test(trimmed)) {
     throw new Error(`slug uses a Windows-reserved filename: ${slug}`);
@@ -478,18 +388,10 @@ export function validateRunId(runId: string): string {
   const trimmed = runId.trim();
   if (!trimmed) throw new Error("run_id must not be empty");
   if (!RUN_ID_RE.test(trimmed)) {
-    throw new Error(
-      `run_id must match /^[A-Za-z0-9][A-Za-z0-9._-]*$/: ${runId}`,
-    );
+    throw new Error(`run_id must match /^[A-Za-z0-9][A-Za-z0-9._-]*$/: ${runId}`);
   }
-  if (
-    trimmed.includes("..") ||
-    trimmed.includes("/") ||
-    trimmed.includes("\\")
-  ) {
-    throw new Error(
-      `run_id must not contain '..' or path separators: ${runId}`,
-    );
+  if (trimmed.includes("..") || trimmed.includes("/") || trimmed.includes("\\")) {
+    throw new Error(`run_id must not contain '..' or path separators: ${runId}`);
   }
   if (WINDOWS_RESERVED_BASENAME_RE.test(trimmed)) {
     throw new Error(`run_id uses a Windows-reserved filename: ${runId}`);
@@ -543,9 +445,7 @@ export function allocateSlug(opts: AllocateSlugOptions): AllocateSlugResult {
   const maxAttempts = opts.maxAttempts ?? 10_000;
 
   if (!prefix || /[\\/]/.test(prefix)) {
-    throw new Error(
-      `allocateSlug: prefix must be non-empty and path-clean: ${prefix}`,
-    );
+    throw new Error(`allocateSlug: prefix must be non-empty and path-clean: ${prefix}`);
   }
 
   // The first candidate is the bare slug. Subsequent attempts append
@@ -555,10 +455,7 @@ export function allocateSlug(opts: AllocateSlugOptions): AllocateSlugResult {
   // test); the realistic worst case is a handful.
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     const slug = attempt === 1 ? baseSlug : `${baseSlug}-${attempt}`;
-    const candidate = ensureInsideVault(
-      join(targetDir, `${prefix}-${slug}.md`),
-      vault,
-    );
+    const candidate = ensureInsideVault(join(targetDir, `${prefix}-${slug}.md`), vault);
     if (!existsSync(candidate)) {
       return { slug, path: candidate, suffix: attempt === 1 ? null : attempt };
     }

--- a/src/core/brain/paths.ts
+++ b/src/core/brain/paths.ts
@@ -45,12 +45,28 @@ export const BRAIN_INBOX_REL = posix.join(BRAIN_ROOT_REL, "inbox");
 export const BRAIN_PROCESSED_REL = posix.join(BRAIN_INBOX_REL, "processed");
 export const BRAIN_PREFERENCES_REL = posix.join(BRAIN_ROOT_REL, "preferences");
 export const BRAIN_RETIRED_REL = posix.join(BRAIN_ROOT_REL, "retired");
-export const BRAIN_SKILL_PROPOSALS_REL = posix.join(BRAIN_ROOT_REL, "skill-proposals");
-export const BRAIN_SKILL_PROPOSALS_PENDING_REL = posix.join(BRAIN_SKILL_PROPOSALS_REL, "pending");
-export const BRAIN_SKILL_PROPOSALS_ACCEPTED_REL = posix.join(BRAIN_SKILL_PROPOSALS_REL, "accepted");
-export const BRAIN_SKILL_PROPOSALS_REJECTED_REL = posix.join(BRAIN_SKILL_PROPOSALS_REL, "rejected");
+export const BRAIN_SKILL_PROPOSALS_REL = posix.join(
+  BRAIN_ROOT_REL,
+  "skill-proposals",
+);
+export const BRAIN_SKILL_PROPOSALS_PENDING_REL = posix.join(
+  BRAIN_SKILL_PROPOSALS_REL,
+  "pending",
+);
+export const BRAIN_SKILL_PROPOSALS_ACCEPTED_REL = posix.join(
+  BRAIN_SKILL_PROPOSALS_REL,
+  "accepted",
+);
+export const BRAIN_SKILL_PROPOSALS_REJECTED_REL = posix.join(
+  BRAIN_SKILL_PROPOSALS_REL,
+  "rejected",
+);
 export const BRAIN_PROCEDURES_REL = posix.join(BRAIN_ROOT_REL, "procedures");
-export const BRAIN_PROCEDURAL_MEMORY_REL = posix.join(BRAIN_ROOT_REL, "procedural-memory");
+export const BRAIN_PROCEDURAL_MEMORY_REL = posix.join(
+  BRAIN_ROOT_REL,
+  "procedural-memory",
+);
+export const BRAIN_ATTENTION_REL = posix.join(BRAIN_ROOT_REL, "attention");
 export const BRAIN_LOG_REL = posix.join(BRAIN_ROOT_REL, "log");
 export const BRAIN_SNAPSHOTS_REL = posix.join(BRAIN_ROOT_REL, ".snapshots");
 /**
@@ -77,7 +93,8 @@ const ISO_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
 // shape check for the date-time stem.
 const RUN_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 
-const WINDOWS_RESERVED_BASENAME_RE = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$/i;
+const WINDOWS_RESERVED_BASENAME_RE =
+  /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$/i;
 
 export interface BrainDirs {
   readonly brain: string;
@@ -111,12 +128,18 @@ export function brainDirs(vault: string): BrainDirs {
 
 /** Path of `Brain/_brain.yaml`. */
 export function brainConfigPath(vault: string): string {
-  return ensureInsideVault(join(brainDirs(vault).brain, BRAIN_CONFIG_FILE), vault);
+  return ensureInsideVault(
+    join(brainDirs(vault).brain, BRAIN_CONFIG_FILE),
+    vault,
+  );
 }
 
 /** Path of the Brain operating manual rendered into the vault. */
 export function brainManualPath(vault: string): string {
-  return ensureInsideVault(join(brainDirs(vault).brain, BRAIN_MANUAL_FILE), vault);
+  return ensureInsideVault(
+    join(brainDirs(vault).brain, BRAIN_MANUAL_FILE),
+    vault,
+  );
 }
 
 /**
@@ -126,32 +149,51 @@ export function brainManualPath(vault: string): string {
  * `osb://preferences/active`.
  */
 export function brainActivePath(vault: string): string {
-  return ensureInsideVault(join(brainDirs(vault).brain, BRAIN_ACTIVE_FILE), vault);
+  return ensureInsideVault(
+    join(brainDirs(vault).brain, BRAIN_ACTIVE_FILE),
+    vault,
+  );
 }
 
 /** Path of the transient current-task scratchpad read by `brain_context`. */
 export function brainPinnedPath(vault: string): string {
-  return ensureInsideVault(join(brainDirs(vault).brain, BRAIN_PINNED_FILE), vault);
+  return ensureInsideVault(
+    join(brainDirs(vault).brain, BRAIN_PINNED_FILE),
+    vault,
+  );
 }
 
 /** Active-signal path: `Brain/inbox/sig-<date>-<slug>.md`. */
 export function signalPath(vault: string, date: string, slug: string): string {
   const d = validateIsoDate(date);
   const s = validateSlug(slug);
-  return ensureInsideVault(join(brainDirs(vault).inbox, `sig-${d}-${s}.md`), vault);
+  return ensureInsideVault(
+    join(brainDirs(vault).inbox, `sig-${d}-${s}.md`),
+    vault,
+  );
 }
 
 /** Processed-signal path: `Brain/inbox/processed/sig-<date>-<slug>.md`. */
-export function processedSignalPath(vault: string, date: string, slug: string): string {
+export function processedSignalPath(
+  vault: string,
+  date: string,
+  slug: string,
+): string {
   const d = validateIsoDate(date);
   const s = validateSlug(slug);
-  return ensureInsideVault(join(brainDirs(vault).processed, `sig-${d}-${s}.md`), vault);
+  return ensureInsideVault(
+    join(brainDirs(vault).processed, `sig-${d}-${s}.md`),
+    vault,
+  );
 }
 
 /** Preference path: `Brain/preferences/pref-<slug>.md`. */
 export function preferencePath(vault: string, slug: string): string {
   const s = validateSlug(slug);
-  return ensureInsideVault(join(brainDirs(vault).preferences, `pref-${s}.md`), vault);
+  return ensureInsideVault(
+    join(brainDirs(vault).preferences, `pref-${s}.md`),
+    vault,
+  );
 }
 
 /**
@@ -161,47 +203,92 @@ export function preferencePath(vault: string, slug: string): string {
  */
 export function preferenceHistoryPath(vault: string, slug: string): string {
   const s = validateSlug(slug);
-  return ensureInsideVault(join(brainDirs(vault).preferences, `pref-${s}.history.jsonl`), vault);
+  return ensureInsideVault(
+    join(brainDirs(vault).preferences, `pref-${s}.history.jsonl`),
+    vault,
+  );
 }
 
 /** Retired-preference path: `Brain/retired/ret-<slug>.md`. */
 export function retiredPath(vault: string, slug: string): string {
   const s = validateSlug(slug);
-  return ensureInsideVault(join(brainDirs(vault).retired, `ret-${s}.md`), vault);
+  return ensureInsideVault(
+    join(brainDirs(vault).retired, `ret-${s}.md`),
+    vault,
+  );
 }
 
 /** Pending skill-proposal path: `Brain/skill-proposals/pending/prop-<slug>.md`. */
 export function skillProposalPendingPath(vault: string, slug: string): string {
   const s = validateSlug(slug);
-  return ensureInsideVault(join(vault, BRAIN_SKILL_PROPOSALS_PENDING_REL, `prop-${s}.md`), vault);
+  return ensureInsideVault(
+    join(vault, BRAIN_SKILL_PROPOSALS_PENDING_REL, `prop-${s}.md`),
+    vault,
+  );
 }
 
 /** Accepted skill-proposal archive path: `Brain/skill-proposals/accepted/prop-<slug>.md`. */
 export function skillProposalAcceptedPath(vault: string, slug: string): string {
   const s = validateSlug(slug);
-  return ensureInsideVault(join(vault, BRAIN_SKILL_PROPOSALS_ACCEPTED_REL, `prop-${s}.md`), vault);
+  return ensureInsideVault(
+    join(vault, BRAIN_SKILL_PROPOSALS_ACCEPTED_REL, `prop-${s}.md`),
+    vault,
+  );
 }
 
 /** Rejected skill-proposal archive path: `Brain/skill-proposals/rejected/prop-<slug>.md`. */
 export function skillProposalRejectedPath(vault: string, slug: string): string {
   const s = validateSlug(slug);
-  return ensureInsideVault(join(vault, BRAIN_SKILL_PROPOSALS_REJECTED_REL, `prop-${s}.md`), vault);
+  return ensureInsideVault(
+    join(vault, BRAIN_SKILL_PROPOSALS_REJECTED_REL, `prop-${s}.md`),
+    vault,
+  );
 }
 
 /** Accepted procedure reference path: `Brain/procedures/proc-<slug>.md`. */
 export function procedurePath(vault: string, slug: string): string {
   const s = validateSlug(slug);
-  return ensureInsideVault(join(vault, BRAIN_PROCEDURES_REL, `proc-${s}.md`), vault);
+  return ensureInsideVault(
+    join(vault, BRAIN_PROCEDURES_REL, `proc-${s}.md`),
+    vault,
+  );
 }
 
 /** Procedural-memory index path: `Brain/procedural-memory/index.json`. */
 export function proceduralMemoryIndexPath(vault: string): string {
-  return ensureInsideVault(join(vault, BRAIN_PROCEDURAL_MEMORY_REL, "index.json"), vault);
+  return ensureInsideVault(
+    join(vault, BRAIN_PROCEDURAL_MEMORY_REL, "index.json"),
+    vault,
+  );
 }
 
 /** Procedural-memory usage sidecar path: `Brain/procedural-memory/usage.jsonl`. */
 export function proceduralMemoryUsagePath(vault: string): string {
-  return ensureInsideVault(join(vault, BRAIN_PROCEDURAL_MEMORY_REL, "usage.jsonl"), vault);
+  return ensureInsideVault(
+    join(vault, BRAIN_PROCEDURAL_MEMORY_REL, "usage.jsonl"),
+    vault,
+  );
+}
+
+/** Procedural graph projection path: `Brain/procedural-memory/graph.json`. */
+export function proceduralGraphPath(vault: string): string {
+  return ensureInsideVault(
+    join(vault, BRAIN_PROCEDURAL_MEMORY_REL, "graph.json"),
+    vault,
+  );
+}
+
+/** Prospective recall hints path: `Brain/procedural-memory/hints.json`. */
+export function proceduralHintsPath(vault: string): string {
+  return ensureInsideVault(
+    join(vault, BRAIN_PROCEDURAL_MEMORY_REL, "hints.json"),
+    vault,
+  );
+}
+
+/** Declarative attention-flows directory: `Brain/attention/flows/`. */
+export function attentionFlowsDir(vault: string): string {
+  return ensureInsideVault(join(vault, BRAIN_ATTENTION_REL, "flows"), vault);
 }
 
 /** Proposal scan watermark path: `Brain/procedural-memory/proposal-watermark.json`. */
@@ -214,7 +301,10 @@ export function proposalWatermarkPath(vault: string): string {
 
 /** Recurrence support ledger path: `Brain/log/recurrence-support.jsonl`. */
 export function proceduralRecurrencePath(vault: string): string {
-  return ensureInsideVault(join(vault, BRAIN_LOG_REL, "recurrence-support.jsonl"), vault);
+  return ensureInsideVault(
+    join(vault, BRAIN_LOG_REL, "recurrence-support.jsonl"),
+    vault,
+  );
 }
 
 /** Log file for the given UTC date: `Brain/log/<YYYY-MM-DD>.md`. */
@@ -283,7 +373,10 @@ export function snapshotsDir(vault: string): string {
 /** Snapshot archive path: `Brain/.snapshots/<run_id>.tar.zst`. */
 export function snapshotPath(vault: string, runId: string): string {
   const id = validateRunId(runId);
-  return ensureInsideVault(join(brainDirs(vault).snapshots, `${id}.tar.zst`), vault);
+  return ensureInsideVault(
+    join(brainDirs(vault).snapshots, `${id}.tar.zst`),
+    vault,
+  );
 }
 
 /** Artifacts root: `Brain/.artifacts/`. */
@@ -303,9 +396,16 @@ export function artifactRunDir(vault: string, runId: string): string {
  * contract: no separators, no traversal, no Windows reservation), so a
  * malicious `artifact_id` from an MCP argument cannot escape the run dir.
  */
-export function artifactPath(vault: string, runId: string, artifactId: string): string {
+export function artifactPath(
+  vault: string,
+  runId: string,
+  artifactId: string,
+): string {
   const aid = validateRunId(artifactId);
-  return ensureInsideVault(join(artifactRunDir(vault, runId), `${aid}.json`), vault);
+  return ensureInsideVault(
+    join(artifactRunDir(vault, runId), `${aid}.json`),
+    vault,
+  );
 }
 
 // ----- Validators -----------------------------------------------------------
@@ -329,11 +429,17 @@ export function validateSlug(slug: string): string {
   if (/[:*?"<>|\x00-\x1F]/.test(trimmed)) {
     throw new Error(`slug contains invalid character: ${JSON.stringify(slug)}`);
   }
-  if (trimmed === ".." || trimmed === "." || /(?:^|[^\w])\.\.(?:$|[^\w])/.test(trimmed)) {
+  if (
+    trimmed === ".." ||
+    trimmed === "." ||
+    /(?:^|[^\w])\.\.(?:$|[^\w])/.test(trimmed)
+  ) {
     throw new Error(`slug must not contain '..' traversal: ${slug}`);
   }
   if (/[. ]$/.test(trimmed)) {
-    throw new Error(`slug must not end with '.' or whitespace (Windows-incompatible): ${slug}`);
+    throw new Error(
+      `slug must not end with '.' or whitespace (Windows-incompatible): ${slug}`,
+    );
   }
   if (WINDOWS_RESERVED_BASENAME_RE.test(trimmed)) {
     throw new Error(`slug uses a Windows-reserved filename: ${slug}`);
@@ -372,10 +478,18 @@ export function validateRunId(runId: string): string {
   const trimmed = runId.trim();
   if (!trimmed) throw new Error("run_id must not be empty");
   if (!RUN_ID_RE.test(trimmed)) {
-    throw new Error(`run_id must match /^[A-Za-z0-9][A-Za-z0-9._-]*$/: ${runId}`);
+    throw new Error(
+      `run_id must match /^[A-Za-z0-9][A-Za-z0-9._-]*$/: ${runId}`,
+    );
   }
-  if (trimmed.includes("..") || trimmed.includes("/") || trimmed.includes("\\")) {
-    throw new Error(`run_id must not contain '..' or path separators: ${runId}`);
+  if (
+    trimmed.includes("..") ||
+    trimmed.includes("/") ||
+    trimmed.includes("\\")
+  ) {
+    throw new Error(
+      `run_id must not contain '..' or path separators: ${runId}`,
+    );
   }
   if (WINDOWS_RESERVED_BASENAME_RE.test(trimmed)) {
     throw new Error(`run_id uses a Windows-reserved filename: ${runId}`);
@@ -429,7 +543,9 @@ export function allocateSlug(opts: AllocateSlugOptions): AllocateSlugResult {
   const maxAttempts = opts.maxAttempts ?? 10_000;
 
   if (!prefix || /[\\/]/.test(prefix)) {
-    throw new Error(`allocateSlug: prefix must be non-empty and path-clean: ${prefix}`);
+    throw new Error(
+      `allocateSlug: prefix must be non-empty and path-clean: ${prefix}`,
+    );
   }
 
   // The first candidate is the bare slug. Subsequent attempts append
@@ -439,7 +555,10 @@ export function allocateSlug(opts: AllocateSlugOptions): AllocateSlugResult {
   // test); the realistic worst case is a handful.
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     const slug = attempt === 1 ? baseSlug : `${baseSlug}-${attempt}`;
-    const candidate = ensureInsideVault(join(targetDir, `${prefix}-${slug}.md`), vault);
+    const candidate = ensureInsideVault(
+      join(targetDir, `${prefix}-${slug}.md`),
+      vault,
+    );
     if (!existsSync(candidate)) {
       return { slug, path: candidate, suffix: attempt === 1 ? null : attempt };
     }

--- a/src/core/brain/procedural-graph.ts
+++ b/src/core/brain/procedural-graph.ts
@@ -12,12 +12,7 @@ import {
 } from "./paths.ts";
 import type { ProceduralMemoryEntry } from "./procedural-memory.ts";
 
-export type ProceduralGraphNodeKind =
-  | "procedure"
-  | "skill"
-  | "runbook"
-  | "proposal"
-  | "entity";
+export type ProceduralGraphNodeKind = "procedure" | "skill" | "runbook" | "proposal" | "entity";
 export type ProceduralGraphEdgeKind =
   | "derived_from_proposal"
   | "trigger_matches"
@@ -146,18 +141,13 @@ export function rebuildProceduralGraph(
   return projection;
 }
 
-export function readProceduralGraph(
-  vault: string,
-): ProceduralGraphProjection | null {
+export function readProceduralGraph(vault: string): ProceduralGraphProjection | null {
   const path = proceduralGraphPath(vault);
   if (!existsSync(path)) return null;
   try {
-    const parsed = JSON.parse(
-      readFileSync(path, "utf8"),
-    ) as ProceduralGraphProjection;
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as ProceduralGraphProjection;
     if (parsed.schema_version !== 1) return null;
-    if (!Array.isArray(parsed.nodes) || !Array.isArray(parsed.edges))
-      return null;
+    if (!Array.isArray(parsed.nodes) || !Array.isArray(parsed.edges)) return null;
     return parsed;
   } catch {
     return null;
@@ -180,21 +170,13 @@ function readProceduralIndex(vault: string): ProceduralMemoryEntry[] {
   }
 }
 
-function detectProcedureSourceProposal(
-  vault: string,
-  sourcePath: string,
-): string | null {
+function detectProcedureSourceProposal(vault: string, sourcePath: string): string | null {
   if (!sourcePath.startsWith("Brain/procedures/")) return null;
-  const absPath = sourcePath.startsWith("/")
-    ? sourcePath
-    : `${vault}/${sourcePath}`;
+  const absPath = sourcePath.startsWith("/") ? sourcePath : `${vault}/${sourcePath}`;
   if (!existsSync(absPath)) return null;
   try {
     const [fm] = parseFrontmatter(absPath);
-    if (
-      typeof fm["source_proposal"] === "string" &&
-      fm["source_proposal"].trim()
-    ) {
+    if (typeof fm["source_proposal"] === "string" && fm["source_proposal"].trim()) {
       return fm["source_proposal"].trim();
     }
     return null;
@@ -219,10 +201,7 @@ function listProposals(vault: string): ProceduralGraphNode[] {
       try {
         const [fm] = parseFrontmatter(absPath);
         if (fm["kind"] !== "brain-skill-proposal") continue;
-        const id =
-          typeof fm["id"] === "string"
-            ? fm["id"]
-            : `proposal-${basename(name, ".md")}`;
+        const id = typeof fm["id"] === "string" ? fm["id"] : `proposal-${basename(name, ".md")}`;
         out.push({
           id,
           kind: "proposal",
@@ -284,9 +263,7 @@ function entityNodeId(raw: string): string {
     .replace(/^-+|-+$/g, "")}`;
 }
 
-function dedupeEdges(
-  edges: ReadonlyArray<ProceduralGraphEdge>,
-): ProceduralGraphEdge[] {
+function dedupeEdges(edges: ReadonlyArray<ProceduralGraphEdge>): ProceduralGraphEdge[] {
   const out: ProceduralGraphEdge[] = [];
   const seen = new Set<string>();
   for (const edge of edges) {

--- a/src/core/brain/procedural-graph.ts
+++ b/src/core/brain/procedural-graph.ts
@@ -1,0 +1,299 @@
+import { existsSync, mkdirSync, readFileSync, readdirSync } from "node:fs";
+import { basename, dirname } from "node:path";
+
+import { atomicWriteFileSync } from "../fs-atomic.ts";
+import { parseFrontmatter } from "../vault.ts";
+import {
+  proceduralGraphPath,
+  proceduralMemoryIndexPath,
+  skillProposalAcceptedPath,
+  skillProposalPendingPath,
+  skillProposalRejectedPath,
+} from "./paths.ts";
+import type { ProceduralMemoryEntry } from "./procedural-memory.ts";
+
+export type ProceduralGraphNodeKind =
+  | "procedure"
+  | "skill"
+  | "runbook"
+  | "proposal"
+  | "entity";
+export type ProceduralGraphEdgeKind =
+  | "derived_from_proposal"
+  | "trigger_matches"
+  | "tag_matches"
+  | "source_mentions"
+  | "proposal_mentions";
+
+export interface ProceduralGraphNode {
+  readonly id: string;
+  readonly kind: ProceduralGraphNodeKind;
+  readonly title: string;
+  readonly sourcePath: string | null;
+  readonly metadata: Readonly<Record<string, unknown>>;
+}
+
+export interface ProceduralGraphEdge {
+  readonly from: string;
+  readonly to: string;
+  readonly kind: ProceduralGraphEdgeKind;
+}
+
+export interface ProceduralGraphProjection {
+  readonly schema_version: 1;
+  readonly generated_at: string;
+  readonly nodes: ReadonlyArray<ProceduralGraphNode>;
+  readonly edges: ReadonlyArray<ProceduralGraphEdge>;
+}
+
+export interface ProceduralGraphBuildOptions {
+  readonly now?: Date;
+}
+
+export function rebuildProceduralGraph(
+  vault: string,
+  opts: ProceduralGraphBuildOptions = {},
+): ProceduralGraphProjection {
+  const now = opts.now ?? new Date();
+  const nodes: ProceduralGraphNode[] = [];
+  const edges: ProceduralGraphEdge[] = [];
+
+  const entries = readProceduralIndex(vault);
+  const nodeById = new Set<string>();
+  for (const entry of entries) {
+    const node: ProceduralGraphNode = {
+      id: entry.id,
+      kind: entry.kind,
+      title: entry.title,
+      sourcePath: entry.sourcePath,
+      metadata: {
+        triggers: [...entry.triggers],
+        tags: [...entry.tags],
+        source: entry.source,
+        version: entry.version,
+      },
+    };
+    nodes.push(node);
+    nodeById.add(node.id);
+
+    if (entry.kind === "procedure") {
+      const proposalId = detectProcedureSourceProposal(vault, entry.sourcePath);
+      if (proposalId) {
+        edges.push({
+          from: node.id,
+          to: proposalId,
+          kind: "derived_from_proposal",
+        });
+      }
+    }
+
+    for (const trigger of entry.triggers) {
+      const entityId = entityNodeId(`trigger:${trigger}`);
+      ensureEntityNode(nodes, nodeById, entityId, `Trigger: ${trigger}`);
+      edges.push({ from: node.id, to: entityId, kind: "trigger_matches" });
+    }
+
+    for (const tag of entry.tags) {
+      const entityId = entityNodeId(`tag:${tag}`);
+      ensureEntityNode(nodes, nodeById, entityId, `Tag: ${tag}`);
+      edges.push({ from: node.id, to: entityId, kind: "tag_matches" });
+    }
+
+    for (const token of sourcePathTokens(entry.sourcePath)) {
+      const entityId = entityNodeId(`path:${token}`);
+      ensureEntityNode(nodes, nodeById, entityId, `Path: ${token}`);
+      edges.push({ from: node.id, to: entityId, kind: "source_mentions" });
+    }
+  }
+
+  for (const proposal of listProposals(vault)) {
+    nodes.push(proposal);
+    nodeById.add(proposal.id);
+    for (const token of sourcePathTokens(proposal.sourcePath ?? "")) {
+      const entityId = entityNodeId(`proposal-path:${token}`);
+      ensureEntityNode(nodes, nodeById, entityId, `Proposal Path: ${token}`);
+      edges.push({
+        from: proposal.id,
+        to: entityId,
+        kind: "proposal_mentions",
+      });
+    }
+  }
+
+  const projection: ProceduralGraphProjection = {
+    schema_version: 1,
+    generated_at: now.toISOString(),
+    nodes: Object.freeze(
+      nodes
+        .toSorted((left, right) => left.id.localeCompare(right.id))
+        .map((item) => Object.freeze(item)),
+    ),
+    edges: Object.freeze(
+      dedupeEdges(edges)
+        .toSorted(
+          (left, right) =>
+            left.from.localeCompare(right.from) ||
+            left.to.localeCompare(right.to) ||
+            left.kind.localeCompare(right.kind),
+        )
+        .map((item) => Object.freeze(item)),
+    ),
+  };
+
+  const path = proceduralGraphPath(vault);
+  mkdirSync(dirname(path), { recursive: true });
+  atomicWriteFileSync(path, `${JSON.stringify(projection, null, 2)}\n`);
+  return projection;
+}
+
+export function readProceduralGraph(
+  vault: string,
+): ProceduralGraphProjection | null {
+  const path = proceduralGraphPath(vault);
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(
+      readFileSync(path, "utf8"),
+    ) as ProceduralGraphProjection;
+    if (parsed.schema_version !== 1) return null;
+    if (!Array.isArray(parsed.nodes) || !Array.isArray(parsed.edges))
+      return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function readProceduralIndex(vault: string): ProceduralMemoryEntry[] {
+  const path = proceduralMemoryIndexPath(vault);
+  if (!existsSync(path)) return [];
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as {
+      schema_version?: unknown;
+      entries?: ProceduralMemoryEntry[];
+    };
+    if (parsed.schema_version !== 1) return [];
+    if (!Array.isArray(parsed.entries)) return [];
+    return parsed.entries;
+  } catch {
+    return [];
+  }
+}
+
+function detectProcedureSourceProposal(
+  vault: string,
+  sourcePath: string,
+): string | null {
+  if (!sourcePath.startsWith("Brain/procedures/")) return null;
+  const absPath = sourcePath.startsWith("/")
+    ? sourcePath
+    : `${vault}/${sourcePath}`;
+  if (!existsSync(absPath)) return null;
+  try {
+    const [fm] = parseFrontmatter(absPath);
+    if (
+      typeof fm["source_proposal"] === "string" &&
+      fm["source_proposal"].trim()
+    ) {
+      return fm["source_proposal"].trim();
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function listProposals(vault: string): ProceduralGraphNode[] {
+  const out: ProceduralGraphNode[] = [];
+  for (const tuple of [
+    ["pending", skillProposalPendingPath],
+    ["accepted", skillProposalAcceptedPath],
+    ["rejected", skillProposalRejectedPath],
+  ] as const) {
+    const [status, builder] = tuple;
+    const dir = dirname(builder(vault, "sample"));
+    if (!existsSync(dir)) continue;
+    for (const name of readDirSorted(dir)) {
+      if (!name.endsWith(".md")) continue;
+      const absPath = `${dir}/${name}`;
+      try {
+        const [fm] = parseFrontmatter(absPath);
+        if (fm["kind"] !== "brain-skill-proposal") continue;
+        const id =
+          typeof fm["id"] === "string"
+            ? fm["id"]
+            : `proposal-${basename(name, ".md")}`;
+        out.push({
+          id,
+          kind: "proposal",
+          title:
+            typeof fm["slug"] === "string"
+              ? `Proposal: ${fm["slug"]}`
+              : `Proposal: ${basename(name, ".md")}`,
+          sourcePath: `Brain/skill-proposals/${status}/${name}`,
+          metadata: {
+            status,
+            pattern_kind: fm["pattern_kind"] ?? null,
+          },
+        });
+      } catch {
+        continue;
+      }
+    }
+  }
+  return out;
+}
+
+function readDirSorted(dir: string): string[] {
+  try {
+    return readdirSync(dir).toSorted();
+  } catch {
+    return [];
+  }
+}
+
+function sourcePathTokens(path: string): string[] {
+  return path
+    .replaceAll("\\", "/")
+    .split("/")
+    .map((part) => part.trim().toLowerCase())
+    .filter((part) => part.length >= 3 && /^[a-z0-9._-]+$/.test(part));
+}
+
+function ensureEntityNode(
+  nodes: ProceduralGraphNode[],
+  nodeById: Set<string>,
+  id: string,
+  title: string,
+): void {
+  if (nodeById.has(id)) return;
+  nodes.push({
+    id,
+    kind: "entity",
+    title,
+    sourcePath: null,
+    metadata: {},
+  });
+  nodeById.add(id);
+}
+
+function entityNodeId(raw: string): string {
+  return `ent-${raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")}`;
+}
+
+function dedupeEdges(
+  edges: ReadonlyArray<ProceduralGraphEdge>,
+): ProceduralGraphEdge[] {
+  const out: ProceduralGraphEdge[] = [];
+  const seen = new Set<string>();
+  for (const edge of edges) {
+    const key = `${edge.from}\u0000${edge.to}\u0000${edge.kind}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(edge);
+  }
+  return out;
+}

--- a/src/core/brain/procedural-graph.ts
+++ b/src/core/brain/procedural-graph.ts
@@ -1,7 +1,8 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync } from "node:fs";
-import { basename, dirname } from "node:path";
+import { basename, dirname, join } from "node:path";
 
 import { atomicWriteFileSync } from "../fs-atomic.ts";
+import { ensureInsideVault } from "../path-safety.ts";
 import { parseFrontmatter } from "../vault.ts";
 import {
   proceduralGraphPath,
@@ -12,7 +13,12 @@ import {
 } from "./paths.ts";
 import type { ProceduralMemoryEntry } from "./procedural-memory.ts";
 
-export type ProceduralGraphNodeKind = "procedure" | "skill" | "runbook" | "proposal" | "entity";
+export type ProceduralGraphNodeKind =
+  | "procedure"
+  | "skill"
+  | "runbook"
+  | "proposal"
+  | "entity";
 export type ProceduralGraphEdgeKind =
   | "derived_from_proposal"
   | "trigger_matches"
@@ -141,13 +147,18 @@ export function rebuildProceduralGraph(
   return projection;
 }
 
-export function readProceduralGraph(vault: string): ProceduralGraphProjection | null {
+export function readProceduralGraph(
+  vault: string,
+): ProceduralGraphProjection | null {
   const path = proceduralGraphPath(vault);
   if (!existsSync(path)) return null;
   try {
-    const parsed = JSON.parse(readFileSync(path, "utf8")) as ProceduralGraphProjection;
+    const parsed = JSON.parse(
+      readFileSync(path, "utf8"),
+    ) as ProceduralGraphProjection;
     if (parsed.schema_version !== 1) return null;
-    if (!Array.isArray(parsed.nodes) || !Array.isArray(parsed.edges)) return null;
+    if (!Array.isArray(parsed.nodes) || !Array.isArray(parsed.edges))
+      return null;
     return parsed;
   } catch {
     return null;
@@ -170,13 +181,24 @@ function readProceduralIndex(vault: string): ProceduralMemoryEntry[] {
   }
 }
 
-function detectProcedureSourceProposal(vault: string, sourcePath: string): string | null {
+function detectProcedureSourceProposal(
+  vault: string,
+  sourcePath: string,
+): string | null {
   if (!sourcePath.startsWith("Brain/procedures/")) return null;
-  const absPath = sourcePath.startsWith("/") ? sourcePath : `${vault}/${sourcePath}`;
+  let absPath: string;
+  try {
+    absPath = ensureInsideVault(join(vault, sourcePath), vault);
+  } catch {
+    return null;
+  }
   if (!existsSync(absPath)) return null;
   try {
     const [fm] = parseFrontmatter(absPath);
-    if (typeof fm["source_proposal"] === "string" && fm["source_proposal"].trim()) {
+    if (
+      typeof fm["source_proposal"] === "string" &&
+      fm["source_proposal"].trim()
+    ) {
       return fm["source_proposal"].trim();
     }
     return null;
@@ -201,7 +223,10 @@ function listProposals(vault: string): ProceduralGraphNode[] {
       try {
         const [fm] = parseFrontmatter(absPath);
         if (fm["kind"] !== "brain-skill-proposal") continue;
-        const id = typeof fm["id"] === "string" ? fm["id"] : `proposal-${basename(name, ".md")}`;
+        const id =
+          typeof fm["id"] === "string"
+            ? fm["id"]
+            : `proposal-${basename(name, ".md")}`;
         out.push({
           id,
           kind: "proposal",
@@ -263,7 +288,9 @@ function entityNodeId(raw: string): string {
     .replace(/^-+|-+$/g, "")}`;
 }
 
-function dedupeEdges(edges: ReadonlyArray<ProceduralGraphEdge>): ProceduralGraphEdge[] {
+function dedupeEdges(
+  edges: ReadonlyArray<ProceduralGraphEdge>,
+): ProceduralGraphEdge[] {
   const out: ProceduralGraphEdge[] = [];
   const seen = new Set<string>();
   for (const edge of edges) {

--- a/src/core/brain/procedural-hints.ts
+++ b/src/core/brain/procedural-hints.ts
@@ -3,7 +3,10 @@ import { dirname } from "node:path";
 
 import { atomicWriteFileSync } from "../fs-atomic.ts";
 import { proceduralHintsPath } from "./paths.ts";
-import { readProceduralGraph, type ProceduralGraphProjection } from "./procedural-graph.ts";
+import {
+  readProceduralGraph,
+  type ProceduralGraphProjection,
+} from "./procedural-graph.ts";
 
 export interface ProceduralHintEntry {
   readonly node_id: string;
@@ -27,7 +30,7 @@ export function rebuildProceduralHints(
     for (const node of graph.nodes) {
       if (node.kind === "entity") continue;
       const cues = new Set<string>();
-      cues.add(node.title.toLowerCase());
+      for (const token of tokenizeCue(node.title)) cues.add(token);
       if (node.sourcePath) {
         for (const token of tokenizeCue(node.sourcePath)) cues.add(token);
       }
@@ -44,7 +47,9 @@ export function rebuildProceduralHints(
       }
       entries.push({
         node_id: node.id,
-        cues: Object.freeze([...cues].filter((item) => item.length >= 3).toSorted()),
+        cues: Object.freeze(
+          [...cues].filter((item) => item.length >= 3).toSorted(),
+        ),
       });
     }
   }
@@ -52,7 +57,9 @@ export function rebuildProceduralHints(
   const projection: ProceduralHintsProjection = {
     schema_version: 1,
     generated_at: now.toISOString(),
-    entries: Object.freeze(entries.toSorted((l, r) => l.node_id.localeCompare(r.node_id))),
+    entries: Object.freeze(
+      entries.toSorted((l, r) => l.node_id.localeCompare(r.node_id)),
+    ),
   };
 
   const path = proceduralHintsPath(vault);
@@ -61,11 +68,15 @@ export function rebuildProceduralHints(
   return projection;
 }
 
-export function readProceduralHints(vault: string): ProceduralHintsProjection | null {
+export function readProceduralHints(
+  vault: string,
+): ProceduralHintsProjection | null {
   const path = proceduralHintsPath(vault);
   if (!existsSync(path)) return null;
   try {
-    const parsed = JSON.parse(readFileSync(path, "utf8")) as ProceduralHintsProjection;
+    const parsed = JSON.parse(
+      readFileSync(path, "utf8"),
+    ) as ProceduralHintsProjection;
     if (parsed.schema_version !== 1) return null;
     if (!Array.isArray(parsed.entries)) return null;
     return parsed;

--- a/src/core/brain/procedural-hints.ts
+++ b/src/core/brain/procedural-hints.ts
@@ -3,10 +3,7 @@ import { dirname } from "node:path";
 
 import { atomicWriteFileSync } from "../fs-atomic.ts";
 import { proceduralHintsPath } from "./paths.ts";
-import {
-  readProceduralGraph,
-  type ProceduralGraphProjection,
-} from "./procedural-graph.ts";
+import { readProceduralGraph, type ProceduralGraphProjection } from "./procedural-graph.ts";
 
 export interface ProceduralHintEntry {
   readonly node_id: string;
@@ -47,9 +44,7 @@ export function rebuildProceduralHints(
       }
       entries.push({
         node_id: node.id,
-        cues: Object.freeze(
-          [...cues].filter((item) => item.length >= 3).toSorted(),
-        ),
+        cues: Object.freeze([...cues].filter((item) => item.length >= 3).toSorted()),
       });
     }
   }
@@ -57,9 +52,7 @@ export function rebuildProceduralHints(
   const projection: ProceduralHintsProjection = {
     schema_version: 1,
     generated_at: now.toISOString(),
-    entries: Object.freeze(
-      entries.toSorted((l, r) => l.node_id.localeCompare(r.node_id)),
-    ),
+    entries: Object.freeze(entries.toSorted((l, r) => l.node_id.localeCompare(r.node_id))),
   };
 
   const path = proceduralHintsPath(vault);
@@ -68,15 +61,11 @@ export function rebuildProceduralHints(
   return projection;
 }
 
-export function readProceduralHints(
-  vault: string,
-): ProceduralHintsProjection | null {
+export function readProceduralHints(vault: string): ProceduralHintsProjection | null {
   const path = proceduralHintsPath(vault);
   if (!existsSync(path)) return null;
   try {
-    const parsed = JSON.parse(
-      readFileSync(path, "utf8"),
-    ) as ProceduralHintsProjection;
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as ProceduralHintsProjection;
     if (parsed.schema_version !== 1) return null;
     if (!Array.isArray(parsed.entries)) return null;
     return parsed;

--- a/src/core/brain/procedural-hints.ts
+++ b/src/core/brain/procedural-hints.ts
@@ -1,0 +1,94 @@
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+import { atomicWriteFileSync } from "../fs-atomic.ts";
+import { proceduralHintsPath } from "./paths.ts";
+import {
+  readProceduralGraph,
+  type ProceduralGraphProjection,
+} from "./procedural-graph.ts";
+
+export interface ProceduralHintEntry {
+  readonly node_id: string;
+  readonly cues: ReadonlyArray<string>;
+}
+
+export interface ProceduralHintsProjection {
+  readonly schema_version: 1;
+  readonly generated_at: string;
+  readonly entries: ReadonlyArray<ProceduralHintEntry>;
+}
+
+export function rebuildProceduralHints(
+  vault: string,
+  opts: { now?: Date; graph?: ProceduralGraphProjection } = {},
+): ProceduralHintsProjection {
+  const graph = opts.graph ?? readProceduralGraph(vault);
+  const now = opts.now ?? new Date();
+  const entries: ProceduralHintEntry[] = [];
+  if (graph !== null) {
+    for (const node of graph.nodes) {
+      if (node.kind === "entity") continue;
+      const cues = new Set<string>();
+      cues.add(node.title.toLowerCase());
+      if (node.sourcePath) {
+        for (const token of tokenizeCue(node.sourcePath)) cues.add(token);
+      }
+      for (const value of Object.values(node.metadata)) {
+        if (Array.isArray(value)) {
+          for (const item of value) {
+            if (typeof item === "string") {
+              for (const token of tokenizeCue(item)) cues.add(token);
+            }
+          }
+        } else if (typeof value === "string") {
+          for (const token of tokenizeCue(value)) cues.add(token);
+        }
+      }
+      entries.push({
+        node_id: node.id,
+        cues: Object.freeze(
+          [...cues].filter((item) => item.length >= 3).toSorted(),
+        ),
+      });
+    }
+  }
+
+  const projection: ProceduralHintsProjection = {
+    schema_version: 1,
+    generated_at: now.toISOString(),
+    entries: Object.freeze(
+      entries.toSorted((l, r) => l.node_id.localeCompare(r.node_id)),
+    ),
+  };
+
+  const path = proceduralHintsPath(vault);
+  mkdirSync(dirname(path), { recursive: true });
+  atomicWriteFileSync(path, `${JSON.stringify(projection, null, 2)}\n`);
+  return projection;
+}
+
+export function readProceduralHints(
+  vault: string,
+): ProceduralHintsProjection | null {
+  const path = proceduralHintsPath(vault);
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(
+      readFileSync(path, "utf8"),
+    ) as ProceduralHintsProjection;
+    if (parsed.schema_version !== 1) return null;
+    if (!Array.isArray(parsed.entries)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function tokenizeCue(input: string): string[] {
+  return input
+    .toLowerCase()
+    .split(/[^a-z0-9]+/g)
+    .map((item) => item.trim())
+    .filter((item) => item.length >= 3);
+}

--- a/src/core/brain/procedural-memory.ts
+++ b/src/core/brain/procedural-memory.ts
@@ -1,11 +1,5 @@
 import { createHash } from "node:crypto";
-import {
-  existsSync,
-  lstatSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-} from "node:fs";
+import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 
 import { atomicWriteFileSync } from "../fs-atomic.ts";
@@ -13,10 +7,7 @@ import { ensureInsideVault } from "../path-safety.ts";
 import { parseFrontmatter } from "../vault.ts";
 import { rebuildProceduralHints } from "./procedural-hints.ts";
 import { rebuildProceduralGraph } from "./procedural-graph.ts";
-import {
-  proceduralMemoryIndexPath,
-  proceduralMemoryUsagePath,
-} from "./paths.ts";
+import { proceduralMemoryIndexPath, proceduralMemoryUsagePath } from "./paths.ts";
 
 export type ProceduralEntryKind = "skill" | "runbook" | "procedure";
 
@@ -49,9 +40,7 @@ export function reconcileProceduralMemory(
   vault: string,
   opts: ProceduralReconcileOptions,
 ): ProceduralReconcileResult {
-  const prev = new Map(
-    listProceduralMemory(vault).map((entry) => [entry.id, entry] as const),
-  );
+  const prev = new Map(listProceduralMemory(vault).map((entry) => [entry.id, entry] as const));
   const usage = readUsageMap(vault);
   const next = collectEntries(vault, opts.roots).map((entry) => {
     const old = prev.get(entry.id);
@@ -89,9 +78,7 @@ export function reconcileProceduralMemory(
   return { total: next.length, added, updated, removed };
 }
 
-export function listProceduralMemory(
-  vault: string,
-): ReadonlyArray<ProceduralMemoryEntry> {
+export function listProceduralMemory(vault: string): ReadonlyArray<ProceduralMemoryEntry> {
   const path = proceduralMemoryIndexPath(vault);
   if (!existsSync(path)) return Object.freeze([]);
   try {
@@ -138,10 +125,7 @@ export function markProceduralMemoryUsed(
   return next.find((entry) => entry.id === id) ?? null;
 }
 
-function collectEntries(
-  vault: string,
-  roots: ReadonlyArray<string>,
-): ProceduralMemoryEntry[] {
+function collectEntries(vault: string, roots: ReadonlyArray<string>): ProceduralMemoryEntry[] {
   const out: ProceduralMemoryEntry[] = [];
 
   for (const root of roots) {
@@ -172,19 +156,13 @@ function collectEntries(
     }
   }
 
-  return out.toSorted((left, right) =>
-    left.sourcePath.localeCompare(right.sourcePath),
-  );
+  return out.toSorted((left, right) => left.sourcePath.localeCompare(right.sourcePath));
 }
 
 function detectKind(vaultRelPath: string): ProceduralEntryKind | null {
   if (vaultRelPath.startsWith("Brain/procedures/")) return "procedure";
   if (vaultRelPath.endsWith("/SKILL.md")) return "skill";
-  if (
-    vaultRelPath.endsWith(".prompt.md") ||
-    vaultRelPath.endsWith("runbook.md")
-  )
-    return "runbook";
+  if (vaultRelPath.endsWith(".prompt.md") || vaultRelPath.endsWith("runbook.md")) return "runbook";
   return null;
 }
 
@@ -231,35 +209,25 @@ function toVaultRelative(vault: string, absPath: string): string {
 }
 
 function entryId(sourcePath: string): string {
-  const hash = createHash("sha256")
-    .update(sourcePath, "utf8")
-    .digest("hex")
-    .slice(0, 12);
+  const hash = createHash("sha256").update(sourcePath, "utf8").digest("hex").slice(0, 12);
   return `pmem-${hash}`;
 }
 
 function asStringArray(value: unknown): string[] {
   if (Array.isArray(value)) {
     return value.filter(
-      (item): item is string =>
-        typeof item === "string" && item.trim().length > 0,
+      (item): item is string => typeof item === "string" && item.trim().length > 0,
     );
   }
-  if (typeof value === "string" && value.trim().length > 0)
-    return [value.trim()];
+  if (typeof value === "string" && value.trim().length > 0) return [value.trim()];
   return [];
 }
 
 function asStringOrNull(value: unknown): string | null {
-  return typeof value === "string" && value.trim().length > 0
-    ? value.trim()
-    : null;
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
-function writeIndex(
-  vault: string,
-  entries: ReadonlyArray<ProceduralMemoryEntry>,
-): void {
+function writeIndex(vault: string, entries: ReadonlyArray<ProceduralMemoryEntry>): void {
   const path = proceduralMemoryIndexPath(vault);
   mkdirSync(ensureInsideVault(dirname(path), vault), { recursive: true });
   const payload = JSON.stringify(
@@ -279,10 +247,7 @@ function readUsageMap(
   const path = proceduralMemoryUsagePath(vault);
   if (!existsSync(path)) return new Map();
 
-  const out = new Map<
-    string,
-    { usedCount: number; lastUsedAt: string | null }
-  >();
+  const out = new Map<string, { usedCount: number; lastUsedAt: string | null }>();
   for (const line of readFileSync(path, "utf8").split("\n")) {
     if (!line.trim()) continue;
     try {
@@ -290,12 +255,8 @@ function readUsageMap(
       const id = typeof parsed["id"] === "string" ? parsed["id"] : null;
       if (!id) continue;
       out.set(id, {
-        usedCount:
-          typeof parsed["usedCount"] === "number" ? parsed["usedCount"] : 0,
-        lastUsedAt:
-          typeof parsed["lastUsedAt"] === "string"
-            ? parsed["lastUsedAt"]
-            : null,
+        usedCount: typeof parsed["usedCount"] === "number" ? parsed["usedCount"] : 0,
+        lastUsedAt: typeof parsed["lastUsedAt"] === "string" ? parsed["lastUsedAt"] : null,
       });
     } catch {
       continue;
@@ -322,8 +283,5 @@ function writeUsageMap(
       }),
     );
   }
-  atomicWriteFileSync(
-    path,
-    `${lines.join("\n")}${lines.length > 0 ? "\n" : ""}`,
-  );
+  atomicWriteFileSync(path, `${lines.join("\n")}${lines.length > 0 ? "\n" : ""}`);
 }

--- a/src/core/brain/procedural-memory.ts
+++ b/src/core/brain/procedural-memory.ts
@@ -1,11 +1,22 @@
 import { createHash } from "node:crypto";
-import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+} from "node:fs";
 import { dirname, join, relative } from "node:path";
 
 import { atomicWriteFileSync } from "../fs-atomic.ts";
 import { ensureInsideVault } from "../path-safety.ts";
 import { parseFrontmatter } from "../vault.ts";
-import { proceduralMemoryIndexPath, proceduralMemoryUsagePath } from "./paths.ts";
+import { rebuildProceduralHints } from "./procedural-hints.ts";
+import { rebuildProceduralGraph } from "./procedural-graph.ts";
+import {
+  proceduralMemoryIndexPath,
+  proceduralMemoryUsagePath,
+} from "./paths.ts";
 
 export type ProceduralEntryKind = "skill" | "runbook" | "procedure";
 
@@ -38,7 +49,9 @@ export function reconcileProceduralMemory(
   vault: string,
   opts: ProceduralReconcileOptions,
 ): ProceduralReconcileResult {
-  const prev = new Map(listProceduralMemory(vault).map((entry) => [entry.id, entry] as const));
+  const prev = new Map(
+    listProceduralMemory(vault).map((entry) => [entry.id, entry] as const),
+  );
   const usage = readUsageMap(vault);
   const next = collectEntries(vault, opts.roots).map((entry) => {
     const old = prev.get(entry.id);
@@ -71,10 +84,14 @@ export function reconcileProceduralMemory(
   }
 
   writeIndex(vault, next);
+  const graph = rebuildProceduralGraph(vault);
+  rebuildProceduralHints(vault, { graph });
   return { total: next.length, added, updated, removed };
 }
 
-export function listProceduralMemory(vault: string): ReadonlyArray<ProceduralMemoryEntry> {
+export function listProceduralMemory(
+  vault: string,
+): ReadonlyArray<ProceduralMemoryEntry> {
   const path = proceduralMemoryIndexPath(vault);
   if (!existsSync(path)) return Object.freeze([]);
   try {
@@ -115,11 +132,16 @@ export function markProceduralMemoryUsed(
     lastUsedAt: now.toISOString(),
   });
   writeUsageMap(vault, usage);
+  const graph = rebuildProceduralGraph(vault);
+  rebuildProceduralHints(vault, { graph });
 
   return next.find((entry) => entry.id === id) ?? null;
 }
 
-function collectEntries(vault: string, roots: ReadonlyArray<string>): ProceduralMemoryEntry[] {
+function collectEntries(
+  vault: string,
+  roots: ReadonlyArray<string>,
+): ProceduralMemoryEntry[] {
   const out: ProceduralMemoryEntry[] = [];
 
   for (const root of roots) {
@@ -150,13 +172,19 @@ function collectEntries(vault: string, roots: ReadonlyArray<string>): Procedural
     }
   }
 
-  return out.toSorted((left, right) => left.sourcePath.localeCompare(right.sourcePath));
+  return out.toSorted((left, right) =>
+    left.sourcePath.localeCompare(right.sourcePath),
+  );
 }
 
 function detectKind(vaultRelPath: string): ProceduralEntryKind | null {
   if (vaultRelPath.startsWith("Brain/procedures/")) return "procedure";
   if (vaultRelPath.endsWith("/SKILL.md")) return "skill";
-  if (vaultRelPath.endsWith(".prompt.md") || vaultRelPath.endsWith("runbook.md")) return "runbook";
+  if (
+    vaultRelPath.endsWith(".prompt.md") ||
+    vaultRelPath.endsWith("runbook.md")
+  )
+    return "runbook";
   return null;
 }
 
@@ -203,25 +231,35 @@ function toVaultRelative(vault: string, absPath: string): string {
 }
 
 function entryId(sourcePath: string): string {
-  const hash = createHash("sha256").update(sourcePath, "utf8").digest("hex").slice(0, 12);
+  const hash = createHash("sha256")
+    .update(sourcePath, "utf8")
+    .digest("hex")
+    .slice(0, 12);
   return `pmem-${hash}`;
 }
 
 function asStringArray(value: unknown): string[] {
   if (Array.isArray(value)) {
     return value.filter(
-      (item): item is string => typeof item === "string" && item.trim().length > 0,
+      (item): item is string =>
+        typeof item === "string" && item.trim().length > 0,
     );
   }
-  if (typeof value === "string" && value.trim().length > 0) return [value.trim()];
+  if (typeof value === "string" && value.trim().length > 0)
+    return [value.trim()];
   return [];
 }
 
 function asStringOrNull(value: unknown): string | null {
-  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
 }
 
-function writeIndex(vault: string, entries: ReadonlyArray<ProceduralMemoryEntry>): void {
+function writeIndex(
+  vault: string,
+  entries: ReadonlyArray<ProceduralMemoryEntry>,
+): void {
   const path = proceduralMemoryIndexPath(vault);
   mkdirSync(ensureInsideVault(dirname(path), vault), { recursive: true });
   const payload = JSON.stringify(
@@ -241,7 +279,10 @@ function readUsageMap(
   const path = proceduralMemoryUsagePath(vault);
   if (!existsSync(path)) return new Map();
 
-  const out = new Map<string, { usedCount: number; lastUsedAt: string | null }>();
+  const out = new Map<
+    string,
+    { usedCount: number; lastUsedAt: string | null }
+  >();
   for (const line of readFileSync(path, "utf8").split("\n")) {
     if (!line.trim()) continue;
     try {
@@ -249,8 +290,12 @@ function readUsageMap(
       const id = typeof parsed["id"] === "string" ? parsed["id"] : null;
       if (!id) continue;
       out.set(id, {
-        usedCount: typeof parsed["usedCount"] === "number" ? parsed["usedCount"] : 0,
-        lastUsedAt: typeof parsed["lastUsedAt"] === "string" ? parsed["lastUsedAt"] : null,
+        usedCount:
+          typeof parsed["usedCount"] === "number" ? parsed["usedCount"] : 0,
+        lastUsedAt:
+          typeof parsed["lastUsedAt"] === "string"
+            ? parsed["lastUsedAt"]
+            : null,
       });
     } catch {
       continue;
@@ -277,5 +322,8 @@ function writeUsageMap(
       }),
     );
   }
-  atomicWriteFileSync(path, `${lines.join("\n")}${lines.length > 0 ? "\n" : ""}`);
+  atomicWriteFileSync(
+    path,
+    `${lines.join("\n")}${lines.length > 0 ? "\n" : ""}`,
+  );
 }

--- a/src/core/brain/procedural-memory.ts
+++ b/src/core/brain/procedural-memory.ts
@@ -1,20 +1,11 @@
 import { createHash } from "node:crypto";
-import {
-  existsSync,
-  lstatSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-} from "node:fs";
+import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 
 import { atomicWriteFileSync } from "../fs-atomic.ts";
 import { ensureInsideVault } from "../path-safety.ts";
 import { parseFrontmatter } from "../vault.ts";
-import {
-  proceduralMemoryIndexPath,
-  proceduralMemoryUsagePath,
-} from "./paths.ts";
+import { proceduralMemoryIndexPath, proceduralMemoryUsagePath } from "./paths.ts";
 
 export type ProceduralEntryKind = "skill" | "runbook" | "procedure";
 
@@ -47,9 +38,7 @@ export function reconcileProceduralMemory(
   vault: string,
   opts: ProceduralReconcileOptions,
 ): ProceduralReconcileResult {
-  const prev = new Map(
-    listProceduralMemory(vault).map((entry) => [entry.id, entry] as const),
-  );
+  const prev = new Map(listProceduralMemory(vault).map((entry) => [entry.id, entry] as const));
   const usage = readUsageMap(vault);
   const next = collectEntries(vault, opts.roots).map((entry) => {
     const old = prev.get(entry.id);
@@ -85,9 +74,7 @@ export function reconcileProceduralMemory(
   return { total: next.length, added, updated, removed };
 }
 
-export function listProceduralMemory(
-  vault: string,
-): ReadonlyArray<ProceduralMemoryEntry> {
+export function listProceduralMemory(vault: string): ReadonlyArray<ProceduralMemoryEntry> {
   const path = proceduralMemoryIndexPath(vault);
   if (!existsSync(path)) return Object.freeze([]);
   try {
@@ -132,10 +119,7 @@ export function markProceduralMemoryUsed(
   return next.find((entry) => entry.id === id) ?? null;
 }
 
-function collectEntries(
-  vault: string,
-  roots: ReadonlyArray<string>,
-): ProceduralMemoryEntry[] {
+function collectEntries(vault: string, roots: ReadonlyArray<string>): ProceduralMemoryEntry[] {
   const out: ProceduralMemoryEntry[] = [];
 
   for (const root of roots) {
@@ -166,19 +150,13 @@ function collectEntries(
     }
   }
 
-  return out.toSorted((left, right) =>
-    left.sourcePath.localeCompare(right.sourcePath),
-  );
+  return out.toSorted((left, right) => left.sourcePath.localeCompare(right.sourcePath));
 }
 
 function detectKind(vaultRelPath: string): ProceduralEntryKind | null {
   if (vaultRelPath.startsWith("Brain/procedures/")) return "procedure";
   if (vaultRelPath.endsWith("/SKILL.md")) return "skill";
-  if (
-    vaultRelPath.endsWith(".prompt.md") ||
-    vaultRelPath.endsWith("runbook.md")
-  )
-    return "runbook";
+  if (vaultRelPath.endsWith(".prompt.md") || vaultRelPath.endsWith("runbook.md")) return "runbook";
   return null;
 }
 
@@ -225,35 +203,25 @@ function toVaultRelative(vault: string, absPath: string): string {
 }
 
 function entryId(sourcePath: string): string {
-  const hash = createHash("sha256")
-    .update(sourcePath, "utf8")
-    .digest("hex")
-    .slice(0, 12);
+  const hash = createHash("sha256").update(sourcePath, "utf8").digest("hex").slice(0, 12);
   return `pmem-${hash}`;
 }
 
 function asStringArray(value: unknown): string[] {
   if (Array.isArray(value)) {
     return value.filter(
-      (item): item is string =>
-        typeof item === "string" && item.trim().length > 0,
+      (item): item is string => typeof item === "string" && item.trim().length > 0,
     );
   }
-  if (typeof value === "string" && value.trim().length > 0)
-    return [value.trim()];
+  if (typeof value === "string" && value.trim().length > 0) return [value.trim()];
   return [];
 }
 
 function asStringOrNull(value: unknown): string | null {
-  return typeof value === "string" && value.trim().length > 0
-    ? value.trim()
-    : null;
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
-function writeIndex(
-  vault: string,
-  entries: ReadonlyArray<ProceduralMemoryEntry>,
-): void {
+function writeIndex(vault: string, entries: ReadonlyArray<ProceduralMemoryEntry>): void {
   const path = proceduralMemoryIndexPath(vault);
   mkdirSync(ensureInsideVault(dirname(path), vault), { recursive: true });
   const payload = JSON.stringify(
@@ -273,10 +241,7 @@ function readUsageMap(
   const path = proceduralMemoryUsagePath(vault);
   if (!existsSync(path)) return new Map();
 
-  const out = new Map<
-    string,
-    { usedCount: number; lastUsedAt: string | null }
-  >();
+  const out = new Map<string, { usedCount: number; lastUsedAt: string | null }>();
   for (const line of readFileSync(path, "utf8").split("\n")) {
     if (!line.trim()) continue;
     try {
@@ -284,12 +249,8 @@ function readUsageMap(
       const id = typeof parsed["id"] === "string" ? parsed["id"] : null;
       if (!id) continue;
       out.set(id, {
-        usedCount:
-          typeof parsed["usedCount"] === "number" ? parsed["usedCount"] : 0,
-        lastUsedAt:
-          typeof parsed["lastUsedAt"] === "string"
-            ? parsed["lastUsedAt"]
-            : null,
+        usedCount: typeof parsed["usedCount"] === "number" ? parsed["usedCount"] : 0,
+        lastUsedAt: typeof parsed["lastUsedAt"] === "string" ? parsed["lastUsedAt"] : null,
       });
     } catch {
       continue;
@@ -316,8 +277,5 @@ function writeUsageMap(
       }),
     );
   }
-  atomicWriteFileSync(
-    path,
-    `${lines.join("\n")}${lines.length > 0 ? "\n" : ""}`,
-  );
+  atomicWriteFileSync(path, `${lines.join("\n")}${lines.length > 0 ? "\n" : ""}`);
 }

--- a/src/core/brain/recurrence.ts
+++ b/src/core/brain/recurrence.ts
@@ -4,11 +4,7 @@ import { dirname } from "node:path";
 import { ensureInsideVault } from "../path-safety.ts";
 import { proceduralRecurrencePath } from "./paths.ts";
 
-export type RecurrenceCommitment =
-  | "exploring"
-  | "leaning"
-  | "decided"
-  | "locked";
+export type RecurrenceCommitment = "exploring" | "leaning" | "decided" | "locked";
 export type RecurrenceAction = "learn" | "forget";
 
 export interface RecurrenceThresholds {
@@ -64,11 +60,7 @@ export function applyRecurrenceEvidence(
   return getRecurrenceEntry(vault, input.contentHash);
 }
 
-export function purgeRecurrenceSource(
-  vault: string,
-  sourceId: string,
-  at?: string,
-): void {
+export function purgeRecurrenceSource(vault: string, sourceId: string, at?: string): void {
   appendEvent(vault, {
     kind: "purge-source",
     sourceId,
@@ -82,9 +74,8 @@ export function getRecurrenceEntry(
   thresholds: RecurrenceThresholds = DEFAULT_THRESHOLDS,
 ): RecurrenceEntry | null {
   return (
-    listRecurrenceEntries(vault, thresholds).find(
-      (entry) => entry.contentHash === contentHash,
-    ) ?? null
+    listRecurrenceEntries(vault, thresholds).find((entry) => entry.contentHash === contentHash) ??
+    null
   );
 }
 
@@ -93,10 +84,7 @@ export function listRecurrenceEntries(
   thresholds: RecurrenceThresholds = DEFAULT_THRESHOLDS,
 ): ReadonlyArray<RecurrenceEntry> {
   const events = readEvents(vault);
-  const state = new Map<
-    string,
-    { supportBySourceScope: Map<string, number> }
-  >();
+  const state = new Map<string, { supportBySourceScope: Map<string, number> }>();
 
   for (const event of events) {
     if (event.kind === "purge-source") {
@@ -120,8 +108,7 @@ export function listRecurrenceEntries(
     if (event.action === "learn") {
       bucket.supportBySourceScope.set(sourceScopeKey, current + 1);
     } else {
-      if (current > 1)
-        bucket.supportBySourceScope.set(sourceScopeKey, current - 1);
+      if (current > 1) bucket.supportBySourceScope.set(sourceScopeKey, current - 1);
       else bucket.supportBySourceScope.delete(sourceScopeKey);
     }
 
@@ -137,10 +124,7 @@ export function listRecurrenceEntries(
       const [scope, sourceId] = splitSourceScopeKey(sourceScopeKey);
       if (!scope || !sourceId) continue;
       supportByScope.set(scope, (supportByScope.get(scope) ?? 0) + support);
-      supportBySource.set(
-        sourceId,
-        (supportBySource.get(sourceId) ?? 0) + support,
-      );
+      supportBySource.set(sourceId, (supportBySource.get(sourceId) ?? 0) + support);
     }
 
     const scopes = [...supportByScope.entries()]
@@ -165,9 +149,7 @@ export function listRecurrenceEntries(
   }
 
   return Object.freeze(
-    out.toSorted((left, right) =>
-      left.contentHash.localeCompare(right.contentHash),
-    ),
+    out.toSorted((left, right) => left.contentHash.localeCompare(right.contentHash)),
   );
 }
 

--- a/src/core/brain/sessions/import.ts
+++ b/src/core/brain/sessions/import.ts
@@ -25,20 +25,10 @@
  * second run on the same file finds every hash already present.
  */
 
-import {
-  existsSync,
-  lstatSync,
-  readdirSync,
-  readFileSync,
-  statSync,
-} from "node:fs";
+import { existsSync, lstatSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
 
-import {
-  buildDedupIndex,
-  computeDedupHash,
-  type DedupIndexEntry,
-} from "../dedup-hash.ts";
+import { buildDedupIndex, computeDedupHash, type DedupIndexEntry } from "../dedup-hash.ts";
 import { discoverMarkersDetailed } from "../inline.ts";
 import { writeSignal } from "../signal.ts";
 import { importSessionRecall } from "../session-recall.ts";
@@ -119,10 +109,7 @@ function firstLineOfFile(path: string): string {
 }
 
 /** Pick an adapter — by explicit format, or autodetect. */
-function chooseAdapter(
-  path: string,
-  format?: SessionAdapterId,
-): SessionAdapter {
+function chooseAdapter(path: string, format?: SessionAdapterId): SessionAdapter {
   if (format !== undefined) {
     return getAdapter(format);
   }
@@ -163,9 +150,7 @@ export async function importSession(
   let filteredTurns = 0;
   const recallTurns: SessionTurn[] = [];
   const filterRoles =
-    opts.filterRoles && opts.filterRoles.length > 0
-      ? new Set(opts.filterRoles)
-      : null;
+    opts.filterRoles && opts.filterRoles.length > 0 ? new Set(opts.filterRoles) : null;
   const filterNeedle = opts.filterTextIncludes?.trim().toLowerCase() ?? null;
 
   // Inline helper that wraps the writeSignal call with the consistent
@@ -207,10 +192,7 @@ export async function importSession(
         session_ref: sessionRef,
         ...(input.note || opts.ingestScope
           ? {
-              raw: [
-                opts.ingestScope ? `[ingest_scope:${opts.ingestScope}]` : "",
-                input.note ?? "",
-              ]
+              raw: [opts.ingestScope ? `[ingest_scope:${opts.ingestScope}]` : "", input.note ?? ""]
                 .filter((chunk) => chunk.length > 0)
                 .join("\n"),
             }
@@ -343,11 +325,7 @@ export async function importSession(
  * the caller, not here), then a per-adapter default, finally
  * `opts.agent`.
  */
-function agentLabelForTurn(
-  turn: SessionTurn,
-  adapter: SessionAdapterId,
-  fallback: string,
-): string {
+function agentLabelForTurn(turn: SessionTurn, adapter: SessionAdapterId, fallback: string): string {
   void turn; // reserved for future per-turn role-aware fallback
   return getAdapter(adapter).defaultAgent.trim() || fallback;
 }

--- a/src/core/brain/sessions/import.ts
+++ b/src/core/brain/sessions/import.ts
@@ -25,10 +25,20 @@
  * second run on the same file finds every hash already present.
  */
 
-import { existsSync, lstatSync, readdirSync, readFileSync, statSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from "node:fs";
 import { basename, join, resolve } from "node:path";
 
-import { buildDedupIndex, computeDedupHash, type DedupIndexEntry } from "../dedup-hash.ts";
+import {
+  buildDedupIndex,
+  computeDedupHash,
+  type DedupIndexEntry,
+} from "../dedup-hash.ts";
 import { discoverMarkersDetailed } from "../inline.ts";
 import { writeSignal } from "../signal.ts";
 import { importSessionRecall } from "../session-recall.ts";
@@ -71,6 +81,12 @@ export interface ImportSessionOptions {
   readonly recall?: boolean;
   readonly recallSessionId?: string;
   readonly recallSummaryGroupSize?: number;
+  /** Optional ingest scope label stamped into imported signal notes. */
+  readonly ingestScope?: string;
+  /** Optional role filter for write-side extraction. */
+  readonly filterRoles?: ReadonlyArray<SessionTurn["role"]>;
+  /** Optional case-insensitive substring filter on turn text. */
+  readonly filterTextIncludes?: string;
 }
 
 export interface ImportSessionResult {
@@ -81,6 +97,7 @@ export interface ImportSessionResult {
   readonly signals_deduped: number;
   readonly tool_replays: number;
   readonly malformed: number;
+  readonly filtered_turns: number;
   readonly recall_turns_imported: number;
   readonly recall_summary_nodes: number;
   readonly errors: ReadonlyArray<{ path: string; message: string }>;
@@ -102,7 +119,10 @@ function firstLineOfFile(path: string): string {
 }
 
 /** Pick an adapter — by explicit format, or autodetect. */
-function chooseAdapter(path: string, format?: SessionAdapterId): SessionAdapter {
+function chooseAdapter(
+  path: string,
+  format?: SessionAdapterId,
+): SessionAdapter {
   if (format !== undefined) {
     return getAdapter(format);
   }
@@ -140,7 +160,13 @@ export async function importSession(
   let signalsDeduped = 0;
   let toolReplays = 0;
   let malformed = 0;
+  let filteredTurns = 0;
   const recallTurns: SessionTurn[] = [];
+  const filterRoles =
+    opts.filterRoles && opts.filterRoles.length > 0
+      ? new Set(opts.filterRoles)
+      : null;
+  const filterNeedle = opts.filterTextIncludes?.trim().toLowerCase() ?? null;
 
   // Inline helper that wraps the writeSignal call with the consistent
   // shape every session-imported signal shares.
@@ -179,7 +205,16 @@ export async function importSession(
         source_type: BRAIN_SIGNAL_SOURCE_TYPE.session,
         dedup_hash: input.dedupHash,
         session_ref: sessionRef,
-        ...(input.note ? { raw: input.note } : {}),
+        ...(input.note || opts.ingestScope
+          ? {
+              raw: [
+                opts.ingestScope ? `[ingest_scope:${opts.ingestScope}]` : "",
+                input.note ?? "",
+              ]
+                .filter((chunk) => chunk.length > 0)
+                .join("\n"),
+            }
+          : {}),
         ...(opts.rawCodec === true ? { rawCodec: true } : {}),
       });
       dedup.set(input.dedupHash, { id: res.id, path: res.path });
@@ -197,6 +232,17 @@ export async function importSession(
     if (sinceMs !== undefined) {
       const t = Date.parse(turn.timestamp);
       if (Number.isFinite(t) && t < sinceMs) continue;
+    }
+    if (filterRoles !== null && !filterRoles.has(turn.role)) {
+      filteredTurns++;
+      continue;
+    }
+    if (filterNeedle !== null) {
+      const haystack = turn.text?.toLowerCase() ?? "";
+      if (!haystack.includes(filterNeedle)) {
+        filteredTurns++;
+        continue;
+      }
     }
     if (opts.recall === true) recallTurns.push(turn);
 
@@ -284,6 +330,7 @@ export async function importSession(
     signals_deduped: signalsDeduped,
     tool_replays: toolReplays,
     malformed,
+    filtered_turns: filteredTurns,
     recall_turns_imported: recallTurnsImported,
     recall_summary_nodes: recallSummaryNodes,
     errors: Object.freeze(errors),
@@ -296,7 +343,11 @@ export async function importSession(
  * the caller, not here), then a per-adapter default, finally
  * `opts.agent`.
  */
-function agentLabelForTurn(turn: SessionTurn, adapter: SessionAdapterId, fallback: string): string {
+function agentLabelForTurn(
+  turn: SessionTurn,
+  adapter: SessionAdapterId,
+  fallback: string,
+): string {
   void turn; // reserved for future per-turn role-aware fallback
   return getAdapter(adapter).defaultAgent.trim() || fallback;
 }

--- a/src/core/brain/skill-proposals.ts
+++ b/src/core/brain/skill-proposals.ts
@@ -1,11 +1,5 @@
 import { createHash } from "node:crypto";
-import {
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  unlinkSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 
 import { parseFrontmatter, slugify, writeFrontmatterAtomic } from "../vault.ts";
@@ -21,10 +15,7 @@ import {
   skillProposalPendingPath,
   skillProposalRejectedPath,
 } from "./paths.ts";
-import {
-  listContinuityRecords,
-  type ContinuityRecord,
-} from "./continuity/store.ts";
+import { listContinuityRecords, type ContinuityRecord } from "./continuity/store.ts";
 
 export type SkillProposalPatternKind =
   | "repeated_action"
@@ -86,8 +77,7 @@ export function learnSkillProposals(
     })
     .toSorted(
       (left, right) =>
-        left.createdAt.localeCompare(right.createdAt) ||
-        left.id.localeCompare(right.id),
+        left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
     );
 
   if (records.length === 0) {
@@ -113,11 +103,7 @@ export function learnSkillProposals(
     const acceptedPath = skillProposalAcceptedPath(vault, slug);
     const rejectedPath = skillProposalRejectedPath(vault, slug);
 
-    if (
-      existsSync(pendingPath) ||
-      existsSync(acceptedPath) ||
-      existsSync(rejectedPath)
-    ) {
+    if (existsSync(pendingPath) || existsSync(acceptedPath) || existsSync(rejectedPath)) {
       suppressed.push(proposalId);
       continue;
     }
@@ -177,10 +163,7 @@ export function listPendingSkillProposals(vault: string): ReadonlyArray<{
   status: string;
   patternKind: string;
 }> {
-  const dir = ensureInsideVault(
-    join(vault, BRAIN_SKILL_PROPOSALS_REL, "pending"),
-    vault,
-  );
+  const dir = ensureInsideVault(join(vault, BRAIN_SKILL_PROPOSALS_REL, "pending"), vault);
   if (!existsSync(dir)) return Object.freeze([]);
 
   const out: Array<{
@@ -197,13 +180,9 @@ export function listPendingSkillProposals(vault: string): ReadonlyArray<{
     if (typeof fm["id"] !== "string") continue;
     out.push({
       id: fm["id"],
-      slug:
-        typeof fm["slug"] === "string"
-          ? fm["slug"]
-          : fm["id"].replace(/^prop-/, ""),
+      slug: typeof fm["slug"] === "string" ? fm["slug"] : fm["id"].replace(/^prop-/, ""),
       status: typeof fm["status"] === "string" ? fm["status"] : "pending",
-      patternKind:
-        typeof fm["pattern_kind"] === "string" ? fm["pattern_kind"] : "unknown",
+      patternKind: typeof fm["pattern_kind"] === "string" ? fm["pattern_kind"] : "unknown",
     });
   }
   return Object.freeze(out);
@@ -331,15 +310,9 @@ function readWatermark(vault: string): WatermarkState {
   const path = watermarkPath(vault);
   if (!existsSync(path)) return { lastCreatedAt: null, lastId: null };
   try {
-    const parsed = JSON.parse(readFileSync(path, "utf8")) as Record<
-      string,
-      unknown
-    >;
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
     return {
-      lastCreatedAt:
-        typeof parsed["lastCreatedAt"] === "string"
-          ? parsed["lastCreatedAt"]
-          : null,
+      lastCreatedAt: typeof parsed["lastCreatedAt"] === "string" ? parsed["lastCreatedAt"] : null,
       lastId: typeof parsed["lastId"] === "string" ? parsed["lastId"] : null,
     };
   } catch {
@@ -437,9 +410,7 @@ function detectCandidates(
     temporalMap.set(key, bucket);
   }
   for (const [key, bucket] of temporalMap) {
-    const daySet = new Set(
-      bucket.map((record) => record.createdAt.slice(0, 10)),
-    );
+    const daySet = new Set(bucket.map((record) => record.createdAt.slice(0, 10)));
     if (daySet.size < minSupport) continue;
     out.push({
       patternKind: "temporal_routine",
@@ -452,8 +423,7 @@ function detectCandidates(
 
   return out.toSorted(
     (left, right) =>
-      left.patternKind.localeCompare(right.patternKind) ||
-      left.key.localeCompare(right.key),
+      left.patternKind.localeCompare(right.patternKind) || left.key.localeCompare(right.key),
   );
 }
 
@@ -520,10 +490,7 @@ function evidenceSnippet(record: ContinuityRecord): string {
   return "";
 }
 
-function proposalSlug(
-  candidate: ProposalCandidate,
-  payloadHash: string,
-): string {
+function proposalSlug(candidate: ProposalCandidate, payloadHash: string): string {
   const keySlug = slugify(candidate.key).slice(0, 40);
   return `${candidate.patternKind}-${keySlug}-${payloadHash.slice(0, 8)}`;
 }
@@ -541,16 +508,10 @@ function candidateHash(candidate: ProposalCandidate): string {
     .digest("hex");
 }
 
-function renderAcceptedProcedureBody(
-  proposalId: string,
-  proposalBody: string,
-): string {
+function renderAcceptedProcedureBody(proposalId: string, proposalBody: string): string {
   const marker = "## Suggested skill body";
   const idx = proposalBody.indexOf(marker);
-  const suggested =
-    idx >= 0
-      ? proposalBody.slice(idx + marker.length).trim()
-      : proposalBody.trim();
+  const suggested = idx >= 0 ? proposalBody.slice(idx + marker.length).trim() : proposalBody.trim();
   return [
     "# Procedure",
     "",

--- a/src/core/brain/skill-proposals.ts
+++ b/src/core/brain/skill-proposals.ts
@@ -1,10 +1,18 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  unlinkSync,
+} from "node:fs";
 import { basename, dirname, join } from "node:path";
 
 import { parseFrontmatter, slugify, writeFrontmatterAtomic } from "../vault.ts";
 import { atomicWriteFileSync } from "../fs-atomic.ts";
 import { ensureInsideVault } from "../path-safety.ts";
+import { rebuildProceduralHints } from "./procedural-hints.ts";
+import { rebuildProceduralGraph } from "./procedural-graph.ts";
 import {
   BRAIN_SKILL_PROPOSALS_REL,
   procedurePath,
@@ -13,7 +21,10 @@ import {
   skillProposalPendingPath,
   skillProposalRejectedPath,
 } from "./paths.ts";
-import { listContinuityRecords, type ContinuityRecord } from "./continuity/store.ts";
+import {
+  listContinuityRecords,
+  type ContinuityRecord,
+} from "./continuity/store.ts";
 
 export type SkillProposalPatternKind =
   | "repeated_action"
@@ -75,7 +86,8 @@ export function learnSkillProposals(
     })
     .toSorted(
       (left, right) =>
-        left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
+        left.createdAt.localeCompare(right.createdAt) ||
+        left.id.localeCompare(right.id),
     );
 
   if (records.length === 0) {
@@ -101,7 +113,11 @@ export function learnSkillProposals(
     const acceptedPath = skillProposalAcceptedPath(vault, slug);
     const rejectedPath = skillProposalRejectedPath(vault, slug);
 
-    if (existsSync(pendingPath) || existsSync(acceptedPath) || existsSync(rejectedPath)) {
+    if (
+      existsSync(pendingPath) ||
+      existsSync(acceptedPath) ||
+      existsSync(rejectedPath)
+    ) {
       suppressed.push(proposalId);
       continue;
     }
@@ -143,6 +159,8 @@ export function learnSkillProposals(
     lastCreatedAt: watermarkTo,
     lastId: watermarkRecord.id,
   });
+  const graph = rebuildProceduralGraph(vault);
+  rebuildProceduralHints(vault, { graph });
 
   return {
     watermarkFrom: watermark.lastCreatedAt,
@@ -159,7 +177,10 @@ export function listPendingSkillProposals(vault: string): ReadonlyArray<{
   status: string;
   patternKind: string;
 }> {
-  const dir = ensureInsideVault(join(vault, BRAIN_SKILL_PROPOSALS_REL, "pending"), vault);
+  const dir = ensureInsideVault(
+    join(vault, BRAIN_SKILL_PROPOSALS_REL, "pending"),
+    vault,
+  );
   if (!existsSync(dir)) return Object.freeze([]);
 
   const out: Array<{
@@ -176,9 +197,13 @@ export function listPendingSkillProposals(vault: string): ReadonlyArray<{
     if (typeof fm["id"] !== "string") continue;
     out.push({
       id: fm["id"],
-      slug: typeof fm["slug"] === "string" ? fm["slug"] : fm["id"].replace(/^prop-/, ""),
+      slug:
+        typeof fm["slug"] === "string"
+          ? fm["slug"]
+          : fm["id"].replace(/^prop-/, ""),
       status: typeof fm["status"] === "string" ? fm["status"] : "pending",
-      patternKind: typeof fm["pattern_kind"] === "string" ? fm["pattern_kind"] : "unknown",
+      patternKind:
+        typeof fm["pattern_kind"] === "string" ? fm["pattern_kind"] : "unknown",
     });
   }
   return Object.freeze(out);
@@ -246,6 +271,8 @@ export function acceptSkillProposal(
   }
 
   unlinkSync(pendingPath);
+  const graph = rebuildProceduralGraph(vault);
+  rebuildProceduralHints(vault, { graph });
   return {
     id,
     slug,
@@ -295,6 +322,8 @@ export function rejectSkillProposal(
   );
 
   unlinkSync(pendingPath);
+  const graph = rebuildProceduralGraph(vault);
+  rebuildProceduralHints(vault, { graph });
   return { id, slug, status: "rejected", proposalPath: rejectedPath };
 }
 
@@ -302,9 +331,15 @@ function readWatermark(vault: string): WatermarkState {
   const path = watermarkPath(vault);
   if (!existsSync(path)) return { lastCreatedAt: null, lastId: null };
   try {
-    const parsed = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Record<
+      string,
+      unknown
+    >;
     return {
-      lastCreatedAt: typeof parsed["lastCreatedAt"] === "string" ? parsed["lastCreatedAt"] : null,
+      lastCreatedAt:
+        typeof parsed["lastCreatedAt"] === "string"
+          ? parsed["lastCreatedAt"]
+          : null,
       lastId: typeof parsed["lastId"] === "string" ? parsed["lastId"] : null,
     };
   } catch {
@@ -402,7 +437,9 @@ function detectCandidates(
     temporalMap.set(key, bucket);
   }
   for (const [key, bucket] of temporalMap) {
-    const daySet = new Set(bucket.map((record) => record.createdAt.slice(0, 10)));
+    const daySet = new Set(
+      bucket.map((record) => record.createdAt.slice(0, 10)),
+    );
     if (daySet.size < minSupport) continue;
     out.push({
       patternKind: "temporal_routine",
@@ -415,7 +452,8 @@ function detectCandidates(
 
   return out.toSorted(
     (left, right) =>
-      left.patternKind.localeCompare(right.patternKind) || left.key.localeCompare(right.key),
+      left.patternKind.localeCompare(right.patternKind) ||
+      left.key.localeCompare(right.key),
   );
 }
 
@@ -482,7 +520,10 @@ function evidenceSnippet(record: ContinuityRecord): string {
   return "";
 }
 
-function proposalSlug(candidate: ProposalCandidate, payloadHash: string): string {
+function proposalSlug(
+  candidate: ProposalCandidate,
+  payloadHash: string,
+): string {
   const keySlug = slugify(candidate.key).slice(0, 40);
   return `${candidate.patternKind}-${keySlug}-${payloadHash.slice(0, 8)}`;
 }
@@ -500,10 +541,16 @@ function candidateHash(candidate: ProposalCandidate): string {
     .digest("hex");
 }
 
-function renderAcceptedProcedureBody(proposalId: string, proposalBody: string): string {
+function renderAcceptedProcedureBody(
+  proposalId: string,
+  proposalBody: string,
+): string {
   const marker = "## Suggested skill body";
   const idx = proposalBody.indexOf(marker);
-  const suggested = idx >= 0 ? proposalBody.slice(idx + marker.length).trim() : proposalBody.trim();
+  const suggested =
+    idx >= 0
+      ? proposalBody.slice(idx + marker.length).trim()
+      : proposalBody.trim();
   return [
     "# Procedure",
     "",

--- a/src/core/brain/skill-proposals.ts
+++ b/src/core/brain/skill-proposals.ts
@@ -1,5 +1,11 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  unlinkSync,
+} from "node:fs";
 import { basename, dirname, join } from "node:path";
 
 import { parseFrontmatter, slugify, writeFrontmatterAtomic } from "../vault.ts";
@@ -7,6 +13,7 @@ import { atomicWriteFileSync } from "../fs-atomic.ts";
 import { ensureInsideVault } from "../path-safety.ts";
 import { rebuildProceduralHints } from "./procedural-hints.ts";
 import { rebuildProceduralGraph } from "./procedural-graph.ts";
+import { reconcileProceduralMemory } from "./procedural-memory.ts";
 import {
   BRAIN_SKILL_PROPOSALS_REL,
   procedurePath,
@@ -15,7 +22,10 @@ import {
   skillProposalPendingPath,
   skillProposalRejectedPath,
 } from "./paths.ts";
-import { listContinuityRecords, type ContinuityRecord } from "./continuity/store.ts";
+import {
+  listContinuityRecords,
+  type ContinuityRecord,
+} from "./continuity/store.ts";
 
 export type SkillProposalPatternKind =
   | "repeated_action"
@@ -58,6 +68,7 @@ interface WatermarkState {
 }
 
 const DEFAULT_MIN_SUPPORT = 3;
+const DEFAULT_PROCEDURAL_ROOTS = ["Brain/procedures", "skills"] as const;
 
 export function learnSkillProposals(
   vault: string,
@@ -77,7 +88,8 @@ export function learnSkillProposals(
     })
     .toSorted(
       (left, right) =>
-        left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
+        left.createdAt.localeCompare(right.createdAt) ||
+        left.id.localeCompare(right.id),
     );
 
   if (records.length === 0) {
@@ -103,7 +115,11 @@ export function learnSkillProposals(
     const acceptedPath = skillProposalAcceptedPath(vault, slug);
     const rejectedPath = skillProposalRejectedPath(vault, slug);
 
-    if (existsSync(pendingPath) || existsSync(acceptedPath) || existsSync(rejectedPath)) {
+    if (
+      existsSync(pendingPath) ||
+      existsSync(acceptedPath) ||
+      existsSync(rejectedPath)
+    ) {
       suppressed.push(proposalId);
       continue;
     }
@@ -163,7 +179,10 @@ export function listPendingSkillProposals(vault: string): ReadonlyArray<{
   status: string;
   patternKind: string;
 }> {
-  const dir = ensureInsideVault(join(vault, BRAIN_SKILL_PROPOSALS_REL, "pending"), vault);
+  const dir = ensureInsideVault(
+    join(vault, BRAIN_SKILL_PROPOSALS_REL, "pending"),
+    vault,
+  );
   if (!existsSync(dir)) return Object.freeze([]);
 
   const out: Array<{
@@ -180,9 +199,13 @@ export function listPendingSkillProposals(vault: string): ReadonlyArray<{
     if (typeof fm["id"] !== "string") continue;
     out.push({
       id: fm["id"],
-      slug: typeof fm["slug"] === "string" ? fm["slug"] : fm["id"].replace(/^prop-/, ""),
+      slug:
+        typeof fm["slug"] === "string"
+          ? fm["slug"]
+          : fm["id"].replace(/^prop-/, ""),
       status: typeof fm["status"] === "string" ? fm["status"] : "pending",
-      patternKind: typeof fm["pattern_kind"] === "string" ? fm["pattern_kind"] : "unknown",
+      patternKind:
+        typeof fm["pattern_kind"] === "string" ? fm["pattern_kind"] : "unknown",
     });
   }
   return Object.freeze(out);
@@ -250,6 +273,9 @@ export function acceptSkillProposal(
   }
 
   unlinkSync(pendingPath);
+  reconcileProceduralMemory(vault, {
+    roots: DEFAULT_PROCEDURAL_ROOTS.map((root) => join(vault, root)),
+  });
   const graph = rebuildProceduralGraph(vault);
   rebuildProceduralHints(vault, { graph });
   return {
@@ -301,6 +327,9 @@ export function rejectSkillProposal(
   );
 
   unlinkSync(pendingPath);
+  reconcileProceduralMemory(vault, {
+    roots: DEFAULT_PROCEDURAL_ROOTS.map((root) => join(vault, root)),
+  });
   const graph = rebuildProceduralGraph(vault);
   rebuildProceduralHints(vault, { graph });
   return { id, slug, status: "rejected", proposalPath: rejectedPath };
@@ -310,9 +339,15 @@ function readWatermark(vault: string): WatermarkState {
   const path = watermarkPath(vault);
   if (!existsSync(path)) return { lastCreatedAt: null, lastId: null };
   try {
-    const parsed = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Record<
+      string,
+      unknown
+    >;
     return {
-      lastCreatedAt: typeof parsed["lastCreatedAt"] === "string" ? parsed["lastCreatedAt"] : null,
+      lastCreatedAt:
+        typeof parsed["lastCreatedAt"] === "string"
+          ? parsed["lastCreatedAt"]
+          : null,
       lastId: typeof parsed["lastId"] === "string" ? parsed["lastId"] : null,
     };
   } catch {
@@ -410,7 +445,9 @@ function detectCandidates(
     temporalMap.set(key, bucket);
   }
   for (const [key, bucket] of temporalMap) {
-    const daySet = new Set(bucket.map((record) => record.createdAt.slice(0, 10)));
+    const daySet = new Set(
+      bucket.map((record) => record.createdAt.slice(0, 10)),
+    );
     if (daySet.size < minSupport) continue;
     out.push({
       patternKind: "temporal_routine",
@@ -423,7 +460,8 @@ function detectCandidates(
 
   return out.toSorted(
     (left, right) =>
-      left.patternKind.localeCompare(right.patternKind) || left.key.localeCompare(right.key),
+      left.patternKind.localeCompare(right.patternKind) ||
+      left.key.localeCompare(right.key),
   );
 }
 
@@ -490,7 +528,10 @@ function evidenceSnippet(record: ContinuityRecord): string {
   return "";
 }
 
-function proposalSlug(candidate: ProposalCandidate, payloadHash: string): string {
+function proposalSlug(
+  candidate: ProposalCandidate,
+  payloadHash: string,
+): string {
   const keySlug = slugify(candidate.key).slice(0, 40);
   return `${candidate.patternKind}-${keySlug}-${payloadHash.slice(0, 8)}`;
 }
@@ -508,10 +549,16 @@ function candidateHash(candidate: ProposalCandidate): string {
     .digest("hex");
 }
 
-function renderAcceptedProcedureBody(proposalId: string, proposalBody: string): string {
+function renderAcceptedProcedureBody(
+  proposalId: string,
+  proposalBody: string,
+): string {
   const marker = "## Suggested skill body";
   const idx = proposalBody.indexOf(marker);
-  const suggested = idx >= 0 ? proposalBody.slice(idx + marker.length).trim() : proposalBody.trim();
+  const suggested =
+    idx >= 0
+      ? proposalBody.slice(idx + marker.length).trim()
+      : proposalBody.trim();
   return [
     "# Procedure",
     "",

--- a/src/core/brain/skill-proposals.ts
+++ b/src/core/brain/skill-proposals.ts
@@ -1,11 +1,5 @@
 import { createHash } from "node:crypto";
-import {
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  unlinkSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 
 import { parseFrontmatter, slugify, writeFrontmatterAtomic } from "../vault.ts";
@@ -19,10 +13,7 @@ import {
   skillProposalPendingPath,
   skillProposalRejectedPath,
 } from "./paths.ts";
-import {
-  listContinuityRecords,
-  type ContinuityRecord,
-} from "./continuity/store.ts";
+import { listContinuityRecords, type ContinuityRecord } from "./continuity/store.ts";
 
 export type SkillProposalPatternKind =
   | "repeated_action"
@@ -84,8 +75,7 @@ export function learnSkillProposals(
     })
     .toSorted(
       (left, right) =>
-        left.createdAt.localeCompare(right.createdAt) ||
-        left.id.localeCompare(right.id),
+        left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
     );
 
   if (records.length === 0) {
@@ -111,11 +101,7 @@ export function learnSkillProposals(
     const acceptedPath = skillProposalAcceptedPath(vault, slug);
     const rejectedPath = skillProposalRejectedPath(vault, slug);
 
-    if (
-      existsSync(pendingPath) ||
-      existsSync(acceptedPath) ||
-      existsSync(rejectedPath)
-    ) {
+    if (existsSync(pendingPath) || existsSync(acceptedPath) || existsSync(rejectedPath)) {
       suppressed.push(proposalId);
       continue;
     }
@@ -173,10 +159,7 @@ export function listPendingSkillProposals(vault: string): ReadonlyArray<{
   status: string;
   patternKind: string;
 }> {
-  const dir = ensureInsideVault(
-    join(vault, BRAIN_SKILL_PROPOSALS_REL, "pending"),
-    vault,
-  );
+  const dir = ensureInsideVault(join(vault, BRAIN_SKILL_PROPOSALS_REL, "pending"), vault);
   if (!existsSync(dir)) return Object.freeze([]);
 
   const out: Array<{
@@ -193,13 +176,9 @@ export function listPendingSkillProposals(vault: string): ReadonlyArray<{
     if (typeof fm["id"] !== "string") continue;
     out.push({
       id: fm["id"],
-      slug:
-        typeof fm["slug"] === "string"
-          ? fm["slug"]
-          : fm["id"].replace(/^prop-/, ""),
+      slug: typeof fm["slug"] === "string" ? fm["slug"] : fm["id"].replace(/^prop-/, ""),
       status: typeof fm["status"] === "string" ? fm["status"] : "pending",
-      patternKind:
-        typeof fm["pattern_kind"] === "string" ? fm["pattern_kind"] : "unknown",
+      patternKind: typeof fm["pattern_kind"] === "string" ? fm["pattern_kind"] : "unknown",
     });
   }
   return Object.freeze(out);
@@ -323,15 +302,9 @@ function readWatermark(vault: string): WatermarkState {
   const path = watermarkPath(vault);
   if (!existsSync(path)) return { lastCreatedAt: null, lastId: null };
   try {
-    const parsed = JSON.parse(readFileSync(path, "utf8")) as Record<
-      string,
-      unknown
-    >;
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
     return {
-      lastCreatedAt:
-        typeof parsed["lastCreatedAt"] === "string"
-          ? parsed["lastCreatedAt"]
-          : null,
+      lastCreatedAt: typeof parsed["lastCreatedAt"] === "string" ? parsed["lastCreatedAt"] : null,
       lastId: typeof parsed["lastId"] === "string" ? parsed["lastId"] : null,
     };
   } catch {
@@ -429,9 +402,7 @@ function detectCandidates(
     temporalMap.set(key, bucket);
   }
   for (const [key, bucket] of temporalMap) {
-    const daySet = new Set(
-      bucket.map((record) => record.createdAt.slice(0, 10)),
-    );
+    const daySet = new Set(bucket.map((record) => record.createdAt.slice(0, 10)));
     if (daySet.size < minSupport) continue;
     out.push({
       patternKind: "temporal_routine",
@@ -444,8 +415,7 @@ function detectCandidates(
 
   return out.toSorted(
     (left, right) =>
-      left.patternKind.localeCompare(right.patternKind) ||
-      left.key.localeCompare(right.key),
+      left.patternKind.localeCompare(right.patternKind) || left.key.localeCompare(right.key),
   );
 }
 
@@ -512,10 +482,7 @@ function evidenceSnippet(record: ContinuityRecord): string {
   return "";
 }
 
-function proposalSlug(
-  candidate: ProposalCandidate,
-  payloadHash: string,
-): string {
+function proposalSlug(candidate: ProposalCandidate, payloadHash: string): string {
   const keySlug = slugify(candidate.key).slice(0, 40);
   return `${candidate.patternKind}-${keySlug}-${payloadHash.slice(0, 8)}`;
 }
@@ -533,16 +500,10 @@ function candidateHash(candidate: ProposalCandidate): string {
     .digest("hex");
 }
 
-function renderAcceptedProcedureBody(
-  proposalId: string,
-  proposalBody: string,
-): string {
+function renderAcceptedProcedureBody(proposalId: string, proposalBody: string): string {
   const marker = "## Suggested skill body";
   const idx = proposalBody.indexOf(marker);
-  const suggested =
-    idx >= 0
-      ? proposalBody.slice(idx + marker.length).trim()
-      : proposalBody.trim();
+  const suggested = idx >= 0 ? proposalBody.slice(idx + marker.length).trim() : proposalBody.trim();
   return [
     "# Procedure",
     "",

--- a/src/mcp/brain-tools.ts
+++ b/src/mcp/brain-tools.ts
@@ -42,7 +42,10 @@ import { existsSync, readFileSync } from "node:fs";
 
 import { resolveAgentName, resolveLinkOutputFormat } from "../core/config.ts";
 import { brainActivePath, brainDirs } from "../core/brain/paths.ts";
-import { regenerateActive, type RegenerateActiveResult } from "../core/brain/active.ts";
+import {
+  regenerateActive,
+  type RegenerateActiveResult,
+} from "../core/brain/active.ts";
 import { parseFrontmatter } from "../core/vault.ts";
 import {
   appendApplyEvidence,
@@ -53,7 +56,10 @@ import { buildBacklinkIndex } from "../core/brain/backlinks.ts";
 import { readPrefAudit } from "../core/brain/pref-audit.ts";
 import { buildMorningBrief } from "../core/brain/morning-brief.ts";
 import { aggregateSources } from "../core/brain/portability/sources.ts";
-import { switchProfile, listProfiles } from "../core/brain/portability/profiles.ts";
+import {
+  switchProfile,
+  listProfiles,
+} from "../core/brain/portability/profiles.ts";
 import { defaultConfigPath } from "../core/config.ts";
 import { findUnlinkedMentions } from "../core/brain/link-graph/unlinked-mentions.ts";
 import { buildConceptCluster } from "../core/brain/link-graph/concept-cluster.ts";
@@ -66,7 +72,10 @@ import { findStaleEntries } from "../core/brain/temporal/stale-watch.ts";
 import { buildDailyBrief } from "../core/brain/temporal/daily-brief.ts";
 import { buildWeeklySynthesis } from "../core/brain/temporal/weekly-brief.ts";
 import { loadTemporalConfigSafe } from "../core/brain/policy.ts";
-import { isBrainLogEventKind, type BrainLogEventKind } from "../core/brain/types.ts";
+import {
+  isBrainLogEventKind,
+  type BrainLogEventKind,
+} from "../core/brain/types.ts";
 import { packContext } from "../core/brain/context-pack.ts";
 import { buildPreCompressPack } from "../core/brain/pre-compress-pack.ts";
 import {
@@ -111,18 +120,34 @@ import {
   reconcileProceduralMemory,
 } from "../core/brain/procedural-memory.ts";
 import {
+  readProceduralGraph,
+  rebuildProceduralGraph,
+} from "../core/brain/procedural-graph.ts";
+import {
+  readProceduralHints,
+  rebuildProceduralHints,
+} from "../core/brain/procedural-hints.ts";
+import {
   applyRecurrenceEvidence,
   getRecurrenceEntry,
   listRecurrenceEntries,
   purgeRecurrenceSource,
 } from "../core/brain/recurrence.ts";
+import {
+  evaluateAttentionFlow,
+  listAttentionFlows,
+  renderAttentionFlow,
+} from "../core/brain/attention-flows.ts";
 import { collectMaintenanceActions } from "../core/brain/maintenance/collect.ts";
 import { normaliseWikilinkTarget } from "../core/brain/wikilink.ts";
 import { renderDigest, type DigestFormat } from "../core/brain/digest.ts";
 import { dream } from "../core/brain/dream.ts";
 import { buildIntentReview } from "../core/brain/intent-review.ts";
 import { buildRetentionReview } from "../core/brain/retention.ts";
-import { buildMonthlyReview, normalizeMonthlyReviewMonth } from "../core/brain/monthly-review.ts";
+import {
+  buildMonthlyReview,
+  normalizeMonthlyReviewMonth,
+} from "../core/brain/monthly-review.ts";
 import { buildReviewCandidates } from "../core/brain/review-candidates.ts";
 import { runDoctor } from "../core/brain/doctor.ts";
 import { buildOperatorSummary } from "../core/brain/trust/operator-summary.ts";
@@ -133,7 +158,10 @@ import {
   queryByPreference,
   queryByTopic,
 } from "../core/brain/query.ts";
-import { diffAgentSources, type AgentSourceDiffMode } from "../core/brain/agent-source/diff.ts";
+import {
+  diffAgentSources,
+  type AgentSourceDiffMode,
+} from "../core/brain/agent-source/diff.ts";
 import { queryAgentSources } from "../core/brain/agent-source/query.ts";
 import type { AgentSourceContributionKind } from "../core/brain/agent-source/types.ts";
 import { writeSignal } from "../core/brain/signal.ts";
@@ -252,7 +280,9 @@ async function toolBrainFeedback(
       },
     });
   } catch (err) {
-    process.stderr.write(`warning: append feedback log failed: ${(err as Error).message}\n`);
+    process.stderr.write(
+      `warning: append feedback log failed: ${(err as Error).message}\n`,
+    );
   }
 
   let prefResult: { path: string; id: string } | null = null;
@@ -326,7 +356,9 @@ async function toolBrainDream(
   const dryRun = coerceBool(args, "dry_run");
   const nowDate = coerceIsoDate(args, "now");
   const agentArg = coerceStr(args, "agent", false);
-  const agent = normalizeAgentArgument(agentArg) ?? resolveAgentName(ctx.configPath ?? undefined);
+  const agent =
+    normalizeAgentArgument(agentArg) ??
+    resolveAgentName(ctx.configPath ?? undefined);
 
   const summary = dream(ctx.vault, {
     dryRun,
@@ -366,7 +398,9 @@ async function toolBrainDream(
     snapshot_path: summary.snapshot_path
       ? vaultRelativeSafe(ctx.vault, summary.snapshot_path)
       : null,
-    log_path: summary.log_path ? vaultRelativeSafe(ctx.vault, summary.log_path) : null,
+    log_path: summary.log_path
+      ? vaultRelativeSafe(ctx.vault, summary.log_path)
+      : null,
   };
 }
 
@@ -397,7 +431,10 @@ async function toolBrainRetention(
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
   const nowDate = coerceIsoDate(args, "now");
-  const report = buildRetentionReview(ctx.vault, nowDate ? { now: nowDate } : {});
+  const report = buildRetentionReview(
+    ctx.vault,
+    nowDate ? { now: nowDate } : {},
+  );
   return {
     schema_version: report.schema_version,
     generated_at: report.generated_at,
@@ -420,12 +457,18 @@ async function toolBrainMonthlyReview(
   let month: string | undefined;
   if (monthRaw !== undefined && monthRaw !== null) {
     if (typeof monthRaw !== "string") {
-      throw new MCPError(INVALID_PARAMS, "brain_monthly_review: month must be YYYY-MM");
+      throw new MCPError(
+        INVALID_PARAMS,
+        "brain_monthly_review: month must be YYYY-MM",
+      );
     }
     try {
       month = normalizeMonthlyReviewMonth(monthRaw);
     } catch {
-      throw new MCPError(INVALID_PARAMS, "brain_monthly_review: month must be YYYY-MM");
+      throw new MCPError(
+        INVALID_PARAMS,
+        "brain_monthly_review: month must be YYYY-MM",
+      );
     }
   }
   const report = buildMonthlyReview(ctx.vault, month ? { month } : {});
@@ -443,7 +486,10 @@ async function toolBrainReviewCandidates(
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
   const nowDate = coerceIsoDate(args, "now");
-  const report = buildReviewCandidates(ctx.vault, nowDate ? { now: nowDate } : {});
+  const report = buildReviewCandidates(
+    ctx.vault,
+    nowDate ? { now: nowDate } : {},
+  );
   return {
     would_create: [...report.would_create],
     would_promote: [...report.would_promote],
@@ -503,7 +549,9 @@ async function toolBrainApplyEvidence(
   const agentArg = coerceStr(args, "agent", false);
   const note = coerceStr(args, "note", false);
 
-  const agent = normalizeAgentArgument(agentArg) ?? resolveAgentName(ctx.configPath ?? undefined);
+  const agent =
+    normalizeAgentArgument(agentArg) ??
+    resolveAgentName(ctx.configPath ?? undefined);
 
   const input: AppendApplyEvidenceInput = {
     pref_id: prefId,
@@ -572,7 +620,9 @@ async function toolBrainNote(
     // any other failure is an I/O / filesystem fault from `appendLogEvent`
     // and must not be reported as a client-side INVALID_PARAMS.
     const message = (err as Error).message ?? String(err);
-    const code = message.startsWith("brain_note:") ? INVALID_PARAMS : INTERNAL_ERROR;
+    const code = message.startsWith("brain_note:")
+      ? INVALID_PARAMS
+      : INTERNAL_ERROR;
     throw new MCPError(code, message);
   }
   return {
@@ -587,7 +637,9 @@ async function toolBrainNote(
 
 type PinnedContextOperation = "read" | "write" | "append" | "clear";
 
-function coercePinnedContextOperation(args: Record<string, unknown>): PinnedContextOperation {
+function coercePinnedContextOperation(
+  args: Record<string, unknown>,
+): PinnedContextOperation {
   const operation = coerceStr(args, "operation", false) ?? "read";
   if (
     operation !== "read" &&
@@ -635,7 +687,10 @@ async function toolBrainPinnedContext(
   return serializePinnedContext(ctx, pinned, operation);
 }
 
-function appendPinnedToContextContent(activeContent: string, pinnedContent: string): string {
+function appendPinnedToContextContent(
+  activeContent: string,
+  pinnedContent: string,
+): string {
   if (pinnedContent.length === 0) return activeContent;
   const pinnedBlock = `## Pinned context\n\n${pinnedContent}`;
   const trimmedActive = activeContent.trimEnd();
@@ -667,7 +722,9 @@ const EMPTY_CONTEXT_COUNTS: BrainContextCounts = {
  *                                        rewrite; the on-disk body is
  *                                        returned verbatim.
  */
-async function toolBrainContext(ctx: ServerContext): Promise<Record<string, unknown>> {
+async function toolBrainContext(
+  ctx: ServerContext,
+): Promise<Record<string, unknown>> {
   const dirs = brainDirs(ctx.vault);
   const activePath = brainActivePath(ctx.vault);
   const pinned = readPinnedContext(ctx.vault);
@@ -940,7 +997,9 @@ async function toolBrainAudit(
     .replace(/^(?:pref-|ret-)/, "")
     .trim();
   if (slug.length === 0) {
-    throw new Error(`brain_audit: empty preference slug after normalising '${raw}'`);
+    throw new Error(
+      `brain_audit: empty preference slug after normalising '${raw}'`,
+    );
   }
   const prefId = `pref-${slug}`;
   const { records, warnings } = readPrefAudit(ctx.vault, prefId);
@@ -957,13 +1016,18 @@ async function toolBrainMorningBrief(
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
   const topK = optionalPositiveInt(args, "top_k", "brain_morning_brief") ?? 10;
-  const lookbackDays = optionalPositiveInt(args, "lookback_days", "brain_morning_brief") ?? 7;
+  const lookbackDays =
+    optionalPositiveInt(args, "lookback_days", "brain_morning_brief") ?? 7;
   const maxCharsPerMemory = optionalPositiveInt(
     args,
     "max_chars_per_memory",
     "brain_morning_brief",
   );
-  const maxTotalChars = optionalPositiveInt(args, "max_total_chars", "brain_morning_brief");
+  const maxTotalChars = optionalPositiveInt(
+    args,
+    "max_total_chars",
+    "brain_morning_brief",
+  );
   const brief = buildMorningBrief(ctx.vault, {
     now: new Date(),
     topK,
@@ -1002,9 +1066,12 @@ async function toolBrainSwitchVault(
   try {
     switchProfile(configPath, name);
   } catch (err) {
-    throw new Error(`brain_switch_vault: ${(err as Error).message ?? String(err)}`, {
-      cause: err,
-    });
+    throw new Error(
+      `brain_switch_vault: ${(err as Error).message ?? String(err)}`,
+      {
+        cause: err,
+      },
+    );
   }
   // The running server keeps its already-resolved vault; the switch
   // takes effect for the next server launch / CLI invocation.
@@ -1029,7 +1096,8 @@ async function toolBrainDoctor(
   // Decide a single ok flag — `strict` only changes the CLI exit code,
   // so we mirror that semantic here: with `strict`, warnings demote ok
   // to false. Errors always do.
-  const ok = result.errors.length === 0 && (!strict || result.warnings.length === 0);
+  const ok =
+    result.errors.length === 0 && (!strict || result.warnings.length === 0);
 
   return {
     format,
@@ -1039,13 +1107,17 @@ async function toolBrainDoctor(
       severity: i.severity,
       code: i.code,
       message: i.message,
-      ...(i.path !== undefined ? { path: vaultRelativeSafe(ctx.vault, i.path) } : {}),
+      ...(i.path !== undefined
+        ? { path: vaultRelativeSafe(ctx.vault, i.path) }
+        : {}),
     })),
     warnings: result.warnings.map((i) => ({
       severity: i.severity,
       code: i.code,
       message: i.message,
-      ...(i.path !== undefined ? { path: vaultRelativeSafe(ctx.vault, i.path) } : {}),
+      ...(i.path !== undefined
+        ? { path: vaultRelativeSafe(ctx.vault, i.path) }
+        : {}),
     })),
     // v0.10.15: ranked maintenance actions surfaced as a parallel
     // signal to errors/warnings. The list is independent of `strict`
@@ -1064,12 +1136,16 @@ async function toolBrainDoctor(
     // surface, so it stays absent here). `instruction_file_warnings`
     // surfaces vault-root instruction files exceeding the configured
     // ceiling.
-    ...(result.trust_verdict !== undefined ? { trust_verdict: result.trust_verdict } : {}),
-    instruction_file_warnings: (result.instruction_file_warnings ?? []).map((w) => ({
-      path: w.path,
-      lines: w.lines,
-      ceiling: w.ceiling,
-    })),
+    ...(result.trust_verdict !== undefined
+      ? { trust_verdict: result.trust_verdict }
+      : {}),
+    instruction_file_warnings: (result.instruction_file_warnings ?? []).map(
+      (w) => ({
+        path: w.path,
+        lines: w.lines,
+        ceiling: w.ceiling,
+      }),
+    ),
   };
 }
 
@@ -1123,7 +1199,9 @@ function serializeSignal(s: BrainSignal): Record<string, unknown> {
   };
 }
 
-function serializePreference(p: BrainPreference | BrainRetired): Record<string, unknown> {
+function serializePreference(
+  p: BrainPreference | BrainRetired,
+): Record<string, unknown> {
   if (p.kind === "brain-retired") {
     return {
       kind: p.kind,
@@ -1132,7 +1210,9 @@ function serializePreference(p: BrainPreference | BrainRetired): Record<string, 
       retired_at: p.retired_at,
       retired_reason: p.retired_reason,
       retired_by: p.retired_by,
-      ...(p.superseded_by !== undefined ? { superseded_by: p.superseded_by } : {}),
+      ...(p.superseded_by !== undefined
+        ? { superseded_by: p.superseded_by }
+        : {}),
       created_at: p.created_at,
       topic: p.topic,
       ...(p.scope !== undefined ? { scope: p.scope } : {}),
@@ -1218,7 +1298,9 @@ export function vaultRelativeSafe(vault: string, target: string): string {
 
 // ----- Tool registration ---------------------------------------------------
 
-const PINNED_CONTEXT_OUTPUT_SCHEMA: NonNullable<ToolDefinition["outputSchema"]> = {
+const PINNED_CONTEXT_OUTPUT_SCHEMA: NonNullable<
+  ToolDefinition["outputSchema"]
+> = {
   type: "object",
   required: ["present", "path", "absolute_path", "content"],
   properties: {
@@ -1231,29 +1313,43 @@ const PINNED_CONTEXT_OUTPUT_SCHEMA: NonNullable<ToolDefinition["outputSchema"]> 
   additionalProperties: false,
 };
 
-const BRAIN_CONTEXT_OUTPUT_SCHEMA: NonNullable<ToolDefinition["outputSchema"]> = {
-  type: "object",
-  required: ["vault_path", "present", "active_path", "content", "counts", "generated_at", "pinned"],
-  properties: {
-    vault_path: { type: "string" },
-    present: { type: "boolean" },
-    active_path: { type: "string" },
-    content: { type: "string" },
-    counts: {
-      type: "object",
-      required: ["confirmed", "quarantine", "retired_recent", "most_applied_30d"],
-      properties: {
-        confirmed: { type: "integer" },
-        quarantine: { type: "integer" },
-        retired_recent: { type: "integer" },
-        most_applied_30d: { type: "integer" },
+const BRAIN_CONTEXT_OUTPUT_SCHEMA: NonNullable<ToolDefinition["outputSchema"]> =
+  {
+    type: "object",
+    required: [
+      "vault_path",
+      "present",
+      "active_path",
+      "content",
+      "counts",
+      "generated_at",
+      "pinned",
+    ],
+    properties: {
+      vault_path: { type: "string" },
+      present: { type: "boolean" },
+      active_path: { type: "string" },
+      content: { type: "string" },
+      counts: {
+        type: "object",
+        required: [
+          "confirmed",
+          "quarantine",
+          "retired_recent",
+          "most_applied_30d",
+        ],
+        properties: {
+          confirmed: { type: "integer" },
+          quarantine: { type: "integer" },
+          retired_recent: { type: "integer" },
+          most_applied_30d: { type: "integer" },
+        },
+        additionalProperties: false,
       },
-      additionalProperties: false,
+      generated_at: {},
+      pinned: PINNED_CONTEXT_OUTPUT_SCHEMA,
     },
-    generated_at: {},
-    pinned: PINNED_CONTEXT_OUTPUT_SCHEMA,
-  },
-};
+  };
 
 const BRAIN_QUERY_OUTPUT_SCHEMA: NonNullable<ToolDefinition["outputSchema"]> = {
   type: "object",
@@ -1313,7 +1409,10 @@ async function toolBrainOperatorSummary(
   } else if (typeof includeDreamRaw === "boolean") {
     includeDream = includeDreamRaw;
   } else {
-    throw new MCPError(INVALID_PARAMS, "brain_operator_summary: include_dream must be a boolean");
+    throw new MCPError(
+      INVALID_PARAMS,
+      "brain_operator_summary: include_dream must be a boolean",
+    );
   }
 
   let dreamSummary;
@@ -1365,7 +1464,10 @@ async function toolBrainUnlinkedMentions(
 ): Promise<Record<string, unknown>> {
   const idRaw = args["id"];
   if (typeof idRaw !== "string" || idRaw.trim().length === 0) {
-    throw new MCPError(INVALID_PARAMS, "brain_unlinked_mentions: id must be a non-empty string");
+    throw new MCPError(
+      INVALID_PARAMS,
+      "brain_unlinked_mentions: id must be a non-empty string",
+    );
   }
   const targetId = normaliseWikilinkTarget(idRaw);
   // Limit coercion mirrors the v0.10.16 `brain_operator_summary`
@@ -1406,7 +1508,11 @@ async function toolBrainUnlinkedMentions(
       );
     }
   }
-  const mentions = findUnlinkedMentions(ctx.vault, targetId, limit !== undefined ? { limit } : {});
+  const mentions = findUnlinkedMentions(
+    ctx.vault,
+    targetId,
+    limit !== undefined ? { limit } : {},
+  );
   return {
     vault_path: ctx.vault,
     target_id: targetId,
@@ -1431,7 +1537,10 @@ async function toolBrainConceptSynthesis(
 ): Promise<Record<string, unknown>> {
   const idRaw = args["id"];
   if (typeof idRaw !== "string" || idRaw.trim().length === 0) {
-    throw new MCPError(INVALID_PARAMS, "brain_concept_synthesis: id must be a non-empty string");
+    throw new MCPError(
+      INVALID_PARAMS,
+      "brain_concept_synthesis: id must be a non-empty string",
+    );
   }
   const includeUnlinkedRaw = args["include_unlinked"];
   let includeUnlinked = false;
@@ -1472,7 +1581,10 @@ async function toolBrainMocAudit(
 ): Promise<Record<string, unknown>> {
   const idRaw = args["id"];
   if (typeof idRaw !== "string" || idRaw.trim().length === 0) {
-    throw new MCPError(INVALID_PARAMS, "brain_moc_audit: id must be a non-empty string");
+    throw new MCPError(
+      INVALID_PARAMS,
+      "brain_moc_audit: id must be a non-empty string",
+    );
   }
   const targetId = normaliseWikilinkTarget(idRaw);
   try {
@@ -1496,26 +1608,42 @@ async function toolBrainMocAudit(
 
 // ----- Temporal subsystem MCP wrappers (v0.10.18) --------------------------
 
-function coercePositiveInteger(tool: string, field: string, raw: unknown): number | undefined {
+function coercePositiveInteger(
+  tool: string,
+  field: string,
+  raw: unknown,
+): number | undefined {
   if (raw === undefined || raw === null) return undefined;
   if (typeof raw === "number") {
     if (!Number.isInteger(raw) || raw < 1) {
-      throw new MCPError(INVALID_PARAMS, `${tool}: ${field} must be a positive integer`);
+      throw new MCPError(
+        INVALID_PARAMS,
+        `${tool}: ${field} must be a positive integer`,
+      );
     }
     return raw;
   }
   if (typeof raw === "string") {
     const trimmed = raw.trim();
     if (trimmed === "" || !/^[0-9]+$/.test(trimmed)) {
-      throw new MCPError(INVALID_PARAMS, `${tool}: ${field} must be a positive integer`);
+      throw new MCPError(
+        INVALID_PARAMS,
+        `${tool}: ${field} must be a positive integer`,
+      );
     }
     const parsed = Number.parseInt(trimmed, 10);
     if (parsed < 1) {
-      throw new MCPError(INVALID_PARAMS, `${tool}: ${field} must be a positive integer`);
+      throw new MCPError(
+        INVALID_PARAMS,
+        `${tool}: ${field} must be a positive integer`,
+      );
     }
     return parsed;
   }
-  throw new MCPError(INVALID_PARAMS, `${tool}: ${field} must be a positive integer`);
+  throw new MCPError(
+    INVALID_PARAMS,
+    `${tool}: ${field} must be a positive integer`,
+  );
 }
 
 const ISO_DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
@@ -1551,13 +1679,19 @@ function coerceIsoTimestampOrDate(
   return v;
 }
 
-function coerceEventKind(tool: string, raw: unknown): BrainLogEventKind | undefined {
+function coerceEventKind(
+  tool: string,
+  raw: unknown,
+): BrainLogEventKind | undefined {
   if (raw === undefined || raw === null) return undefined;
   if (typeof raw !== "string") {
     throw new MCPError(INVALID_PARAMS, `${tool}: kind must be a string`);
   }
   if (!isBrainLogEventKind(raw)) {
-    throw new MCPError(INVALID_PARAMS, `${tool}: kind must be a known BrainLogEventKind`);
+    throw new MCPError(
+      INVALID_PARAMS,
+      `${tool}: kind must be a known BrainLogEventKind`,
+    );
   }
   return raw;
 }
@@ -1571,11 +1705,20 @@ async function toolBrainTimeline(
   ctx: ServerContext,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const prefId = typeof args["pref_id"] === "string" ? args["pref_id"] : undefined;
+  const prefId =
+    typeof args["pref_id"] === "string" ? args["pref_id"] : undefined;
   const topic = typeof args["topic"] === "string" ? args["topic"] : undefined;
   const kind = coerceEventKind("brain_timeline", args["kind"]);
-  const since = coerceIsoTimestampOrDate("brain_timeline", "since", args["since"]);
-  const until = coerceIsoTimestampOrDate("brain_timeline", "until", args["until"]);
+  const since = coerceIsoTimestampOrDate(
+    "brain_timeline",
+    "since",
+    args["since"],
+  );
+  const until = coerceIsoTimestampOrDate(
+    "brain_timeline",
+    "until",
+    args["until"],
+  );
   const limit = coercePositiveInteger("brain_timeline", "limit", args["limit"]);
 
   const index = buildTimelineIndex(ctx.vault, {
@@ -1674,7 +1817,12 @@ async function toolBrainDailyBrief(
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
   const dateRaw = args["date"];
-  const dateCoerced = coerceIsoTimestampOrDate("brain_daily_brief", "date", dateRaw, "date-only");
+  const dateCoerced = coerceIsoTimestampOrDate(
+    "brain_daily_brief",
+    "date",
+    dateRaw,
+    "date-only",
+  );
   const date = dateCoerced ?? new Date().toISOString().slice(0, 10);
   const cfg = loadTemporalConfigSafe(ctx.vault);
   const index = buildTimelineIndex(ctx.vault, {});
@@ -1744,15 +1892,33 @@ async function toolBrainContextPack(
         ? Number.parseInt(maxRaw.trim(), 10)
         : Number.NaN;
   if (!Number.isInteger(maxTokens) || maxTokens <= 0) {
-    throw new MCPError(INVALID_PARAMS, "brain_context_pack: max_tokens must be a positive integer");
+    throw new MCPError(
+      INVALID_PARAMS,
+      "brain_context_pack: max_tokens must be a positive integer",
+    );
   }
-  const query = typeof args["query"] === "string" ? (args["query"] as string) : undefined;
+  const query =
+    typeof args["query"] === "string" ? (args["query"] as string) : undefined;
   const includeLanes = coerceBool(args, "lanes");
   const cacheStable = coerceBool(args, "cache_stable");
   const dedupRepeated = coerceBool(args, "dedup_repeated");
-  const maxCharsPerMemory = optionalPositiveInt(args, "max_chars_per_memory", "brain_context_pack");
-  const maxTotalChars = optionalPositiveInt(args, "max_total_chars", "brain_context_pack");
-  const receipt = receiptOptionsFromArgs("brain_context_pack", args, "context_pack", "mcp");
+  const attentionFlowIds = coerceStrList(args, "attention_flow_ids");
+  const maxCharsPerMemory = optionalPositiveInt(
+    args,
+    "max_chars_per_memory",
+    "brain_context_pack",
+  );
+  const maxTotalChars = optionalPositiveInt(
+    args,
+    "max_total_chars",
+    "brain_context_pack",
+  );
+  const receipt = receiptOptionsFromArgs(
+    "brain_context_pack",
+    args,
+    "context_pack",
+    "mcp",
+  );
   const telemetry = telemetryOptionsFromArgs("brain_context_pack", args, "mcp");
   const report = packContext(ctx.vault, {
     maxTokens,
@@ -1770,6 +1936,7 @@ async function toolBrainContextPack(
     ...(maxCharsPerMemory !== undefined ? { maxCharsPerMemory } : {}),
     ...(maxTotalChars !== undefined ? { maxTotalChars } : {}),
     ...(telemetry !== undefined ? { telemetry } : {}),
+    ...(attentionFlowIds.length > 0 ? { attentionFlowIds } : {}),
   });
   return {
     vault_path: ctx.vault,
@@ -1782,10 +1949,14 @@ async function toolBrainContextPack(
       tokens: i.tokens,
       body: i.body,
       trimmed: i.trimmed,
-      ...(i.originalRank !== undefined ? { original_rank: i.originalRank } : {}),
+      ...(i.originalRank !== undefined
+        ? { original_rank: i.originalRank }
+        : {}),
       ...(i.stableRank !== undefined ? { stable_rank: i.stableRank } : {}),
       ...(i.dedupedFrom !== undefined ? { deduped_from: i.dedupedFrom } : {}),
-      ...(i.referenceHint !== undefined ? { reference_hint: i.referenceHint } : {}),
+      ...(i.referenceHint !== undefined
+        ? { reference_hint: i.referenceHint }
+        : {}),
       ...(i.safety ? { safety: i.safety } : {}),
     })),
     skipped: report.skipped.map((s) => ({
@@ -1805,9 +1976,17 @@ async function toolBrainContextReceipts(
   ctx: ServerContext,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const operation = optionalStringArg("brain_context_receipts", args, "operation");
+  const operation = optionalStringArg(
+    "brain_context_receipts",
+    args,
+    "operation",
+  );
   if (operation === "list") {
-    const trigger = optionalStringArg("brain_context_receipts", args, "trigger");
+    const trigger = optionalStringArg(
+      "brain_context_receipts",
+      args,
+      "trigger",
+    );
     if (trigger !== undefined && !isContextReceiptTrigger(trigger)) {
       throw new MCPError(
         INVALID_PARAMS,
@@ -1815,8 +1994,16 @@ async function toolBrainContextReceipts(
       );
     }
     const host = optionalStringArg("brain_context_receipts", args, "host");
-    const sessionId = optionalStringArg("brain_context_receipts", args, "session_id");
-    const limit = coercePositiveInteger("brain_context_receipts", "limit", args["limit"]);
+    const sessionId = optionalStringArg(
+      "brain_context_receipts",
+      args,
+      "session_id",
+    );
+    const limit = coercePositiveInteger(
+      "brain_context_receipts",
+      "limit",
+      args["limit"],
+    );
     const receipts = listContextReceipts(ctx.vault, {
       ...(trigger !== undefined ? { trigger } : {}),
       ...(host !== undefined ? { host } : {}),
@@ -1834,11 +2021,17 @@ async function toolBrainContextReceipts(
   if (operation === "show") {
     const id = optionalStringArg("brain_context_receipts", args, "id");
     if (id === undefined) {
-      throw new MCPError(INVALID_PARAMS, "brain_context_receipts: id is required for show");
+      throw new MCPError(
+        INVALID_PARAMS,
+        "brain_context_receipts: id is required for show",
+      );
     }
     const receipt = getContextReceipt(ctx.vault, id);
     if (receipt === null) {
-      throw new MCPError(INVALID_PARAMS, `brain_context_receipts: receipt not found: ${id}`);
+      throw new MCPError(
+        INVALID_PARAMS,
+        `brain_context_receipts: receipt not found: ${id}`,
+      );
     }
     return {
       id: receipt.id,
@@ -1851,7 +2044,10 @@ async function toolBrainContextReceipts(
     };
   }
 
-  throw new MCPError(INVALID_PARAMS, "brain_context_receipts: operation must be list or show");
+  throw new MCPError(
+    INVALID_PARAMS,
+    "brain_context_receipts: operation must be list or show",
+  );
 }
 
 function optionalStringArg(
@@ -1862,14 +2058,22 @@ function optionalStringArg(
   const raw = args[key];
   if (raw === undefined || raw === null) return undefined;
   if (typeof raw !== "string" || raw.trim().length === 0) {
-    throw new MCPError(INVALID_PARAMS, `${tool}: ${key} must be a non-empty string`);
+    throw new MCPError(
+      INVALID_PARAMS,
+      `${tool}: ${key} must be a non-empty string`,
+    );
   }
   return raw.trim();
 }
 
-function requiredStringArg(tool: string, args: Record<string, unknown>, key: string): string {
+function requiredStringArg(
+  tool: string,
+  args: Record<string, unknown>,
+  key: string,
+): string {
   const value = optionalStringArg(tool, args, key);
-  if (value === undefined) throw new MCPError(INVALID_PARAMS, `${tool}: ${key} is required`);
+  if (value === undefined)
+    throw new MCPError(INVALID_PARAMS, `${tool}: ${key} is required`);
   return value;
 }
 
@@ -1879,7 +2083,11 @@ async function toolBrainRecallTelemetry(
   ctx: ServerContext,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const operation = optionalStringArg("brain_recall_telemetry", args, "operation");
+  const operation = optionalStringArg(
+    "brain_recall_telemetry",
+    args,
+    "operation",
+  );
   const filter = recallTelemetryFilter(args);
 
   if (operation === "list") {
@@ -1890,16 +2098,25 @@ async function toolBrainRecallTelemetry(
     const summary = summarizeRecallTelemetry(ctx.vault, filter);
     return { ...summary };
   }
-  throw new MCPError(INVALID_PARAMS, "brain_recall_telemetry: operation must be list or summary");
+  throw new MCPError(
+    INVALID_PARAMS,
+    "brain_recall_telemetry: operation must be list or summary",
+  );
 }
 
-function recallTelemetryFilter(args: Record<string, unknown>): RecallTelemetryFilter {
+function recallTelemetryFilter(
+  args: Record<string, unknown>,
+): RecallTelemetryFilter {
   const mode = coerceRecallTelemetryMode(args["mode"]);
   const status = coerceRecallTelemetryStatus(args["status"]);
   const host = optionalStringArg("brain_recall_telemetry", args, "host");
   const since = optionalStringArg("brain_recall_telemetry", args, "since");
   const until = optionalStringArg("brain_recall_telemetry", args, "until");
-  const limit = coercePositiveInteger("brain_recall_telemetry", "limit", args["limit"]);
+  const limit = coercePositiveInteger(
+    "brain_recall_telemetry",
+    "limit",
+    args["limit"],
+  );
   return {
     ...(mode !== undefined ? { mode } : {}),
     ...(status !== undefined ? { status } : {}),
@@ -1910,7 +2127,9 @@ function recallTelemetryFilter(args: Record<string, unknown>): RecallTelemetryFi
   };
 }
 
-function coerceRecallTelemetryMode(raw: unknown): RecallTelemetryMode | undefined {
+function coerceRecallTelemetryMode(
+  raw: unknown,
+): RecallTelemetryMode | undefined {
   if (raw === undefined || raw === null) return undefined;
   const trimmed = typeof raw === "string" ? raw.trim() : raw;
   if (!isRecallTelemetryMode(trimmed)) {
@@ -1922,7 +2141,9 @@ function coerceRecallTelemetryMode(raw: unknown): RecallTelemetryMode | undefine
   return trimmed;
 }
 
-function coerceRecallTelemetryStatus(raw: unknown): RecallTelemetryStatus | undefined {
+function coerceRecallTelemetryStatus(
+  raw: unknown,
+): RecallTelemetryStatus | undefined {
   if (raw === undefined || raw === null) return undefined;
   const trimmed = typeof raw === "string" ? raw.trim() : raw;
   if (!isRecallTelemetryStatus(trimmed)) {
@@ -1940,13 +2161,26 @@ async function toolBrainContextPresets(
   _ctx: ServerContext,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const operation = optionalStringArg("brain_context_presets", args, "operation");
+  const operation = optionalStringArg(
+    "brain_context_presets",
+    args,
+    "operation",
+  );
   if (operation === "show") {
-    const presetId = optionalStringArg("brain_context_presets", args, "preset_id");
+    const presetId = optionalStringArg(
+      "brain_context_presets",
+      args,
+      "preset_id",
+    );
     const result =
-      presetId === undefined ? { presets: listContextPresets() } : getContextPreset(presetId);
+      presetId === undefined
+        ? { presets: listContextPresets() }
+        : getContextPreset(presetId);
     if (result === null) {
-      throw new MCPError(INVALID_PARAMS, `brain_context_presets: unknown preset ${presetId}`);
+      throw new MCPError(
+        INVALID_PARAMS,
+        `brain_context_presets: unknown preset ${presetId}`,
+      );
     }
     return Array.isArray(result) ? { presets: result } : { ...result };
   }
@@ -1965,12 +2199,22 @@ async function toolBrainContextPresets(
     };
   }
   if (operation === "diff") {
-    const presetId = optionalStringArg("brain_context_presets", args, "preset_id");
+    const presetId = optionalStringArg(
+      "brain_context_presets",
+      args,
+      "preset_id",
+    );
     if (presetId === undefined) {
-      throw new MCPError(INVALID_PARAMS, "brain_context_presets: preset_id is required for diff");
+      throw new MCPError(
+        INVALID_PARAMS,
+        "brain_context_presets: preset_id is required for diff",
+      );
     }
     return {
-      ...diffContextPreset(presetId, contextPresetCurrentConfig(args["current"])),
+      ...diffContextPreset(
+        presetId,
+        contextPresetCurrentConfig(args["current"]),
+      ),
     };
   }
   throw new MCPError(
@@ -1982,7 +2226,10 @@ async function toolBrainContextPresets(
 function contextPresetCurrentConfig(raw: unknown): ContextPresetCurrentConfig {
   if (raw === undefined || raw === null) return {};
   if (typeof raw !== "object" || Array.isArray(raw)) {
-    throw new MCPError(INVALID_PARAMS, "brain_context_presets: current must be an object");
+    throw new MCPError(
+      INVALID_PARAMS,
+      "brain_context_presets: current must be an object",
+    );
   }
   return raw as ContextPresetCurrentConfig;
 }
@@ -1993,9 +2240,21 @@ async function toolBrainPreCompactExtract(
   ctx: ServerContext,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const sessionId = requiredStringArg("brain_pre_compact_extract", args, "session_id");
-  const turnStart = requiredStringArg("brain_pre_compact_extract", args, "turn_start");
-  const turnEnd = requiredStringArg("brain_pre_compact_extract", args, "turn_end");
+  const sessionId = requiredStringArg(
+    "brain_pre_compact_extract",
+    args,
+    "session_id",
+  );
+  const turnStart = requiredStringArg(
+    "brain_pre_compact_extract",
+    args,
+    "turn_start",
+  );
+  const turnEnd = requiredStringArg(
+    "brain_pre_compact_extract",
+    args,
+    "turn_end",
+  );
   const text = requiredStringArg("brain_pre_compact_extract", args, "text");
   const maxChars = coercePositiveInteger(
     "brain_pre_compact_extract",
@@ -2007,7 +2266,8 @@ async function toolBrainPreCompactExtract(
     turnStart,
     turnEnd,
     text,
-    ...(optionalStringArg("brain_pre_compact_extract", args, "host") !== undefined
+    ...(optionalStringArg("brain_pre_compact_extract", args, "host") !==
+    undefined
       ? { host: optionalStringArg("brain_pre_compact_extract", args, "host") }
       : {}),
     ...(maxChars !== undefined ? { maxChars } : {}),
@@ -2021,7 +2281,11 @@ async function toolBrainSessionGrep(
   ctx: ServerContext,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const limit = coercePositiveInteger("brain_session_grep", "limit", args["limit"]);
+  const limit = coercePositiveInteger(
+    "brain_session_grep",
+    "limit",
+    args["limit"],
+  );
   const snippetChars = coercePositiveInteger(
     "brain_session_grep",
     "snippet_chars",
@@ -2030,9 +2294,14 @@ async function toolBrainSessionGrep(
   return {
     ...searchSessionRecall(ctx.vault, {
       query: requiredStringArg("brain_session_grep", args, "query"),
-      ...(optionalStringArg("brain_session_grep", args, "session_id") !== undefined
+      ...(optionalStringArg("brain_session_grep", args, "session_id") !==
+      undefined
         ? {
-            sessionId: optionalStringArg("brain_session_grep", args, "session_id"),
+            sessionId: optionalStringArg(
+              "brain_session_grep",
+              args,
+              "session_id",
+            ),
           }
         : {}),
       ...(limit !== undefined ? { limit } : {}),
@@ -2047,7 +2316,11 @@ async function toolBrainSessionDescribe(
 ): Promise<Record<string, unknown>> {
   return {
     ...describeSessionRecall(ctx.vault, {
-      sessionId: requiredStringArg("brain_session_describe", args, "session_id"),
+      sessionId: requiredStringArg(
+        "brain_session_describe",
+        args,
+        "session_id",
+      ),
     }),
   };
 }
@@ -2056,12 +2329,17 @@ async function toolBrainSessionExpand(
   ctx: ServerContext,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const rawLimit = coercePositiveInteger("brain_session_expand", "raw_limit", args["raw_limit"]);
+  const rawLimit = coercePositiveInteger(
+    "brain_session_expand",
+    "raw_limit",
+    args["raw_limit"],
+  );
   return {
     ...expandSessionRecall(ctx.vault, {
       id: requiredStringArg("brain_session_expand", args, "id"),
       ...(rawLimit !== undefined ? { rawLimit } : {}),
-      ...(optionalStringArg("brain_session_expand", args, "cursor") !== undefined
+      ...(optionalStringArg("brain_session_expand", args, "cursor") !==
+      undefined
         ? { cursor: optionalStringArg("brain_session_expand", args, "cursor") }
         : {}),
     }),
@@ -2085,7 +2363,10 @@ function optionalPositiveInt(
         ? Number.parseInt(raw.trim(), 10)
         : Number.NaN;
   if (!Number.isInteger(n) || n <= 0) {
-    throw new MCPError(INVALID_PARAMS, `${tool}: ${key} must be a positive integer`);
+    throw new MCPError(
+      INVALID_PARAMS,
+      `${tool}: ${key} must be a positive integer`,
+    );
   }
   return n;
 }
@@ -2099,15 +2380,29 @@ async function toolBrainPreCompressPack(
   ctx: ServerContext,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const topK = optionalPositiveInt(args, "top_k", "brain_pre_compress_pack") ?? 10;
+  const topK =
+    optionalPositiveInt(args, "top_k", "brain_pre_compress_pack") ?? 10;
   const maxCharsPerMemory = optionalPositiveInt(
     args,
     "max_chars_per_memory",
     "brain_pre_compress_pack",
   );
-  const maxTotalChars = optionalPositiveInt(args, "max_total_chars", "brain_pre_compress_pack");
-  const receipt = receiptOptionsFromArgs("brain_pre_compress_pack", args, "pre_compress", "mcp");
-  const telemetry = telemetryOptionsFromArgs("brain_pre_compress_pack", args, "mcp");
+  const maxTotalChars = optionalPositiveInt(
+    args,
+    "max_total_chars",
+    "brain_pre_compress_pack",
+  );
+  const receipt = receiptOptionsFromArgs(
+    "brain_pre_compress_pack",
+    args,
+    "pre_compress",
+    "mcp",
+  );
+  const telemetry = telemetryOptionsFromArgs(
+    "brain_pre_compress_pack",
+    args,
+    "mcp",
+  );
   const pack = buildPreCompressPack(ctx.vault, {
     topK,
     ...(maxCharsPerMemory !== undefined ? { maxCharsPerMemory } : {}),
@@ -2119,7 +2414,9 @@ async function toolBrainPreCompressPack(
     vault_path: ctx.vault,
     text: pack.text,
     active_head_included: pack.activeHeadIncluded,
-    ...(pack.activeHeadSafety ? { active_head_safety: pack.activeHeadSafety } : {}),
+    ...(pack.activeHeadSafety
+      ? { active_head_safety: pack.activeHeadSafety }
+      : {}),
     total_chars: pack.totalChars,
     ...(pack.receiptId ? { receipt_id: pack.receiptId } : {}),
     ...(pack.telemetryId ? { telemetry_id: pack.telemetryId } : {}),
@@ -2172,9 +2469,17 @@ async function toolBrainSkillProposals(
   ctx: ServerContext,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const operation = requiredStringArg("brain_skill_proposals", args, "operation");
+  const operation = requiredStringArg(
+    "brain_skill_proposals",
+    args,
+    "operation",
+  );
   if (operation === "learn") {
-    const minSupport = optionalPositiveInt(args, "min_support", "brain_skill_proposals");
+    const minSupport = optionalPositiveInt(
+      args,
+      "min_support",
+      "brain_skill_proposals",
+    );
     const result =
       minSupport !== undefined
         ? learnSkillProposals(ctx.vault, { minSupport })
@@ -2209,7 +2514,11 @@ async function toolBrainProceduralMemory(
   ctx: ServerContext,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const operation = requiredStringArg("brain_procedural_memory", args, "operation");
+  const operation = requiredStringArg(
+    "brain_procedural_memory",
+    args,
+    "operation",
+  );
   if (operation === "reconcile") {
     const roots = coerceStrList(args, "roots");
     const effectiveRoots =
@@ -2232,7 +2541,10 @@ async function toolBrainProceduralMemory(
     const id = requiredStringArg("brain_procedural_memory", args, "id");
     const updated = markProceduralMemoryUsed(ctx.vault, id);
     if (!updated) {
-      throw new MCPError(INVALID_PARAMS, `brain_procedural_memory: unknown entry id: ${id}`);
+      throw new MCPError(
+        INVALID_PARAMS,
+        `brain_procedural_memory: unknown entry id: ${id}`,
+      );
     }
     return { ...updated };
   }
@@ -2252,15 +2564,26 @@ async function toolBrainRecurrence(
     return { total: entries.length, entries };
   }
   if (operation === "show") {
-    const contentHash = requiredStringArg("brain_recurrence", args, "content_hash");
+    const contentHash = requiredStringArg(
+      "brain_recurrence",
+      args,
+      "content_hash",
+    );
     const entry = getRecurrenceEntry(ctx.vault, contentHash);
     if (!entry) {
-      throw new MCPError(INVALID_PARAMS, `brain_recurrence: unknown content hash: ${contentHash}`);
+      throw new MCPError(
+        INVALID_PARAMS,
+        `brain_recurrence: unknown content hash: ${contentHash}`,
+      );
     }
     return { ...entry };
   }
   if (operation === "learn" || operation === "forget") {
-    const contentHash = requiredStringArg("brain_recurrence", args, "content_hash");
+    const contentHash = requiredStringArg(
+      "brain_recurrence",
+      args,
+      "content_hash",
+    );
     const scope = requiredStringArg("brain_recurrence", args, "scope");
     const sourceId = requiredStringArg("brain_recurrence", args, "source_id");
     const entry = applyRecurrenceEvidence(ctx.vault, {
@@ -2282,7 +2605,91 @@ async function toolBrainRecurrence(
   );
 }
 
-async function toolMcpLandscape(ctx: ServerContext): Promise<Record<string, unknown>> {
+async function toolBrainProceduralGraph(
+  ctx: ServerContext,
+  args: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const operation = requiredStringArg(
+    "brain_procedural_graph",
+    args,
+    "operation",
+  );
+  if (operation === "rebuild") {
+    const graph = rebuildProceduralGraph(ctx.vault);
+    const hints = rebuildProceduralHints(ctx.vault, { graph });
+    return {
+      operation,
+      graph: {
+        nodes: graph.nodes.length,
+        edges: graph.edges.length,
+        generated_at: graph.generated_at,
+      },
+      hints: {
+        entries: hints.entries.length,
+        generated_at: hints.generated_at,
+      },
+    };
+  }
+  if (operation === "show") {
+    const graph = readProceduralGraph(ctx.vault);
+    if (!graph) {
+      throw new MCPError(
+        INVALID_PARAMS,
+        "brain_procedural_graph: graph projection not found",
+      );
+    }
+    return { ...graph };
+  }
+  if (operation === "hints") {
+    const hints = readProceduralHints(ctx.vault);
+    if (!hints) {
+      throw new MCPError(
+        INVALID_PARAMS,
+        "brain_procedural_graph: hints projection not found",
+      );
+    }
+    return { ...hints };
+  }
+  throw new MCPError(
+    INVALID_PARAMS,
+    "brain_procedural_graph: operation must be one of rebuild|show|hints",
+  );
+}
+
+async function toolBrainAttentionFlows(
+  ctx: ServerContext,
+  args: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const operation = requiredStringArg(
+    "brain_attention_flows",
+    args,
+    "operation",
+  );
+  if (operation === "list") {
+    const flows = listAttentionFlows(ctx.vault);
+    return { total: flows.length, flows };
+  }
+  if (operation === "evaluate") {
+    const flowId = requiredStringArg("brain_attention_flows", args, "flow_id");
+    const report = evaluateAttentionFlow(ctx.vault, flowId);
+    return { ...report };
+  }
+  if (operation === "render") {
+    const flowId = requiredStringArg("brain_attention_flows", args, "flow_id");
+    return {
+      flow_id: flowId,
+      text: renderAttentionFlow(ctx.vault, flowId),
+    };
+  }
+  throw new MCPError(
+    INVALID_PARAMS,
+    "brain_attention_flows: operation must be one of list|evaluate|render",
+  );
+}
+
+async function toolMcpLandscape(
+  ctx: ServerContext,
+): Promise<Record<string, unknown>> {
   const landscape = buildMcpLandscape(ctx.vault);
   return {
     vault_path: ctx.vault,
@@ -2305,7 +2712,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
       properties: {
         topic: {
           type: "string",
-          description: "Stable kebab-slug for the rule, e.g. `no-internal-abbrev`.",
+          description:
+            "Stable kebab-slug for the rule, e.g. `no-internal-abbrev`.",
         },
         signal: {
           type: "string",
@@ -2315,7 +2723,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         },
         principle: {
           type: "string",
-          description: "One-line, agent-readable formulation of the rule (imperative voice).",
+          description:
+            "One-line, agent-readable formulation of the rule (imperative voice).",
         },
         scope: {
           type: "string",
@@ -2325,15 +2734,18 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         source: {
           type: "array",
           items: { type: "string" },
-          description: "Optional wikilinks to the artifacts or notes that triggered the signal.",
+          description:
+            "Optional wikilinks to the artifacts or notes that triggered the signal.",
         },
         agent: {
           type: "string",
-          description: "Optional agent identity override; defaults to the server-resolved name.",
+          description:
+            "Optional agent identity override; defaults to the server-resolved name.",
         },
         raw: {
           type: "string",
-          description: "Optional free-form raw quote (rendered under `## Raw` in the signal file).",
+          description:
+            "Optional free-form raw quote (rendered under `## Raw` in the signal file).",
         },
         force_confirmed: {
           type: "boolean",
@@ -2416,7 +2828,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
       properties: {
         month: {
           type: "string",
-          description: "Optional target month in YYYY-MM form. Defaults to the current UTC month.",
+          description:
+            "Optional target month in YYYY-MM form. Defaults to the current UTC month.",
         },
       },
       additionalProperties: false,
@@ -2464,7 +2877,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         },
         agent: {
           type: "string",
-          description: "Optional agent identity override; defaults to the server-resolved name.",
+          description:
+            "Optional agent identity override; defaults to the server-resolved name.",
         },
         note: {
           type: "string",
@@ -2490,7 +2904,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         },
         agent: {
           type: "string",
-          description: "Optional agent identity override; defaults to the server-resolved name.",
+          description:
+            "Optional agent identity override; defaults to the server-resolved name.",
         },
       },
       required: ["text"],
@@ -2542,7 +2957,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
       properties: {
         since: {
           type: "string",
-          description: "Inclusive lower bound (ISO-8601). Defaults to `until - 24h`.",
+          description:
+            "Inclusive lower bound (ISO-8601). Defaults to `until - 24h`.",
         },
         until: {
           type: "string",
@@ -2572,11 +2988,13 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         },
         topic: {
           type: "string",
-          description: "Topic slug to aggregate signals + active/retired preference + log events.",
+          description:
+            "Topic slug to aggregate signals + active/retired preference + log events.",
         },
         since: {
           type: "string",
-          description: "ISO-8601 timestamp; returns every Brain log event with timestamp >= since.",
+          description:
+            "ISO-8601 timestamp; returns every Brain log event with timestamp >= since.",
         },
         format: {
           type: "string",
@@ -2600,7 +3018,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         agents: {
           type: "array",
           items: { type: "string" },
-          description: "Agent ids to query. Omit or pass [] to query all known agents.",
+          description:
+            "Agent ids to query. Omit or pass [] to query all known agents.",
         },
         topic: {
           type: "string",
@@ -2643,7 +3062,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         agents: {
           type: "array",
           items: { type: "string" },
-          description: "Agent ids to compare. Omit or pass [] to compare all known agents.",
+          description:
+            "Agent ids to compare. Omit or pass [] to compare all known agents.",
         },
         topic: {
           type: "string",
@@ -2663,7 +3083,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
           type: "integer",
           minimum: 1,
           maximum: 500,
-          description: "Maximum contributions returned before comparison. Defaults to 50.",
+          description:
+            "Maximum contributions returned before comparison. Defaults to 50.",
         },
       },
       additionalProperties: false,
@@ -2679,7 +3100,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
       properties: {
         strict: {
           type: "boolean",
-          description: "When true, warnings demote `ok` to false (CLI exit-code parity).",
+          description:
+            "When true, warnings demote `ok` to false (CLI exit-code parity).",
         },
         format: {
           type: "string",
@@ -2792,7 +3214,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         lookback_days: {
           type: "integer",
           minimum: 1,
-          description: "Days of log history scanned for open questions + notes (default 7).",
+          description:
+            "Days of log history scanned for open questions + notes (default 7).",
         },
         max_chars_per_memory: {
           type: "integer",
@@ -2845,11 +3268,13 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         max_tokens: {
           type: "integer",
           minimum: 1,
-          description: "Strict upper bound on the returned slice's token count.",
+          description:
+            "Strict upper bound on the returned slice's token count.",
         },
         query: {
           type: "string",
-          description: "Optional case/Unicode-insensitive substring filter on topic + principle.",
+          description:
+            "Optional case/Unicode-insensitive substring filter on topic + principle.",
         },
         max_chars_per_memory: {
           type: "integer",
@@ -2878,13 +3303,21 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
           description:
             "When true, replace repeated context bodies with reference hints to an earlier emitted item.",
         },
+        attention_flow_ids: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Optional declarative attention flow ids to inject as a synthetic context block.",
+        },
         receipt: {
           type: "boolean",
-          description: "When true, emit an opt-in context receipt for this context-pack run.",
+          description:
+            "When true, emit an opt-in context receipt for this context-pack run.",
         },
         receipt_host: {
           type: "string",
-          description: "Optional host/runtime name for emitted receipts; defaults to `mcp`.",
+          description:
+            "Optional host/runtime name for emitted receipts; defaults to `mcp`.",
         },
         telemetry: {
           type: "boolean",
@@ -2893,7 +3326,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         },
         telemetry_host: {
           type: "string",
-          description: "Optional host/runtime name for emitted telemetry; defaults to `mcp`.",
+          description:
+            "Optional host/runtime name for emitted telemetry; defaults to `mcp`.",
         },
         session_id: {
           type: "string",
@@ -2919,7 +3353,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         operation: {
           type: "string",
           enum: ["list", "show"],
-          description: "Use list for summaries, show for one full receipt by id.",
+          description:
+            "Use list for summaries, show for one full receipt by id.",
         },
         id: {
           type: "string",
@@ -2959,7 +3394,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         operation: {
           type: "string",
           enum: ["list", "summary"],
-          description: "Use list for raw records, summary for aggregate counts.",
+          description:
+            "Use list for raw records, summary for aggregate counts.",
         },
         mode: {
           type: "string",
@@ -3009,7 +3445,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         },
         preset_id: {
           type: "string",
-          description: "Preset id for show/diff, e.g. tight-context or long-context.",
+          description:
+            "Preset id for show/diff, e.g. tight-context or long-context.",
         },
         model: {
           type: "string",
@@ -3120,6 +3557,46 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
     handler: toolBrainRecurrence,
   },
   {
+    name: "brain_procedural_graph",
+    description:
+      "Rebuild/show procedural graph projection and prospective hint projection (rebuild, show, hints).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        operation: {
+          type: "string",
+          enum: ["rebuild", "show", "hints"],
+          description: "Tool operation.",
+        },
+      },
+      required: ["operation"],
+      additionalProperties: false,
+    },
+    handler: toolBrainProceduralGraph,
+  },
+  {
+    name: "brain_attention_flows",
+    description:
+      "List/evaluate/render declarative attention-flow recipes for open loops and learnings.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        operation: {
+          type: "string",
+          enum: ["list", "evaluate", "render"],
+          description: "Tool operation.",
+        },
+        flow_id: {
+          type: "string",
+          description: "Flow id for evaluate/render operations.",
+        },
+      },
+      required: ["operation"],
+      additionalProperties: false,
+    },
+    handler: toolBrainAttentionFlows,
+  },
+  {
     name: "brain_pre_compact_extract",
     description:
       "Extract typed Decision/Commitment/Outcome/Rule/Open question records from bounded text into continuity storage.",
@@ -3128,7 +3605,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
       properties: {
         session_id: {
           type: "string",
-          description: "Session identifier used for idempotency and source refs.",
+          description:
+            "Session identifier used for idempotency and source refs.",
         },
         turn_start: {
           type: "string",
@@ -3140,13 +3618,15 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         },
         text: {
           type: "string",
-          description: "Bounded text segment to scan for labeled extraction lines.",
+          description:
+            "Bounded text segment to scan for labeled extraction lines.",
         },
         host: { type: "string", description: "Optional host/client label." },
         max_chars: {
           type: "integer",
           minimum: 1,
-          description: "Optional maximum input characters to scan before extracting.",
+          description:
+            "Optional maximum input characters to scan before extracting.",
         },
       },
       required: ["session_id", "turn_start", "turn_end", "text"],
@@ -3183,7 +3663,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
   },
   {
     name: "brain_session_describe",
-    description: "Describe counts and summary depths for an imported session recall DAG.",
+    description:
+      "Describe counts and summary depths for an imported session recall DAG.",
     inputSchema: {
       type: "object",
       properties: {
@@ -3246,11 +3727,13 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         },
         receipt: {
           type: "boolean",
-          description: "When true, emit an opt-in context receipt for this pre-compress run.",
+          description:
+            "When true, emit an opt-in context receipt for this pre-compress run.",
         },
         receipt_host: {
           type: "string",
-          description: "Optional host/runtime name for emitted receipts; defaults to `mcp`.",
+          description:
+            "Optional host/runtime name for emitted receipts; defaults to `mcp`.",
         },
         telemetry: {
           type: "boolean",
@@ -3259,7 +3742,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         },
         telemetry_host: {
           type: "string",
-          description: "Optional host/runtime name for emitted telemetry; defaults to `mcp`.",
+          description:
+            "Optional host/runtime name for emitted telemetry; defaults to `mcp`.",
         },
         session_id: {
           type: "string",
@@ -3308,7 +3792,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
       properties: {
         id: {
           type: "string",
-          description: "Target id (e.g. `pref-foo`). Wikilink decoration is stripped if present.",
+          description:
+            "Target id (e.g. `pref-foo`). Wikilink decoration is stripped if present.",
         },
         include_unlinked: {
           type: "boolean",
@@ -3330,7 +3815,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
       properties: {
         id: {
           type: "string",
-          description: "Hub note id (e.g. `pref-foo`). Wikilink decoration is stripped if present.",
+          description:
+            "Hub note id (e.g. `pref-foo`). Wikilink decoration is stripped if present.",
         },
       },
       required: ["id"],
@@ -3348,7 +3834,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
       properties: {
         pref_id: {
           type: "string",
-          description: "Restrict to events for this preference / retired / signal id.",
+          description:
+            "Restrict to events for this preference / retired / signal id.",
         },
         topic: {
           type: "string",
@@ -3356,20 +3843,24 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         },
         kind: {
           type: "string",
-          description: "Restrict to events of this BrainLogEventKind (e.g. `apply-evidence`).",
+          description:
+            "Restrict to events of this BrainLogEventKind (e.g. `apply-evidence`).",
         },
         since: {
           type: "string",
-          description: "Inclusive lower bound (ISO date or ISO timestamp). Defaults to epoch.",
+          description:
+            "Inclusive lower bound (ISO date or ISO timestamp). Defaults to epoch.",
         },
         until: {
           type: "string",
-          description: "Exclusive upper bound (ISO date or ISO timestamp). Defaults to now.",
+          description:
+            "Exclusive upper bound (ISO date or ISO timestamp). Defaults to now.",
         },
         limit: {
           type: "integer",
           minimum: 1,
-          description: "Maximum number of events to return after filtering. Omit for no cap.",
+          description:
+            "Maximum number of events to return after filtering. Omit for no cap.",
         },
       },
       additionalProperties: false,
@@ -3385,7 +3876,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
       properties: {
         pref_id: {
           type: "string",
-          description: "Target preference id (e.g. `pref-foo`). Mutually exclusive with `topic`.",
+          description:
+            "Target preference id (e.g. `pref-foo`). Mutually exclusive with `topic`.",
         },
         topic: {
           type: "string",
@@ -3418,7 +3910,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
       properties: {
         date: {
           type: "string",
-          description: "ISO date (`YYYY-MM-DD`) the brief targets. Defaults to today UTC.",
+          description:
+            "ISO date (`YYYY-MM-DD`) the brief targets. Defaults to today UTC.",
         },
       },
       additionalProperties: false,
@@ -3459,7 +3952,8 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         top_actions: {
           type: "integer",
           minimum: 0,
-          description: "Cap on the ranked maintenance action list. Defaults to 5.",
+          description:
+            "Cap on the ranked maintenance action list. Defaults to 5.",
         },
       },
       additionalProperties: false,

--- a/src/mcp/brain-tools.ts
+++ b/src/mcp/brain-tools.ts
@@ -42,10 +42,7 @@ import { existsSync, readFileSync } from "node:fs";
 
 import { resolveAgentName, resolveLinkOutputFormat } from "../core/config.ts";
 import { brainActivePath, brainDirs } from "../core/brain/paths.ts";
-import {
-  regenerateActive,
-  type RegenerateActiveResult,
-} from "../core/brain/active.ts";
+import { regenerateActive, type RegenerateActiveResult } from "../core/brain/active.ts";
 import { parseFrontmatter } from "../core/vault.ts";
 import {
   appendApplyEvidence,
@@ -56,10 +53,7 @@ import { buildBacklinkIndex } from "../core/brain/backlinks.ts";
 import { readPrefAudit } from "../core/brain/pref-audit.ts";
 import { buildMorningBrief } from "../core/brain/morning-brief.ts";
 import { aggregateSources } from "../core/brain/portability/sources.ts";
-import {
-  switchProfile,
-  listProfiles,
-} from "../core/brain/portability/profiles.ts";
+import { switchProfile, listProfiles } from "../core/brain/portability/profiles.ts";
 import { defaultConfigPath } from "../core/config.ts";
 import { findUnlinkedMentions } from "../core/brain/link-graph/unlinked-mentions.ts";
 import { buildConceptCluster } from "../core/brain/link-graph/concept-cluster.ts";
@@ -72,10 +66,7 @@ import { findStaleEntries } from "../core/brain/temporal/stale-watch.ts";
 import { buildDailyBrief } from "../core/brain/temporal/daily-brief.ts";
 import { buildWeeklySynthesis } from "../core/brain/temporal/weekly-brief.ts";
 import { loadTemporalConfigSafe } from "../core/brain/policy.ts";
-import {
-  isBrainLogEventKind,
-  type BrainLogEventKind,
-} from "../core/brain/types.ts";
+import { isBrainLogEventKind, type BrainLogEventKind } from "../core/brain/types.ts";
 import { packContext } from "../core/brain/context-pack.ts";
 import { buildPreCompressPack } from "../core/brain/pre-compress-pack.ts";
 import {
@@ -119,14 +110,8 @@ import {
   markProceduralMemoryUsed,
   reconcileProceduralMemory,
 } from "../core/brain/procedural-memory.ts";
-import {
-  readProceduralGraph,
-  rebuildProceduralGraph,
-} from "../core/brain/procedural-graph.ts";
-import {
-  readProceduralHints,
-  rebuildProceduralHints,
-} from "../core/brain/procedural-hints.ts";
+import { readProceduralGraph, rebuildProceduralGraph } from "../core/brain/procedural-graph.ts";
+import { readProceduralHints, rebuildProceduralHints } from "../core/brain/procedural-hints.ts";
 import {
   applyRecurrenceEvidence,
   getRecurrenceEntry,
@@ -144,10 +129,7 @@ import { renderDigest, type DigestFormat } from "../core/brain/digest.ts";
 import { dream } from "../core/brain/dream.ts";
 import { buildIntentReview } from "../core/brain/intent-review.ts";
 import { buildRetentionReview } from "../core/brain/retention.ts";
-import {
-  buildMonthlyReview,
-  normalizeMonthlyReviewMonth,
-} from "../core/brain/monthly-review.ts";
+import { buildMonthlyReview, normalizeMonthlyReviewMonth } from "../core/brain/monthly-review.ts";
 import { buildReviewCandidates } from "../core/brain/review-candidates.ts";
 import { runDoctor } from "../core/brain/doctor.ts";
 import { buildOperatorSummary } from "../core/brain/trust/operator-summary.ts";
@@ -158,10 +140,7 @@ import {
   queryByPreference,
   queryByTopic,
 } from "../core/brain/query.ts";
-import {
-  diffAgentSources,
-  type AgentSourceDiffMode,
-} from "../core/brain/agent-source/diff.ts";
+import { diffAgentSources, type AgentSourceDiffMode } from "../core/brain/agent-source/diff.ts";
 import { queryAgentSources } from "../core/brain/agent-source/query.ts";
 import type { AgentSourceContributionKind } from "../core/brain/agent-source/types.ts";
 import { writeSignal } from "../core/brain/signal.ts";
@@ -280,9 +259,7 @@ async function toolBrainFeedback(
       },
     });
   } catch (err) {
-    process.stderr.write(
-      `warning: append feedback log failed: ${(err as Error).message}\n`,
-    );
+    process.stderr.write(`warning: append feedback log failed: ${(err as Error).message}\n`);
   }
 
   let prefResult: { path: string; id: string } | null = null;
@@ -356,9 +333,7 @@ async function toolBrainDream(
   const dryRun = coerceBool(args, "dry_run");
   const nowDate = coerceIsoDate(args, "now");
   const agentArg = coerceStr(args, "agent", false);
-  const agent =
-    normalizeAgentArgument(agentArg) ??
-    resolveAgentName(ctx.configPath ?? undefined);
+  const agent = normalizeAgentArgument(agentArg) ?? resolveAgentName(ctx.configPath ?? undefined);
 
   const summary = dream(ctx.vault, {
     dryRun,
@@ -398,9 +373,7 @@ async function toolBrainDream(
     snapshot_path: summary.snapshot_path
       ? vaultRelativeSafe(ctx.vault, summary.snapshot_path)
       : null,
-    log_path: summary.log_path
-      ? vaultRelativeSafe(ctx.vault, summary.log_path)
-      : null,
+    log_path: summary.log_path ? vaultRelativeSafe(ctx.vault, summary.log_path) : null,
   };
 }
 
@@ -431,10 +404,7 @@ async function toolBrainRetention(
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
   const nowDate = coerceIsoDate(args, "now");
-  const report = buildRetentionReview(
-    ctx.vault,
-    nowDate ? { now: nowDate } : {},
-  );
+  const report = buildRetentionReview(ctx.vault, nowDate ? { now: nowDate } : {});
   return {
     schema_version: report.schema_version,
     generated_at: report.generated_at,
@@ -457,18 +427,12 @@ async function toolBrainMonthlyReview(
   let month: string | undefined;
   if (monthRaw !== undefined && monthRaw !== null) {
     if (typeof monthRaw !== "string") {
-      throw new MCPError(
-        INVALID_PARAMS,
-        "brain_monthly_review: month must be YYYY-MM",
-      );
+      throw new MCPError(INVALID_PARAMS, "brain_monthly_review: month must be YYYY-MM");
     }
     try {
       month = normalizeMonthlyReviewMonth(monthRaw);
     } catch {
-      throw new MCPError(
-        INVALID_PARAMS,
-        "brain_monthly_review: month must be YYYY-MM",
-      );
+      throw new MCPError(INVALID_PARAMS, "brain_monthly_review: month must be YYYY-MM");
     }
   }
   const report = buildMonthlyReview(ctx.vault, month ? { month } : {});
@@ -486,10 +450,7 @@ async function toolBrainReviewCandidates(
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
   const nowDate = coerceIsoDate(args, "now");
-  const report = buildReviewCandidates(
-    ctx.vault,
-    nowDate ? { now: nowDate } : {},
-  );
+  const report = buildReviewCandidates(ctx.vault, nowDate ? { now: nowDate } : {});
   return {
     would_create: [...report.would_create],
     would_promote: [...report.would_promote],
@@ -549,9 +510,7 @@ async function toolBrainApplyEvidence(
   const agentArg = coerceStr(args, "agent", false);
   const note = coerceStr(args, "note", false);
 
-  const agent =
-    normalizeAgentArgument(agentArg) ??
-    resolveAgentName(ctx.configPath ?? undefined);
+  const agent = normalizeAgentArgument(agentArg) ?? resolveAgentName(ctx.configPath ?? undefined);
 
   const input: AppendApplyEvidenceInput = {
     pref_id: prefId,
@@ -620,9 +579,7 @@ async function toolBrainNote(
     // any other failure is an I/O / filesystem fault from `appendLogEvent`
     // and must not be reported as a client-side INVALID_PARAMS.
     const message = (err as Error).message ?? String(err);
-    const code = message.startsWith("brain_note:")
-      ? INVALID_PARAMS
-      : INTERNAL_ERROR;
+    const code = message.startsWith("brain_note:") ? INVALID_PARAMS : INTERNAL_ERROR;
     throw new MCPError(code, message);
   }
   return {
@@ -637,9 +594,7 @@ async function toolBrainNote(
 
 type PinnedContextOperation = "read" | "write" | "append" | "clear";
 
-function coercePinnedContextOperation(
-  args: Record<string, unknown>,
-): PinnedContextOperation {
+function coercePinnedContextOperation(args: Record<string, unknown>): PinnedContextOperation {
   const operation = coerceStr(args, "operation", false) ?? "read";
   if (
     operation !== "read" &&
@@ -687,10 +642,7 @@ async function toolBrainPinnedContext(
   return serializePinnedContext(ctx, pinned, operation);
 }
 
-function appendPinnedToContextContent(
-  activeContent: string,
-  pinnedContent: string,
-): string {
+function appendPinnedToContextContent(activeContent: string, pinnedContent: string): string {
   if (pinnedContent.length === 0) return activeContent;
   const pinnedBlock = `## Pinned context\n\n${pinnedContent}`;
   const trimmedActive = activeContent.trimEnd();
@@ -722,9 +674,7 @@ const EMPTY_CONTEXT_COUNTS: BrainContextCounts = {
  *                                        rewrite; the on-disk body is
  *                                        returned verbatim.
  */
-async function toolBrainContext(
-  ctx: ServerContext,
-): Promise<Record<string, unknown>> {
+async function toolBrainContext(ctx: ServerContext): Promise<Record<string, unknown>> {
   const dirs = brainDirs(ctx.vault);
   const activePath = brainActivePath(ctx.vault);
   const pinned = readPinnedContext(ctx.vault);
@@ -997,9 +947,7 @@ async function toolBrainAudit(
     .replace(/^(?:pref-|ret-)/, "")
     .trim();
   if (slug.length === 0) {
-    throw new Error(
-      `brain_audit: empty preference slug after normalising '${raw}'`,
-    );
+    throw new Error(`brain_audit: empty preference slug after normalising '${raw}'`);
   }
   const prefId = `pref-${slug}`;
   const { records, warnings } = readPrefAudit(ctx.vault, prefId);
@@ -1016,18 +964,13 @@ async function toolBrainMorningBrief(
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
   const topK = optionalPositiveInt(args, "top_k", "brain_morning_brief") ?? 10;
-  const lookbackDays =
-    optionalPositiveInt(args, "lookback_days", "brain_morning_brief") ?? 7;
+  const lookbackDays = optionalPositiveInt(args, "lookback_days", "brain_morning_brief") ?? 7;
   const maxCharsPerMemory = optionalPositiveInt(
     args,
     "max_chars_per_memory",
     "brain_morning_brief",
   );
-  const maxTotalChars = optionalPositiveInt(
-    args,
-    "max_total_chars",
-    "brain_morning_brief",
-  );
+  const maxTotalChars = optionalPositiveInt(args, "max_total_chars", "brain_morning_brief");
   const brief = buildMorningBrief(ctx.vault, {
     now: new Date(),
     topK,
@@ -1066,12 +1009,9 @@ async function toolBrainSwitchVault(
   try {
     switchProfile(configPath, name);
   } catch (err) {
-    throw new Error(
-      `brain_switch_vault: ${(err as Error).message ?? String(err)}`,
-      {
-        cause: err,
-      },
-    );
+    throw new Error(`brain_switch_vault: ${(err as Error).message ?? String(err)}`, {
+      cause: err,
+    });
   }
   // The running server keeps its already-resolved vault; the switch
   // takes effect for the next server launch / CLI invocation.
@@ -1096,8 +1036,7 @@ async function toolBrainDoctor(
   // Decide a single ok flag — `strict` only changes the CLI exit code,
   // so we mirror that semantic here: with `strict`, warnings demote ok
   // to false. Errors always do.
-  const ok =
-    result.errors.length === 0 && (!strict || result.warnings.length === 0);
+  const ok = result.errors.length === 0 && (!strict || result.warnings.length === 0);
 
   return {
     format,
@@ -1107,17 +1046,13 @@ async function toolBrainDoctor(
       severity: i.severity,
       code: i.code,
       message: i.message,
-      ...(i.path !== undefined
-        ? { path: vaultRelativeSafe(ctx.vault, i.path) }
-        : {}),
+      ...(i.path !== undefined ? { path: vaultRelativeSafe(ctx.vault, i.path) } : {}),
     })),
     warnings: result.warnings.map((i) => ({
       severity: i.severity,
       code: i.code,
       message: i.message,
-      ...(i.path !== undefined
-        ? { path: vaultRelativeSafe(ctx.vault, i.path) }
-        : {}),
+      ...(i.path !== undefined ? { path: vaultRelativeSafe(ctx.vault, i.path) } : {}),
     })),
     // v0.10.15: ranked maintenance actions surfaced as a parallel
     // signal to errors/warnings. The list is independent of `strict`
@@ -1136,16 +1071,12 @@ async function toolBrainDoctor(
     // surface, so it stays absent here). `instruction_file_warnings`
     // surfaces vault-root instruction files exceeding the configured
     // ceiling.
-    ...(result.trust_verdict !== undefined
-      ? { trust_verdict: result.trust_verdict }
-      : {}),
-    instruction_file_warnings: (result.instruction_file_warnings ?? []).map(
-      (w) => ({
-        path: w.path,
-        lines: w.lines,
-        ceiling: w.ceiling,
-      }),
-    ),
+    ...(result.trust_verdict !== undefined ? { trust_verdict: result.trust_verdict } : {}),
+    instruction_file_warnings: (result.instruction_file_warnings ?? []).map((w) => ({
+      path: w.path,
+      lines: w.lines,
+      ceiling: w.ceiling,
+    })),
   };
 }
 
@@ -1199,9 +1130,7 @@ function serializeSignal(s: BrainSignal): Record<string, unknown> {
   };
 }
 
-function serializePreference(
-  p: BrainPreference | BrainRetired,
-): Record<string, unknown> {
+function serializePreference(p: BrainPreference | BrainRetired): Record<string, unknown> {
   if (p.kind === "brain-retired") {
     return {
       kind: p.kind,
@@ -1210,9 +1139,7 @@ function serializePreference(
       retired_at: p.retired_at,
       retired_reason: p.retired_reason,
       retired_by: p.retired_by,
-      ...(p.superseded_by !== undefined
-        ? { superseded_by: p.superseded_by }
-        : {}),
+      ...(p.superseded_by !== undefined ? { superseded_by: p.superseded_by } : {}),
       created_at: p.created_at,
       topic: p.topic,
       ...(p.scope !== undefined ? { scope: p.scope } : {}),
@@ -1298,9 +1225,7 @@ export function vaultRelativeSafe(vault: string, target: string): string {
 
 // ----- Tool registration ---------------------------------------------------
 
-const PINNED_CONTEXT_OUTPUT_SCHEMA: NonNullable<
-  ToolDefinition["outputSchema"]
-> = {
+const PINNED_CONTEXT_OUTPUT_SCHEMA: NonNullable<ToolDefinition["outputSchema"]> = {
   type: "object",
   required: ["present", "path", "absolute_path", "content"],
   properties: {
@@ -1313,43 +1238,29 @@ const PINNED_CONTEXT_OUTPUT_SCHEMA: NonNullable<
   additionalProperties: false,
 };
 
-const BRAIN_CONTEXT_OUTPUT_SCHEMA: NonNullable<ToolDefinition["outputSchema"]> =
-  {
-    type: "object",
-    required: [
-      "vault_path",
-      "present",
-      "active_path",
-      "content",
-      "counts",
-      "generated_at",
-      "pinned",
-    ],
-    properties: {
-      vault_path: { type: "string" },
-      present: { type: "boolean" },
-      active_path: { type: "string" },
-      content: { type: "string" },
-      counts: {
-        type: "object",
-        required: [
-          "confirmed",
-          "quarantine",
-          "retired_recent",
-          "most_applied_30d",
-        ],
-        properties: {
-          confirmed: { type: "integer" },
-          quarantine: { type: "integer" },
-          retired_recent: { type: "integer" },
-          most_applied_30d: { type: "integer" },
-        },
-        additionalProperties: false,
+const BRAIN_CONTEXT_OUTPUT_SCHEMA: NonNullable<ToolDefinition["outputSchema"]> = {
+  type: "object",
+  required: ["vault_path", "present", "active_path", "content", "counts", "generated_at", "pinned"],
+  properties: {
+    vault_path: { type: "string" },
+    present: { type: "boolean" },
+    active_path: { type: "string" },
+    content: { type: "string" },
+    counts: {
+      type: "object",
+      required: ["confirmed", "quarantine", "retired_recent", "most_applied_30d"],
+      properties: {
+        confirmed: { type: "integer" },
+        quarantine: { type: "integer" },
+        retired_recent: { type: "integer" },
+        most_applied_30d: { type: "integer" },
       },
-      generated_at: {},
-      pinned: PINNED_CONTEXT_OUTPUT_SCHEMA,
+      additionalProperties: false,
     },
-  };
+    generated_at: {},
+    pinned: PINNED_CONTEXT_OUTPUT_SCHEMA,
+  },
+};
 
 const BRAIN_QUERY_OUTPUT_SCHEMA: NonNullable<ToolDefinition["outputSchema"]> = {
   type: "object",
@@ -1409,10 +1320,7 @@ async function toolBrainOperatorSummary(
   } else if (typeof includeDreamRaw === "boolean") {
     includeDream = includeDreamRaw;
   } else {
-    throw new MCPError(
-      INVALID_PARAMS,
-      "brain_operator_summary: include_dream must be a boolean",
-    );
+    throw new MCPError(INVALID_PARAMS, "brain_operator_summary: include_dream must be a boolean");
   }
 
   let dreamSummary;
@@ -1464,10 +1372,7 @@ async function toolBrainUnlinkedMentions(
 ): Promise<Record<string, unknown>> {
   const idRaw = args["id"];
   if (typeof idRaw !== "string" || idRaw.trim().length === 0) {
-    throw new MCPError(
-      INVALID_PARAMS,
-      "brain_unlinked_mentions: id must be a non-empty string",
-    );
+    throw new MCPError(INVALID_PARAMS, "brain_unlinked_mentions: id must be a non-empty string");
   }
   const targetId = normaliseWikilinkTarget(idRaw);
   // Limit coercion mirrors the v0.10.16 `brain_operator_summary`
@@ -1508,11 +1413,7 @@ async function toolBrainUnlinkedMentions(
       );
     }
   }
-  const mentions = findUnlinkedMentions(
-    ctx.vault,
-    targetId,
-    limit !== undefined ? { limit } : {},
-  );
+  const mentions = findUnlinkedMentions(ctx.vault, targetId, limit !== undefined ? { limit } : {});
   return {
     vault_path: ctx.vault,
     target_id: targetId,
@@ -1537,10 +1438,7 @@ async function toolBrainConceptSynthesis(
 ): Promise<Record<string, unknown>> {
   const idRaw = args["id"];
   if (typeof idRaw !== "string" || idRaw.trim().length === 0) {
-    throw new MCPError(
-      INVALID_PARAMS,
-      "brain_concept_synthesis: id must be a non-empty string",
-    );
+    throw new MCPError(INVALID_PARAMS, "brain_concept_synthesis: id must be a non-empty string");
   }
   const includeUnlinkedRaw = args["include_unlinked"];
   let includeUnlinked = false;
@@ -1581,10 +1479,7 @@ async function toolBrainMocAudit(
 ): Promise<Record<string, unknown>> {
   const idRaw = args["id"];
   if (typeof idRaw !== "string" || idRaw.trim().length === 0) {
-    throw new MCPError(
-      INVALID_PARAMS,
-      "brain_moc_audit: id must be a non-empty string",
-    );
+    throw new MCPError(INVALID_PARAMS, "brain_moc_audit: id must be a non-empty string");
   }
   const targetId = normaliseWikilinkTarget(idRaw);
   try {
@@ -1608,42 +1503,26 @@ async function toolBrainMocAudit(
 
 // ----- Temporal subsystem MCP wrappers (v0.10.18) --------------------------
 
-function coercePositiveInteger(
-  tool: string,
-  field: string,
-  raw: unknown,
-): number | undefined {
+function coercePositiveInteger(tool: string, field: string, raw: unknown): number | undefined {
   if (raw === undefined || raw === null) return undefined;
   if (typeof raw === "number") {
     if (!Number.isInteger(raw) || raw < 1) {
-      throw new MCPError(
-        INVALID_PARAMS,
-        `${tool}: ${field} must be a positive integer`,
-      );
+      throw new MCPError(INVALID_PARAMS, `${tool}: ${field} must be a positive integer`);
     }
     return raw;
   }
   if (typeof raw === "string") {
     const trimmed = raw.trim();
     if (trimmed === "" || !/^[0-9]+$/.test(trimmed)) {
-      throw new MCPError(
-        INVALID_PARAMS,
-        `${tool}: ${field} must be a positive integer`,
-      );
+      throw new MCPError(INVALID_PARAMS, `${tool}: ${field} must be a positive integer`);
     }
     const parsed = Number.parseInt(trimmed, 10);
     if (parsed < 1) {
-      throw new MCPError(
-        INVALID_PARAMS,
-        `${tool}: ${field} must be a positive integer`,
-      );
+      throw new MCPError(INVALID_PARAMS, `${tool}: ${field} must be a positive integer`);
     }
     return parsed;
   }
-  throw new MCPError(
-    INVALID_PARAMS,
-    `${tool}: ${field} must be a positive integer`,
-  );
+  throw new MCPError(INVALID_PARAMS, `${tool}: ${field} must be a positive integer`);
 }
 
 const ISO_DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
@@ -1679,19 +1558,13 @@ function coerceIsoTimestampOrDate(
   return v;
 }
 
-function coerceEventKind(
-  tool: string,
-  raw: unknown,
-): BrainLogEventKind | undefined {
+function coerceEventKind(tool: string, raw: unknown): BrainLogEventKind | undefined {
   if (raw === undefined || raw === null) return undefined;
   if (typeof raw !== "string") {
     throw new MCPError(INVALID_PARAMS, `${tool}: kind must be a string`);
   }
   if (!isBrainLogEventKind(raw)) {
-    throw new MCPError(
-      INVALID_PARAMS,
-      `${tool}: kind must be a known BrainLogEventKind`,
-    );
+    throw new MCPError(INVALID_PARAMS, `${tool}: kind must be a known BrainLogEventKind`);
   }
   return raw;
 }
@@ -1705,20 +1578,11 @@ async function toolBrainTimeline(
   ctx: ServerContext,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const prefId =
-    typeof args["pref_id"] === "string" ? args["pref_id"] : undefined;
+  const prefId = typeof args["pref_id"] === "string" ? args["pref_id"] : undefined;
   const topic = typeof args["topic"] === "string" ? args["topic"] : undefined;
   const kind = coerceEventKind("brain_timeline", args["kind"]);
-  const since = coerceIsoTimestampOrDate(
-    "brain_timeline",
-    "since",
-    args["since"],
-  );
-  const until = coerceIsoTimestampOrDate(
-    "brain_timeline",
-    "until",
-    args["until"],
-  );
+  const since = coerceIsoTimestampOrDate("brain_timeline", "since", args["since"]);
+  const until = coerceIsoTimestampOrDate("brain_timeline", "until", args["until"]);
   const limit = coercePositiveInteger("brain_timeline", "limit", args["limit"]);
 
   const index = buildTimelineIndex(ctx.vault, {
@@ -1817,12 +1681,7 @@ async function toolBrainDailyBrief(
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
   const dateRaw = args["date"];
-  const dateCoerced = coerceIsoTimestampOrDate(
-    "brain_daily_brief",
-    "date",
-    dateRaw,
-    "date-only",
-  );
+  const dateCoerced = coerceIsoTimestampOrDate("brain_daily_brief", "date", dateRaw, "date-only");
   const date = dateCoerced ?? new Date().toISOString().slice(0, 10);
   const cfg = loadTemporalConfigSafe(ctx.vault);
   const index = buildTimelineIndex(ctx.vault, {});
@@ -1892,33 +1751,16 @@ async function toolBrainContextPack(
         ? Number.parseInt(maxRaw.trim(), 10)
         : Number.NaN;
   if (!Number.isInteger(maxTokens) || maxTokens <= 0) {
-    throw new MCPError(
-      INVALID_PARAMS,
-      "brain_context_pack: max_tokens must be a positive integer",
-    );
+    throw new MCPError(INVALID_PARAMS, "brain_context_pack: max_tokens must be a positive integer");
   }
-  const query =
-    typeof args["query"] === "string" ? (args["query"] as string) : undefined;
+  const query = typeof args["query"] === "string" ? (args["query"] as string) : undefined;
   const includeLanes = coerceBool(args, "lanes");
   const cacheStable = coerceBool(args, "cache_stable");
   const dedupRepeated = coerceBool(args, "dedup_repeated");
   const attentionFlowIds = coerceStrList(args, "attention_flow_ids");
-  const maxCharsPerMemory = optionalPositiveInt(
-    args,
-    "max_chars_per_memory",
-    "brain_context_pack",
-  );
-  const maxTotalChars = optionalPositiveInt(
-    args,
-    "max_total_chars",
-    "brain_context_pack",
-  );
-  const receipt = receiptOptionsFromArgs(
-    "brain_context_pack",
-    args,
-    "context_pack",
-    "mcp",
-  );
+  const maxCharsPerMemory = optionalPositiveInt(args, "max_chars_per_memory", "brain_context_pack");
+  const maxTotalChars = optionalPositiveInt(args, "max_total_chars", "brain_context_pack");
+  const receipt = receiptOptionsFromArgs("brain_context_pack", args, "context_pack", "mcp");
   const telemetry = telemetryOptionsFromArgs("brain_context_pack", args, "mcp");
   const report = packContext(ctx.vault, {
     maxTokens,
@@ -1949,14 +1791,10 @@ async function toolBrainContextPack(
       tokens: i.tokens,
       body: i.body,
       trimmed: i.trimmed,
-      ...(i.originalRank !== undefined
-        ? { original_rank: i.originalRank }
-        : {}),
+      ...(i.originalRank !== undefined ? { original_rank: i.originalRank } : {}),
       ...(i.stableRank !== undefined ? { stable_rank: i.stableRank } : {}),
       ...(i.dedupedFrom !== undefined ? { deduped_from: i.dedupedFrom } : {}),
-      ...(i.referenceHint !== undefined
-        ? { reference_hint: i.referenceHint }
-        : {}),
+      ...(i.referenceHint !== undefined ? { reference_hint: i.referenceHint } : {}),
       ...(i.safety ? { safety: i.safety } : {}),
     })),
     skipped: report.skipped.map((s) => ({
@@ -1976,17 +1814,9 @@ async function toolBrainContextReceipts(
   ctx: ServerContext,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const operation = optionalStringArg(
-    "brain_context_receipts",
-    args,
-    "operation",
-  );
+  const operation = optionalStringArg("brain_context_receipts", args, "operation");
   if (operation === "list") {
-    const trigger = optionalStringArg(
-      "brain_context_receipts",
-      args,
-      "trigger",
-    );
+    const trigger = optionalStringArg("brain_context_receipts", args, "trigger");
     if (trigger !== undefined && !isContextReceiptTrigger(trigger)) {
       throw new MCPError(
         INVALID_PARAMS,
@@ -1994,16 +1824,8 @@ async function toolBrainContextReceipts(
       );
     }
     const host = optionalStringArg("brain_context_receipts", args, "host");
-    const sessionId = optionalStringArg(
-      "brain_context_receipts",
-      args,
-      "session_id",
-    );
-    const limit = coercePositiveInteger(
-      "brain_context_receipts",
-      "limit",
-      args["limit"],
-    );
+    const sessionId = optionalStringArg("brain_context_receipts", args, "session_id");
+    const limit = coercePositiveInteger("brain_context_receipts", "limit", args["limit"]);
     const receipts = listContextReceipts(ctx.vault, {
       ...(trigger !== undefined ? { trigger } : {}),
       ...(host !== undefined ? { host } : {}),
@@ -2021,17 +1843,11 @@ async function toolBrainContextReceipts(
   if (operation === "show") {
     const id = optionalStringArg("brain_context_receipts", args, "id");
     if (id === undefined) {
-      throw new MCPError(
-        INVALID_PARAMS,
-        "brain_context_receipts: id is required for show",
-      );
+      throw new MCPError(INVALID_PARAMS, "brain_context_receipts: id is required for show");
     }
     const receipt = getContextReceipt(ctx.vault, id);
     if (receipt === null) {
-      throw new MCPError(
-        INVALID_PARAMS,
-        `brain_context_receipts: receipt not found: ${id}`,
-      );
+      throw new MCPError(INVALID_PARAMS, `brain_context_receipts: receipt not found: ${id}`);
     }
     return {
       id: receipt.id,
@@ -2044,10 +1860,7 @@ async function toolBrainContextReceipts(
     };
   }
 
-  throw new MCPError(
-    INVALID_PARAMS,
-    "brain_context_receipts: operation must be list or show",
-  );
+  throw new MCPError(INVALID_PARAMS, "brain_context_receipts: operation must be list or show");
 }
 
 function optionalStringArg(
@@ -2058,22 +1871,14 @@ function optionalStringArg(
   const raw = args[key];
   if (raw === undefined || raw === null) return undefined;
   if (typeof raw !== "string" || raw.trim().length === 0) {
-    throw new MCPError(
-      INVALID_PARAMS,
-      `${tool}: ${key} must be a non-empty string`,
-    );
+    throw new MCPError(INVALID_PARAMS, `${tool}: ${key} must be a non-empty string`);
   }
   return raw.trim();
 }
 
-function requiredStringArg(
-  tool: string,
-  args: Record<string, unknown>,
-  key: string,
-): string {
+function requiredStringArg(tool: string, args: Record<string, unknown>, key: string): string {
   const value = optionalStringArg(tool, args, key);
-  if (value === undefined)
-    throw new MCPError(INVALID_PARAMS, `${tool}: ${key} is required`);
+  if (value === undefined) throw new MCPError(INVALID_PARAMS, `${tool}: ${key} is required`);
   return value;
 }
 
@@ -2083,11 +1888,7 @@ async function toolBrainRecallTelemetry(
   ctx: ServerContext,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const operation = optionalStringArg(
-    "brain_recall_telemetry",
-    args,
-    "operation",
-  );
+  const operation = optionalStringArg("brain_recall_telemetry", args, "operation");
   const filter = recallTelemetryFilter(args);
 
   if (operation === "list") {
@@ -2098,25 +1899,16 @@ async function toolBrainRecallTelemetry(
     const summary = summarizeRecallTelemetry(ctx.vault, filter);
     return { ...summary };
   }
-  throw new MCPError(
-    INVALID_PARAMS,
-    "brain_recall_telemetry: operation must be list or summary",
-  );
+  throw new MCPError(INVALID_PARAMS, "brain_recall_telemetry: operation must be list or summary");
 }
 
-function recallTelemetryFilter(
-  args: Record<string, unknown>,
-): RecallTelemetryFilter {
+function recallTelemetryFilter(args: Record<string, unknown>): RecallTelemetryFilter {
   const mode = coerceRecallTelemetryMode(args["mode"]);
   const status = coerceRecallTelemetryStatus(args["status"]);
   const host = optionalStringArg("brain_recall_telemetry", args, "host");
   const since = optionalStringArg("brain_recall_telemetry", args, "since");
   const until = optionalStringArg("brain_recall_telemetry", args, "until");
-  const limit = coercePositiveInteger(
-    "brain_recall_telemetry",
-    "limit",
-    args["limit"],
-  );
+  const limit = coercePositiveInteger("brain_recall_telemetry", "limit", args["limit"]);
   return {
     ...(mode !== undefined ? { mode } : {}),
     ...(status !== undefined ? { status } : {}),
@@ -2127,9 +1919,7 @@ function recallTelemetryFilter(
   };
 }
 
-function coerceRecallTelemetryMode(
-  raw: unknown,
-): RecallTelemetryMode | undefined {
+function coerceRecallTelemetryMode(raw: unknown): RecallTelemetryMode | undefined {
   if (raw === undefined || raw === null) return undefined;
   const trimmed = typeof raw === "string" ? raw.trim() : raw;
   if (!isRecallTelemetryMode(trimmed)) {
@@ -2141,9 +1931,7 @@ function coerceRecallTelemetryMode(
   return trimmed;
 }
 
-function coerceRecallTelemetryStatus(
-  raw: unknown,
-): RecallTelemetryStatus | undefined {
+function coerceRecallTelemetryStatus(raw: unknown): RecallTelemetryStatus | undefined {
   if (raw === undefined || raw === null) return undefined;
   const trimmed = typeof raw === "string" ? raw.trim() : raw;
   if (!isRecallTelemetryStatus(trimmed)) {
@@ -2161,26 +1949,13 @@ async function toolBrainContextPresets(
   _ctx: ServerContext,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const operation = optionalStringArg(
-    "brain_context_presets",
-    args,
-    "operation",
-  );
+  const operation = optionalStringArg("brain_context_presets", args, "operation");
   if (operation === "show") {
-    const presetId = optionalStringArg(
-      "brain_context_presets",
-      args,
-      "preset_id",
-    );
+    const presetId = optionalStringArg("brain_context_presets", args, "preset_id");
     const result =
-      presetId === undefined
-        ? { presets: listContextPresets() }
-        : getContextPreset(presetId);
+      presetId === undefined ? { presets: listContextPresets() } : getContextPreset(presetId);
     if (result === null) {
-      throw new MCPError(
-        INVALID_PARAMS,
-        `brain_context_presets: unknown preset ${presetId}`,
-      );
+      throw new MCPError(INVALID_PARAMS, `brain_context_presets: unknown preset ${presetId}`);
     }
     return Array.isArray(result) ? { presets: result } : { ...result };
   }
@@ -2199,22 +1974,12 @@ async function toolBrainContextPresets(
     };
   }
   if (operation === "diff") {
-    const presetId = optionalStringArg(
-      "brain_context_presets",
-      args,
-      "preset_id",
-    );
+    const presetId = optionalStringArg("brain_context_presets", args, "preset_id");
     if (presetId === undefined) {
-      throw new MCPError(
-        INVALID_PARAMS,
-        "brain_context_presets: preset_id is required for diff",
-      );
+      throw new MCPError(INVALID_PARAMS, "brain_context_presets: preset_id is required for diff");
     }
     return {
-      ...diffContextPreset(
-        presetId,
-        contextPresetCurrentConfig(args["current"]),
-      ),
+      ...diffContextPreset(presetId, contextPresetCurrentConfig(args["current"])),
     };
   }
   throw new MCPError(
@@ -2226,10 +1991,7 @@ async function toolBrainContextPresets(
 function contextPresetCurrentConfig(raw: unknown): ContextPresetCurrentConfig {
   if (raw === undefined || raw === null) return {};
   if (typeof raw !== "object" || Array.isArray(raw)) {
-    throw new MCPError(
-      INVALID_PARAMS,
-      "brain_context_presets: current must be an object",
-    );
+    throw new MCPError(INVALID_PARAMS, "brain_context_presets: current must be an object");
   }
   return raw as ContextPresetCurrentConfig;
 }
@@ -2240,21 +2002,9 @@ async function toolBrainPreCompactExtract(
   ctx: ServerContext,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const sessionId = requiredStringArg(
-    "brain_pre_compact_extract",
-    args,
-    "session_id",
-  );
-  const turnStart = requiredStringArg(
-    "brain_pre_compact_extract",
-    args,
-    "turn_start",
-  );
-  const turnEnd = requiredStringArg(
-    "brain_pre_compact_extract",
-    args,
-    "turn_end",
-  );
+  const sessionId = requiredStringArg("brain_pre_compact_extract", args, "session_id");
+  const turnStart = requiredStringArg("brain_pre_compact_extract", args, "turn_start");
+  const turnEnd = requiredStringArg("brain_pre_compact_extract", args, "turn_end");
   const text = requiredStringArg("brain_pre_compact_extract", args, "text");
   const maxChars = coercePositiveInteger(
     "brain_pre_compact_extract",
@@ -2266,8 +2016,7 @@ async function toolBrainPreCompactExtract(
     turnStart,
     turnEnd,
     text,
-    ...(optionalStringArg("brain_pre_compact_extract", args, "host") !==
-    undefined
+    ...(optionalStringArg("brain_pre_compact_extract", args, "host") !== undefined
       ? { host: optionalStringArg("brain_pre_compact_extract", args, "host") }
       : {}),
     ...(maxChars !== undefined ? { maxChars } : {}),
@@ -2281,11 +2030,7 @@ async function toolBrainSessionGrep(
   ctx: ServerContext,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const limit = coercePositiveInteger(
-    "brain_session_grep",
-    "limit",
-    args["limit"],
-  );
+  const limit = coercePositiveInteger("brain_session_grep", "limit", args["limit"]);
   const snippetChars = coercePositiveInteger(
     "brain_session_grep",
     "snippet_chars",
@@ -2294,14 +2039,9 @@ async function toolBrainSessionGrep(
   return {
     ...searchSessionRecall(ctx.vault, {
       query: requiredStringArg("brain_session_grep", args, "query"),
-      ...(optionalStringArg("brain_session_grep", args, "session_id") !==
-      undefined
+      ...(optionalStringArg("brain_session_grep", args, "session_id") !== undefined
         ? {
-            sessionId: optionalStringArg(
-              "brain_session_grep",
-              args,
-              "session_id",
-            ),
+            sessionId: optionalStringArg("brain_session_grep", args, "session_id"),
           }
         : {}),
       ...(limit !== undefined ? { limit } : {}),
@@ -2316,11 +2056,7 @@ async function toolBrainSessionDescribe(
 ): Promise<Record<string, unknown>> {
   return {
     ...describeSessionRecall(ctx.vault, {
-      sessionId: requiredStringArg(
-        "brain_session_describe",
-        args,
-        "session_id",
-      ),
+      sessionId: requiredStringArg("brain_session_describe", args, "session_id"),
     }),
   };
 }
@@ -2329,17 +2065,12 @@ async function toolBrainSessionExpand(
   ctx: ServerContext,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const rawLimit = coercePositiveInteger(
-    "brain_session_expand",
-    "raw_limit",
-    args["raw_limit"],
-  );
+  const rawLimit = coercePositiveInteger("brain_session_expand", "raw_limit", args["raw_limit"]);
   return {
     ...expandSessionRecall(ctx.vault, {
       id: requiredStringArg("brain_session_expand", args, "id"),
       ...(rawLimit !== undefined ? { rawLimit } : {}),
-      ...(optionalStringArg("brain_session_expand", args, "cursor") !==
-      undefined
+      ...(optionalStringArg("brain_session_expand", args, "cursor") !== undefined
         ? { cursor: optionalStringArg("brain_session_expand", args, "cursor") }
         : {}),
     }),
@@ -2363,10 +2094,7 @@ function optionalPositiveInt(
         ? Number.parseInt(raw.trim(), 10)
         : Number.NaN;
   if (!Number.isInteger(n) || n <= 0) {
-    throw new MCPError(
-      INVALID_PARAMS,
-      `${tool}: ${key} must be a positive integer`,
-    );
+    throw new MCPError(INVALID_PARAMS, `${tool}: ${key} must be a positive integer`);
   }
   return n;
 }
@@ -2380,29 +2108,15 @@ async function toolBrainPreCompressPack(
   ctx: ServerContext,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const topK =
-    optionalPositiveInt(args, "top_k", "brain_pre_compress_pack") ?? 10;
+  const topK = optionalPositiveInt(args, "top_k", "brain_pre_compress_pack") ?? 10;
   const maxCharsPerMemory = optionalPositiveInt(
     args,
     "max_chars_per_memory",
     "brain_pre_compress_pack",
   );
-  const maxTotalChars = optionalPositiveInt(
-    args,
-    "max_total_chars",
-    "brain_pre_compress_pack",
-  );
-  const receipt = receiptOptionsFromArgs(
-    "brain_pre_compress_pack",
-    args,
-    "pre_compress",
-    "mcp",
-  );
-  const telemetry = telemetryOptionsFromArgs(
-    "brain_pre_compress_pack",
-    args,
-    "mcp",
-  );
+  const maxTotalChars = optionalPositiveInt(args, "max_total_chars", "brain_pre_compress_pack");
+  const receipt = receiptOptionsFromArgs("brain_pre_compress_pack", args, "pre_compress", "mcp");
+  const telemetry = telemetryOptionsFromArgs("brain_pre_compress_pack", args, "mcp");
   const pack = buildPreCompressPack(ctx.vault, {
     topK,
     ...(maxCharsPerMemory !== undefined ? { maxCharsPerMemory } : {}),
@@ -2414,9 +2128,7 @@ async function toolBrainPreCompressPack(
     vault_path: ctx.vault,
     text: pack.text,
     active_head_included: pack.activeHeadIncluded,
-    ...(pack.activeHeadSafety
-      ? { active_head_safety: pack.activeHeadSafety }
-      : {}),
+    ...(pack.activeHeadSafety ? { active_head_safety: pack.activeHeadSafety } : {}),
     total_chars: pack.totalChars,
     ...(pack.receiptId ? { receipt_id: pack.receiptId } : {}),
     ...(pack.telemetryId ? { telemetry_id: pack.telemetryId } : {}),
@@ -2469,17 +2181,9 @@ async function toolBrainSkillProposals(
   ctx: ServerContext,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const operation = requiredStringArg(
-    "brain_skill_proposals",
-    args,
-    "operation",
-  );
+  const operation = requiredStringArg("brain_skill_proposals", args, "operation");
   if (operation === "learn") {
-    const minSupport = optionalPositiveInt(
-      args,
-      "min_support",
-      "brain_skill_proposals",
-    );
+    const minSupport = optionalPositiveInt(args, "min_support", "brain_skill_proposals");
     const result =
       minSupport !== undefined
         ? learnSkillProposals(ctx.vault, { minSupport })
@@ -2514,11 +2218,7 @@ async function toolBrainProceduralMemory(
   ctx: ServerContext,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const operation = requiredStringArg(
-    "brain_procedural_memory",
-    args,
-    "operation",
-  );
+  const operation = requiredStringArg("brain_procedural_memory", args, "operation");
   if (operation === "reconcile") {
     const roots = coerceStrList(args, "roots");
     const effectiveRoots =
@@ -2541,10 +2241,7 @@ async function toolBrainProceduralMemory(
     const id = requiredStringArg("brain_procedural_memory", args, "id");
     const updated = markProceduralMemoryUsed(ctx.vault, id);
     if (!updated) {
-      throw new MCPError(
-        INVALID_PARAMS,
-        `brain_procedural_memory: unknown entry id: ${id}`,
-      );
+      throw new MCPError(INVALID_PARAMS, `brain_procedural_memory: unknown entry id: ${id}`);
     }
     return { ...updated };
   }
@@ -2564,26 +2261,15 @@ async function toolBrainRecurrence(
     return { total: entries.length, entries };
   }
   if (operation === "show") {
-    const contentHash = requiredStringArg(
-      "brain_recurrence",
-      args,
-      "content_hash",
-    );
+    const contentHash = requiredStringArg("brain_recurrence", args, "content_hash");
     const entry = getRecurrenceEntry(ctx.vault, contentHash);
     if (!entry) {
-      throw new MCPError(
-        INVALID_PARAMS,
-        `brain_recurrence: unknown content hash: ${contentHash}`,
-      );
+      throw new MCPError(INVALID_PARAMS, `brain_recurrence: unknown content hash: ${contentHash}`);
     }
     return { ...entry };
   }
   if (operation === "learn" || operation === "forget") {
-    const contentHash = requiredStringArg(
-      "brain_recurrence",
-      args,
-      "content_hash",
-    );
+    const contentHash = requiredStringArg("brain_recurrence", args, "content_hash");
     const scope = requiredStringArg("brain_recurrence", args, "scope");
     const sourceId = requiredStringArg("brain_recurrence", args, "source_id");
     const entry = applyRecurrenceEvidence(ctx.vault, {
@@ -2609,11 +2295,7 @@ async function toolBrainProceduralGraph(
   ctx: ServerContext,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const operation = requiredStringArg(
-    "brain_procedural_graph",
-    args,
-    "operation",
-  );
+  const operation = requiredStringArg("brain_procedural_graph", args, "operation");
   if (operation === "rebuild") {
     const graph = rebuildProceduralGraph(ctx.vault);
     const hints = rebuildProceduralHints(ctx.vault, { graph });
@@ -2633,20 +2315,14 @@ async function toolBrainProceduralGraph(
   if (operation === "show") {
     const graph = readProceduralGraph(ctx.vault);
     if (!graph) {
-      throw new MCPError(
-        INVALID_PARAMS,
-        "brain_procedural_graph: graph projection not found",
-      );
+      throw new MCPError(INVALID_PARAMS, "brain_procedural_graph: graph projection not found");
     }
     return { ...graph };
   }
   if (operation === "hints") {
     const hints = readProceduralHints(ctx.vault);
     if (!hints) {
-      throw new MCPError(
-        INVALID_PARAMS,
-        "brain_procedural_graph: hints projection not found",
-      );
+      throw new MCPError(INVALID_PARAMS, "brain_procedural_graph: hints projection not found");
     }
     return { ...hints };
   }
@@ -2660,11 +2336,7 @@ async function toolBrainAttentionFlows(
   ctx: ServerContext,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const operation = requiredStringArg(
-    "brain_attention_flows",
-    args,
-    "operation",
-  );
+  const operation = requiredStringArg("brain_attention_flows", args, "operation");
   if (operation === "list") {
     const flows = listAttentionFlows(ctx.vault);
     return { total: flows.length, flows };
@@ -2687,9 +2359,7 @@ async function toolBrainAttentionFlows(
   );
 }
 
-async function toolMcpLandscape(
-  ctx: ServerContext,
-): Promise<Record<string, unknown>> {
+async function toolMcpLandscape(ctx: ServerContext): Promise<Record<string, unknown>> {
   const landscape = buildMcpLandscape(ctx.vault);
   return {
     vault_path: ctx.vault,
@@ -2712,8 +2382,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
       properties: {
         topic: {
           type: "string",
-          description:
-            "Stable kebab-slug for the rule, e.g. `no-internal-abbrev`.",
+          description: "Stable kebab-slug for the rule, e.g. `no-internal-abbrev`.",
         },
         signal: {
           type: "string",
@@ -2723,8 +2392,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         },
         principle: {
           type: "string",
-          description:
-            "One-line, agent-readable formulation of the rule (imperative voice).",
+          description: "One-line, agent-readable formulation of the rule (imperative voice).",
         },
         scope: {
           type: "string",
@@ -2734,18 +2402,15 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         source: {
           type: "array",
           items: { type: "string" },
-          description:
-            "Optional wikilinks to the artifacts or notes that triggered the signal.",
+          description: "Optional wikilinks to the artifacts or notes that triggered the signal.",
         },
         agent: {
           type: "string",
-          description:
-            "Optional agent identity override; defaults to the server-resolved name.",
+          description: "Optional agent identity override; defaults to the server-resolved name.",
         },
         raw: {
           type: "string",
-          description:
-            "Optional free-form raw quote (rendered under `## Raw` in the signal file).",
+          description: "Optional free-form raw quote (rendered under `## Raw` in the signal file).",
         },
         force_confirmed: {
           type: "boolean",
@@ -2828,8 +2493,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
       properties: {
         month: {
           type: "string",
-          description:
-            "Optional target month in YYYY-MM form. Defaults to the current UTC month.",
+          description: "Optional target month in YYYY-MM form. Defaults to the current UTC month.",
         },
       },
       additionalProperties: false,
@@ -2877,8 +2541,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         },
         agent: {
           type: "string",
-          description:
-            "Optional agent identity override; defaults to the server-resolved name.",
+          description: "Optional agent identity override; defaults to the server-resolved name.",
         },
         note: {
           type: "string",
@@ -2904,8 +2567,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         },
         agent: {
           type: "string",
-          description:
-            "Optional agent identity override; defaults to the server-resolved name.",
+          description: "Optional agent identity override; defaults to the server-resolved name.",
         },
       },
       required: ["text"],
@@ -2957,8 +2619,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
       properties: {
         since: {
           type: "string",
-          description:
-            "Inclusive lower bound (ISO-8601). Defaults to `until - 24h`.",
+          description: "Inclusive lower bound (ISO-8601). Defaults to `until - 24h`.",
         },
         until: {
           type: "string",
@@ -2988,13 +2649,11 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         },
         topic: {
           type: "string",
-          description:
-            "Topic slug to aggregate signals + active/retired preference + log events.",
+          description: "Topic slug to aggregate signals + active/retired preference + log events.",
         },
         since: {
           type: "string",
-          description:
-            "ISO-8601 timestamp; returns every Brain log event with timestamp >= since.",
+          description: "ISO-8601 timestamp; returns every Brain log event with timestamp >= since.",
         },
         format: {
           type: "string",
@@ -3018,8 +2677,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         agents: {
           type: "array",
           items: { type: "string" },
-          description:
-            "Agent ids to query. Omit or pass [] to query all known agents.",
+          description: "Agent ids to query. Omit or pass [] to query all known agents.",
         },
         topic: {
           type: "string",
@@ -3062,8 +2720,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         agents: {
           type: "array",
           items: { type: "string" },
-          description:
-            "Agent ids to compare. Omit or pass [] to compare all known agents.",
+          description: "Agent ids to compare. Omit or pass [] to compare all known agents.",
         },
         topic: {
           type: "string",
@@ -3083,8 +2740,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
           type: "integer",
           minimum: 1,
           maximum: 500,
-          description:
-            "Maximum contributions returned before comparison. Defaults to 50.",
+          description: "Maximum contributions returned before comparison. Defaults to 50.",
         },
       },
       additionalProperties: false,
@@ -3100,8 +2756,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
       properties: {
         strict: {
           type: "boolean",
-          description:
-            "When true, warnings demote `ok` to false (CLI exit-code parity).",
+          description: "When true, warnings demote `ok` to false (CLI exit-code parity).",
         },
         format: {
           type: "string",
@@ -3214,8 +2869,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         lookback_days: {
           type: "integer",
           minimum: 1,
-          description:
-            "Days of log history scanned for open questions + notes (default 7).",
+          description: "Days of log history scanned for open questions + notes (default 7).",
         },
         max_chars_per_memory: {
           type: "integer",
@@ -3268,13 +2922,11 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         max_tokens: {
           type: "integer",
           minimum: 1,
-          description:
-            "Strict upper bound on the returned slice's token count.",
+          description: "Strict upper bound on the returned slice's token count.",
         },
         query: {
           type: "string",
-          description:
-            "Optional case/Unicode-insensitive substring filter on topic + principle.",
+          description: "Optional case/Unicode-insensitive substring filter on topic + principle.",
         },
         max_chars_per_memory: {
           type: "integer",
@@ -3311,13 +2963,11 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         },
         receipt: {
           type: "boolean",
-          description:
-            "When true, emit an opt-in context receipt for this context-pack run.",
+          description: "When true, emit an opt-in context receipt for this context-pack run.",
         },
         receipt_host: {
           type: "string",
-          description:
-            "Optional host/runtime name for emitted receipts; defaults to `mcp`.",
+          description: "Optional host/runtime name for emitted receipts; defaults to `mcp`.",
         },
         telemetry: {
           type: "boolean",
@@ -3326,8 +2976,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         },
         telemetry_host: {
           type: "string",
-          description:
-            "Optional host/runtime name for emitted telemetry; defaults to `mcp`.",
+          description: "Optional host/runtime name for emitted telemetry; defaults to `mcp`.",
         },
         session_id: {
           type: "string",
@@ -3353,8 +3002,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         operation: {
           type: "string",
           enum: ["list", "show"],
-          description:
-            "Use list for summaries, show for one full receipt by id.",
+          description: "Use list for summaries, show for one full receipt by id.",
         },
         id: {
           type: "string",
@@ -3394,8 +3042,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         operation: {
           type: "string",
           enum: ["list", "summary"],
-          description:
-            "Use list for raw records, summary for aggregate counts.",
+          description: "Use list for raw records, summary for aggregate counts.",
         },
         mode: {
           type: "string",
@@ -3445,8 +3092,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         },
         preset_id: {
           type: "string",
-          description:
-            "Preset id for show/diff, e.g. tight-context or long-context.",
+          description: "Preset id for show/diff, e.g. tight-context or long-context.",
         },
         model: {
           type: "string",
@@ -3605,8 +3251,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
       properties: {
         session_id: {
           type: "string",
-          description:
-            "Session identifier used for idempotency and source refs.",
+          description: "Session identifier used for idempotency and source refs.",
         },
         turn_start: {
           type: "string",
@@ -3618,15 +3263,13 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         },
         text: {
           type: "string",
-          description:
-            "Bounded text segment to scan for labeled extraction lines.",
+          description: "Bounded text segment to scan for labeled extraction lines.",
         },
         host: { type: "string", description: "Optional host/client label." },
         max_chars: {
           type: "integer",
           minimum: 1,
-          description:
-            "Optional maximum input characters to scan before extracting.",
+          description: "Optional maximum input characters to scan before extracting.",
         },
       },
       required: ["session_id", "turn_start", "turn_end", "text"],
@@ -3663,8 +3306,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
   },
   {
     name: "brain_session_describe",
-    description:
-      "Describe counts and summary depths for an imported session recall DAG.",
+    description: "Describe counts and summary depths for an imported session recall DAG.",
     inputSchema: {
       type: "object",
       properties: {
@@ -3727,13 +3369,11 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         },
         receipt: {
           type: "boolean",
-          description:
-            "When true, emit an opt-in context receipt for this pre-compress run.",
+          description: "When true, emit an opt-in context receipt for this pre-compress run.",
         },
         receipt_host: {
           type: "string",
-          description:
-            "Optional host/runtime name for emitted receipts; defaults to `mcp`.",
+          description: "Optional host/runtime name for emitted receipts; defaults to `mcp`.",
         },
         telemetry: {
           type: "boolean",
@@ -3742,8 +3382,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         },
         telemetry_host: {
           type: "string",
-          description:
-            "Optional host/runtime name for emitted telemetry; defaults to `mcp`.",
+          description: "Optional host/runtime name for emitted telemetry; defaults to `mcp`.",
         },
         session_id: {
           type: "string",
@@ -3792,8 +3431,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
       properties: {
         id: {
           type: "string",
-          description:
-            "Target id (e.g. `pref-foo`). Wikilink decoration is stripped if present.",
+          description: "Target id (e.g. `pref-foo`). Wikilink decoration is stripped if present.",
         },
         include_unlinked: {
           type: "boolean",
@@ -3815,8 +3453,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
       properties: {
         id: {
           type: "string",
-          description:
-            "Hub note id (e.g. `pref-foo`). Wikilink decoration is stripped if present.",
+          description: "Hub note id (e.g. `pref-foo`). Wikilink decoration is stripped if present.",
         },
       },
       required: ["id"],
@@ -3834,8 +3471,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
       properties: {
         pref_id: {
           type: "string",
-          description:
-            "Restrict to events for this preference / retired / signal id.",
+          description: "Restrict to events for this preference / retired / signal id.",
         },
         topic: {
           type: "string",
@@ -3843,24 +3479,20 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         },
         kind: {
           type: "string",
-          description:
-            "Restrict to events of this BrainLogEventKind (e.g. `apply-evidence`).",
+          description: "Restrict to events of this BrainLogEventKind (e.g. `apply-evidence`).",
         },
         since: {
           type: "string",
-          description:
-            "Inclusive lower bound (ISO date or ISO timestamp). Defaults to epoch.",
+          description: "Inclusive lower bound (ISO date or ISO timestamp). Defaults to epoch.",
         },
         until: {
           type: "string",
-          description:
-            "Exclusive upper bound (ISO date or ISO timestamp). Defaults to now.",
+          description: "Exclusive upper bound (ISO date or ISO timestamp). Defaults to now.",
         },
         limit: {
           type: "integer",
           minimum: 1,
-          description:
-            "Maximum number of events to return after filtering. Omit for no cap.",
+          description: "Maximum number of events to return after filtering. Omit for no cap.",
         },
       },
       additionalProperties: false,
@@ -3876,8 +3508,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
       properties: {
         pref_id: {
           type: "string",
-          description:
-            "Target preference id (e.g. `pref-foo`). Mutually exclusive with `topic`.",
+          description: "Target preference id (e.g. `pref-foo`). Mutually exclusive with `topic`.",
         },
         topic: {
           type: "string",
@@ -3910,8 +3541,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
       properties: {
         date: {
           type: "string",
-          description:
-            "ISO date (`YYYY-MM-DD`) the brief targets. Defaults to today UTC.",
+          description: "ISO date (`YYYY-MM-DD`) the brief targets. Defaults to today UTC.",
         },
       },
       additionalProperties: false,
@@ -3952,8 +3582,7 @@ export const BRAIN_TOOLS: ReadonlyArray<ToolDefinition> = Object.freeze([
         top_actions: {
           type: "integer",
           minimum: 0,
-          description:
-            "Cap on the ranked maintenance action list. Defaults to 5.",
+          description: "Cap on the ranked maintenance action list. Defaults to 5.",
         },
       },
       additionalProperties: false,

--- a/tests/cli/brain-procedural-learning.test.ts
+++ b/tests/cli/brain-procedural-learning.test.ts
@@ -49,14 +49,7 @@ test("brain procedural learning verbs wire end-to-end", async () => {
   const learnedJson = JSON.parse(learned.stdout);
   expect(learnedJson.created.length).toBeGreaterThanOrEqual(1);
 
-  const listed = await runCli([
-    "brain",
-    "skill-proposals",
-    "list",
-    "--vault",
-    vault,
-    "--json",
-  ]);
+  const listed = await runCli(["brain", "skill-proposals", "list", "--vault", vault, "--json"]);
   expect(listed.returncode).toBe(0);
   const listJson = JSON.parse(listed.stdout);
   expect(listJson.total).toBeGreaterThanOrEqual(1);
@@ -74,26 +67,12 @@ test("brain procedural learning verbs wire end-to-end", async () => {
   ]);
   expect(accepted.returncode).toBe(0);
 
-  const rec = await runCli([
-    "brain",
-    "procedural-memory",
-    "reconcile",
-    "--vault",
-    vault,
-    "--json",
-  ]);
+  const rec = await runCli(["brain", "procedural-memory", "reconcile", "--vault", vault, "--json"]);
   expect(rec.returncode).toBe(0);
   const recJson = JSON.parse(rec.stdout);
   expect(recJson.total).toBeGreaterThanOrEqual(1);
 
-  const mem = await runCli([
-    "brain",
-    "procedural-memory",
-    "list",
-    "--vault",
-    vault,
-    "--json",
-  ]);
+  const mem = await runCli(["brain", "procedural-memory", "list", "--vault", vault, "--json"]);
   expect(mem.returncode).toBe(0);
   const memJson = JSON.parse(mem.stdout);
   expect(memJson.total).toBeGreaterThanOrEqual(1);
@@ -123,14 +102,7 @@ test("brain procedural learning verbs wire end-to-end", async () => {
   const graphRebuildJson = JSON.parse(graphRebuild.stdout);
   expect(graphRebuildJson.operation).toBe("rebuild");
 
-  const graphShow = await runCli([
-    "brain",
-    "procedural-graph",
-    "show",
-    "--vault",
-    vault,
-    "--json",
-  ]);
+  const graphShow = await runCli(["brain", "procedural-graph", "show", "--vault", vault, "--json"]);
   expect(graphShow.returncode).toBe(0);
   const graphShowJson = JSON.parse(graphShow.stdout);
   expect(graphShowJson.nodes.length).toBeGreaterThan(0);
@@ -147,14 +119,7 @@ test("brain procedural learning verbs wire end-to-end", async () => {
   const graphHintsJson = JSON.parse(graphHints.stdout);
   expect(graphHintsJson.entries.length).toBeGreaterThan(0);
 
-  const flowsList = await runCli([
-    "brain",
-    "attention-flows",
-    "list",
-    "--vault",
-    vault,
-    "--json",
-  ]);
+  const flowsList = await runCli(["brain", "attention-flows", "list", "--vault", vault, "--json"]);
   expect(flowsList.returncode).toBe(0);
   const flowsListJson = JSON.parse(flowsList.stdout);
   expect(flowsListJson.total).toBeGreaterThan(0);

--- a/tests/cli/brain-procedural-learning.test.ts
+++ b/tests/cli/brain-procedural-learning.test.ts
@@ -49,7 +49,14 @@ test("brain procedural learning verbs wire end-to-end", async () => {
   const learnedJson = JSON.parse(learned.stdout);
   expect(learnedJson.created.length).toBeGreaterThanOrEqual(1);
 
-  const listed = await runCli(["brain", "skill-proposals", "list", "--vault", vault, "--json"]);
+  const listed = await runCli([
+    "brain",
+    "skill-proposals",
+    "list",
+    "--vault",
+    vault,
+    "--json",
+  ]);
   expect(listed.returncode).toBe(0);
   const listJson = JSON.parse(listed.stdout);
   expect(listJson.total).toBeGreaterThanOrEqual(1);
@@ -67,12 +74,26 @@ test("brain procedural learning verbs wire end-to-end", async () => {
   ]);
   expect(accepted.returncode).toBe(0);
 
-  const rec = await runCli(["brain", "procedural-memory", "reconcile", "--vault", vault, "--json"]);
+  const rec = await runCli([
+    "brain",
+    "procedural-memory",
+    "reconcile",
+    "--vault",
+    vault,
+    "--json",
+  ]);
   expect(rec.returncode).toBe(0);
   const recJson = JSON.parse(rec.stdout);
   expect(recJson.total).toBeGreaterThanOrEqual(1);
 
-  const mem = await runCli(["brain", "procedural-memory", "list", "--vault", vault, "--json"]);
+  const mem = await runCli([
+    "brain",
+    "procedural-memory",
+    "list",
+    "--vault",
+    vault,
+    "--json",
+  ]);
   expect(mem.returncode).toBe(0);
   const memJson = JSON.parse(mem.stdout);
   expect(memJson.total).toBeGreaterThanOrEqual(1);
@@ -89,6 +110,81 @@ test("brain procedural learning verbs wire end-to-end", async () => {
     "--json",
   ]);
   expect(mark.returncode).toBe(0);
+
+  const graphRebuild = await runCli([
+    "brain",
+    "procedural-graph",
+    "rebuild",
+    "--vault",
+    vault,
+    "--json",
+  ]);
+  expect(graphRebuild.returncode).toBe(0);
+  const graphRebuildJson = JSON.parse(graphRebuild.stdout);
+  expect(graphRebuildJson.operation).toBe("rebuild");
+
+  const graphShow = await runCli([
+    "brain",
+    "procedural-graph",
+    "show",
+    "--vault",
+    vault,
+    "--json",
+  ]);
+  expect(graphShow.returncode).toBe(0);
+  const graphShowJson = JSON.parse(graphShow.stdout);
+  expect(graphShowJson.nodes.length).toBeGreaterThan(0);
+
+  const graphHints = await runCli([
+    "brain",
+    "procedural-graph",
+    "hints",
+    "--vault",
+    vault,
+    "--json",
+  ]);
+  expect(graphHints.returncode).toBe(0);
+  const graphHintsJson = JSON.parse(graphHints.stdout);
+  expect(graphHintsJson.entries.length).toBeGreaterThan(0);
+
+  const flowsList = await runCli([
+    "brain",
+    "attention-flows",
+    "list",
+    "--vault",
+    vault,
+    "--json",
+  ]);
+  expect(flowsList.returncode).toBe(0);
+  const flowsListJson = JSON.parse(flowsList.stdout);
+  expect(flowsListJson.total).toBeGreaterThan(0);
+
+  const flowId = flowsListJson.flows[0]?.id;
+  expect(typeof flowId).toBe("string");
+
+  const flowEval = await runCli([
+    "brain",
+    "attention-flows",
+    "evaluate",
+    flowId,
+    "--vault",
+    vault,
+    "--json",
+  ]);
+  expect(flowEval.returncode).toBe(0);
+
+  const flowRender = await runCli([
+    "brain",
+    "attention-flows",
+    "render",
+    flowId,
+    "--vault",
+    vault,
+    "--json",
+  ]);
+  expect(flowRender.returncode).toBe(0);
+  const flowRenderJson = JSON.parse(flowRender.stdout);
+  expect(flowRenderJson.text).toContain("#");
 
   const learnRecurrence = await runCli([
     "brain",

--- a/tests/core/brain.sessions.import.test.ts
+++ b/tests/core/brain.sessions.import.test.ts
@@ -7,14 +7,23 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 import { brainDirs } from "../../src/core/brain/paths.ts";
 import { DEFAULT_BRAIN_CONFIG_YAML } from "../../src/core/brain/policy.ts";
 import { atomicWriteFileSync } from "../../src/core/fs-atomic.ts";
-import { importSession, importSessionPath } from "../../src/core/brain/sessions/import.ts";
+import {
+  importSession,
+  importSessionPath,
+} from "../../src/core/brain/sessions/import.ts";
 import { SessionImportError } from "../../src/core/brain/sessions/types.ts";
 import { describeSessionRecall } from "../../src/core/brain/session-recall.ts";
 
@@ -38,7 +47,10 @@ beforeEach(() => {
   ]) {
     mkdirSync(d, { recursive: true });
   }
-  atomicWriteFileSync(join(dirs.brain, "_brain.yaml"), DEFAULT_BRAIN_CONFIG_YAML);
+  atomicWriteFileSync(
+    join(dirs.brain, "_brain.yaml"),
+    DEFAULT_BRAIN_CONFIG_YAML,
+  );
 });
 
 afterEach(() => {
@@ -92,7 +104,9 @@ describe("importSession", () => {
       dryRun: true,
     });
     expect(res.signals_created).toBe(0);
-    const inbox = readdirSync(brainDirs(tmp).inbox).filter((n) => n.startsWith("sig-"));
+    const inbox = readdirSync(brainDirs(tmp).inbox).filter((n) =>
+      n.startsWith("sig-"),
+    );
     expect(inbox.length).toBe(0);
   });
 
@@ -106,9 +120,31 @@ describe("importSession", () => {
 
     expect(res.recall_turns_imported).toBeGreaterThan(0);
     expect(res.recall_summary_nodes).toBeGreaterThan(0);
-    expect(describeSessionRecall(tmp, { sessionId: "session-import-test" }).raw_turns).toBe(
-      res.recall_turns_imported,
-    );
+    expect(
+      describeSessionRecall(tmp, { sessionId: "session-import-test" })
+        .raw_turns,
+    ).toBe(res.recall_turns_imported);
+  });
+
+  test("supports filtered write mode by role", async () => {
+    const res = await importSession(tmp, CLAUDE, {
+      agent: "test",
+      filterRoles: ["user"],
+    });
+
+    expect(res.signals_created).toBe(1);
+    expect(res.tool_replays).toBe(0);
+    expect(res.filtered_turns).toBeGreaterThan(0);
+  });
+
+  test("supports filtered write mode by text substring", async () => {
+    const res = await importSession(tmp, CLAUDE, {
+      agent: "test",
+      filterTextIncludes: "no-match-substring",
+    });
+
+    expect(res.signals_created).toBe(0);
+    expect(res.filtered_turns).toBe(res.turns_scanned);
   });
 
   test("handles the codex fixture", async () => {

--- a/tests/core/brain.sessions.import.test.ts
+++ b/tests/core/brain.sessions.import.test.ts
@@ -7,23 +7,14 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import {
-  mkdirSync,
-  mkdtempSync,
-  readdirSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 import { brainDirs } from "../../src/core/brain/paths.ts";
 import { DEFAULT_BRAIN_CONFIG_YAML } from "../../src/core/brain/policy.ts";
 import { atomicWriteFileSync } from "../../src/core/fs-atomic.ts";
-import {
-  importSession,
-  importSessionPath,
-} from "../../src/core/brain/sessions/import.ts";
+import { importSession, importSessionPath } from "../../src/core/brain/sessions/import.ts";
 import { SessionImportError } from "../../src/core/brain/sessions/types.ts";
 import { describeSessionRecall } from "../../src/core/brain/session-recall.ts";
 
@@ -47,10 +38,7 @@ beforeEach(() => {
   ]) {
     mkdirSync(d, { recursive: true });
   }
-  atomicWriteFileSync(
-    join(dirs.brain, "_brain.yaml"),
-    DEFAULT_BRAIN_CONFIG_YAML,
-  );
+  atomicWriteFileSync(join(dirs.brain, "_brain.yaml"), DEFAULT_BRAIN_CONFIG_YAML);
 });
 
 afterEach(() => {
@@ -104,9 +92,7 @@ describe("importSession", () => {
       dryRun: true,
     });
     expect(res.signals_created).toBe(0);
-    const inbox = readdirSync(brainDirs(tmp).inbox).filter((n) =>
-      n.startsWith("sig-"),
-    );
+    const inbox = readdirSync(brainDirs(tmp).inbox).filter((n) => n.startsWith("sig-"));
     expect(inbox.length).toBe(0);
   });
 
@@ -120,10 +106,9 @@ describe("importSession", () => {
 
     expect(res.recall_turns_imported).toBeGreaterThan(0);
     expect(res.recall_summary_nodes).toBeGreaterThan(0);
-    expect(
-      describeSessionRecall(tmp, { sessionId: "session-import-test" })
-        .raw_turns,
-    ).toBe(res.recall_turns_imported);
+    expect(describeSessionRecall(tmp, { sessionId: "session-import-test" }).raw_turns).toBe(
+      res.recall_turns_imported,
+    );
   });
 
   test("supports filtered write mode by role", async () => {

--- a/tests/core/brain/attention-flows.test.ts
+++ b/tests/core/brain/attention-flows.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  buildAttentionContextBlock,
+  evaluateAttentionFlow,
+  listAttentionFlows,
+  renderAttentionFlow,
+} from "../../../src/core/brain/attention-flows.ts";
+import { applyRecurrenceEvidence } from "../../../src/core/brain/recurrence.ts";
+import { reconcileProceduralMemory } from "../../../src/core/brain/procedural-memory.ts";
+import { writeFrontmatterAtomic } from "../../../src/core/vault.ts";
+import { skillProposalPendingPath } from "../../../src/core/brain/paths.ts";
+
+let vault: string;
+
+beforeEach(() => {
+  vault = join(
+    tmpdir(),
+    `o2b-attention-flows-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  );
+  mkdirSync(vault, { recursive: true });
+  seedSources(vault);
+});
+
+afterEach(() => {
+  rmSync(vault, { recursive: true, force: true });
+});
+
+describe("attention flow recipes", () => {
+  test("lists default flow and evaluates deterministic sections", () => {
+    const flows = listAttentionFlows(vault);
+    expect(flows.length).toBeGreaterThan(0);
+
+    const report = evaluateAttentionFlow(vault, flows[0]!.id);
+    expect(report.sections.length).toBeGreaterThan(0);
+    expect(renderAttentionFlow(vault, report.flow_id)).toContain("#");
+  });
+
+  test("builds context block for requested flow ids", () => {
+    const flows = listAttentionFlows(vault);
+    const block = buildAttentionContextBlock(vault, [flows[0]!.id]);
+    expect(block).not.toBeNull();
+    expect(block).toContain(flows[0]!.title);
+  });
+});
+
+function seedSources(vaultPath: string): void {
+  const proceduresDir = join(vaultPath, "Brain", "procedures");
+  const skillsDir = join(vaultPath, "skills", "release");
+  mkdirSync(proceduresDir, { recursive: true });
+  mkdirSync(skillsDir, { recursive: true });
+
+  writeFileSync(
+    join(proceduresDir, "proc-release-notes.md"),
+    [
+      "---",
+      "kind: brain-procedure",
+      "triggers: [release, changelog]",
+      "tags: [ops, docs]",
+      "---",
+      "# Release notes procedure",
+    ].join("\n") + "\n",
+    "utf8",
+  );
+
+  writeFileSync(
+    join(skillsDir, "SKILL.md"),
+    [
+      "---",
+      "version: 1",
+      "triggers: [release]",
+      "tags: [ops]",
+      "permissions: [read]",
+      "source: test-suite",
+      "---",
+      "# Release Skill",
+    ].join("\n") + "\n",
+    "utf8",
+  );
+
+  reconcileProceduralMemory(vaultPath, {
+    roots: [join(vaultPath, "Brain", "procedures"), join(vaultPath, "skills")],
+  });
+
+  writeFrontmatterAtomic(
+    skillProposalPendingPath(vaultPath, "release-routine"),
+    {
+      kind: "brain-skill-proposal",
+      id: "prop-release-routine",
+      slug: "release-routine",
+      status: "pending",
+      pattern_kind: "repeated_action",
+    },
+    "# Proposal",
+    {
+      overwrite: false,
+      existsErrorKind: "skill proposal",
+      vaultForRelativePath: vaultPath,
+    },
+  );
+
+  applyRecurrenceEvidence(vaultPath, {
+    contentHash: "h-attn",
+    scope: "project-a",
+    sourceId: "src-1",
+    action: "learn",
+  });
+  applyRecurrenceEvidence(vaultPath, {
+    contentHash: "h-attn",
+    scope: "project-b",
+    sourceId: "src-2",
+    action: "learn",
+  });
+  applyRecurrenceEvidence(vaultPath, {
+    contentHash: "h-attn",
+    scope: "project-c",
+    sourceId: "src-3",
+    action: "learn",
+  });
+}

--- a/tests/core/brain/procedural-graph.test.ts
+++ b/tests/core/brain/procedural-graph.test.ts
@@ -7,10 +7,7 @@ import {
   rebuildProceduralGraph,
   readProceduralGraph,
 } from "../../../src/core/brain/procedural-graph.ts";
-import {
-  proceduralGraphPath,
-  skillProposalAcceptedPath,
-} from "../../../src/core/brain/paths.ts";
+import { proceduralGraphPath, skillProposalAcceptedPath } from "../../../src/core/brain/paths.ts";
 import { reconcileProceduralMemory } from "../../../src/core/brain/procedural-memory.ts";
 
 let vault: string;
@@ -41,9 +38,7 @@ describe("procedural graph projection", () => {
     expect(projection.nodes.length).toBeGreaterThanOrEqual(3);
     expect(projection.edges.length).toBeGreaterThan(0);
 
-    const proposalNode = projection.nodes.find(
-      (node) => node.kind === "proposal",
-    );
+    const proposalNode = projection.nodes.find((node) => node.kind === "proposal");
     expect(proposalNode).toBeDefined();
 
     const entityNode = projection.nodes.find((node) => node.kind === "entity");
@@ -56,9 +51,7 @@ describe("procedural graph projection", () => {
 
   test("returns null when projection file does not exist", () => {
     expect(readProceduralGraph(vault)).toBeNull();
-    expect(
-      proceduralGraphPath(vault).endsWith("Brain/procedural-memory/graph.json"),
-    ).toBe(true);
+    expect(proceduralGraphPath(vault).endsWith("Brain/procedural-memory/graph.json")).toBe(true);
   });
 });
 

--- a/tests/core/brain/procedural-graph.test.ts
+++ b/tests/core/brain/procedural-graph.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import {
+  rebuildProceduralGraph,
+  readProceduralGraph,
+} from "../../../src/core/brain/procedural-graph.ts";
+import {
+  proceduralGraphPath,
+  skillProposalAcceptedPath,
+} from "../../../src/core/brain/paths.ts";
+import { reconcileProceduralMemory } from "../../../src/core/brain/procedural-memory.ts";
+
+let vault: string;
+
+beforeEach(() => {
+  vault = join(
+    tmpdir(),
+    `o2b-procedural-graph-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  );
+  mkdirSync(vault, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(vault, { recursive: true, force: true });
+});
+
+describe("procedural graph projection", () => {
+  test("rebuilds graph with entry nodes, proposal nodes, and entity links", () => {
+    seedProceduralSources(vault);
+    reconcileProceduralMemory(vault, {
+      roots: [join(vault, "Brain", "procedures"), join(vault, "skills")],
+    });
+
+    const projection = rebuildProceduralGraph(vault, {
+      now: new Date("2026-06-02T10:00:00Z"),
+    });
+    expect(projection.schema_version).toBe(1);
+    expect(projection.nodes.length).toBeGreaterThanOrEqual(3);
+    expect(projection.edges.length).toBeGreaterThan(0);
+
+    const proposalNode = projection.nodes.find(
+      (node) => node.kind === "proposal",
+    );
+    expect(proposalNode).toBeDefined();
+
+    const entityNode = projection.nodes.find((node) => node.kind === "entity");
+    expect(entityNode).toBeDefined();
+
+    const restored = readProceduralGraph(vault);
+    expect(restored).not.toBeNull();
+    expect(restored?.generated_at).toBe("2026-06-02T10:00:00.000Z");
+  });
+
+  test("returns null when projection file does not exist", () => {
+    expect(readProceduralGraph(vault)).toBeNull();
+    expect(
+      proceduralGraphPath(vault).endsWith("Brain/procedural-memory/graph.json"),
+    ).toBe(true);
+  });
+});
+
+function seedProceduralSources(vaultPath: string): void {
+  const proceduresDir = join(vaultPath, "Brain", "procedures");
+  const skillsDir = join(vaultPath, "skills", "release");
+  mkdirSync(proceduresDir, { recursive: true });
+  mkdirSync(skillsDir, { recursive: true });
+
+  writeFileSync(
+    join(proceduresDir, "proc-release-notes.md"),
+    [
+      "---",
+      "kind: brain-procedure",
+      "source_proposal: prop-release-notes",
+      "triggers: [release, changelog]",
+      "tags: [ops, docs]",
+      "---",
+      "# Release notes procedure",
+    ].join("\n") + "\n",
+    "utf8",
+  );
+
+  writeFileSync(
+    join(skillsDir, "SKILL.md"),
+    [
+      "---",
+      "version: 1",
+      "triggers: [release]",
+      "tags: [ops]",
+      "permissions: [read]",
+      "source: test-suite",
+      "---",
+      "# Release Skill",
+    ].join("\n") + "\n",
+    "utf8",
+  );
+
+  writeFileSync(
+    ensureParent(skillProposalAcceptedPath(vaultPath, "release-notes")),
+    [
+      "---",
+      "kind: brain-skill-proposal",
+      "id: prop-release-notes",
+      "slug: release-notes",
+      "status: accepted",
+      "pattern_kind: repeated_action",
+      "---",
+      "# Proposal release-notes",
+    ].join("\n") + "\n",
+    "utf8",
+  );
+}
+
+function ensureParent(path: string): string {
+  mkdirSync(dirname(path), { recursive: true });
+  return path;
+}

--- a/tests/core/brain/procedural-hints.test.ts
+++ b/tests/core/brain/procedural-hints.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  readProceduralHints,
+  rebuildProceduralHints,
+} from "../../../src/core/brain/procedural-hints.ts";
+import { rebuildProceduralGraph } from "../../../src/core/brain/procedural-graph.ts";
+import { reconcileProceduralMemory } from "../../../src/core/brain/procedural-memory.ts";
+
+let vault: string;
+
+beforeEach(() => {
+  vault = join(
+    tmpdir(),
+    `o2b-procedural-hints-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  );
+  mkdirSync(vault, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(vault, { recursive: true, force: true });
+});
+
+describe("procedural hints projection", () => {
+  test("builds deterministic hint cues from graph nodes", () => {
+    seedSources(vault);
+    reconcileProceduralMemory(vault, {
+      roots: [join(vault, "Brain", "procedures"), join(vault, "skills")],
+    });
+    const graph = rebuildProceduralGraph(vault, {
+      now: new Date("2026-06-02T12:00:00Z"),
+    });
+
+    const hints = rebuildProceduralHints(vault, {
+      graph,
+      now: new Date("2026-06-02T12:01:00Z"),
+    });
+
+    expect(hints.schema_version).toBe(1);
+    expect(hints.generated_at).toBe("2026-06-02T12:01:00.000Z");
+    expect(hints.entries.length).toBeGreaterThan(0);
+
+    const first = hints.entries[0]!;
+    expect(first.cues.length).toBeGreaterThan(0);
+  });
+
+  test("returns null when no projection exists", () => {
+    expect(readProceduralHints(vault)).toBeNull();
+  });
+});
+
+function seedSources(vaultPath: string): void {
+  const proceduresDir = join(vaultPath, "Brain", "procedures");
+  const skillsDir = join(vaultPath, "skills", "release");
+  mkdirSync(proceduresDir, { recursive: true });
+  mkdirSync(skillsDir, { recursive: true });
+
+  writeFileSync(
+    join(proceduresDir, "proc-release-notes.md"),
+    [
+      "---",
+      "kind: brain-procedure",
+      "triggers: [release, changelog]",
+      "tags: [ops, docs]",
+      "---",
+      "# Release notes procedure",
+    ].join("\n") + "\n",
+    "utf8",
+  );
+
+  writeFileSync(
+    join(skillsDir, "SKILL.md"),
+    [
+      "---",
+      "version: 1",
+      "triggers: [release]",
+      "tags: [ops]",
+      "permissions: [read]",
+      "source: test-suite",
+      "---",
+      "# Release Skill",
+    ].join("\n") + "\n",
+    "utf8",
+  );
+}

--- a/tests/core/brain/skill-proposals.test.ts
+++ b/tests/core/brain/skill-proposals.test.ts
@@ -123,9 +123,7 @@ describe("skill proposal learning", () => {
     });
 
     const pending = listPendingSkillProposals(vault);
-    const target = pending.find(
-      (item) => item.patternKind === "repeated_action",
-    );
+    const target = pending.find((item) => item.patternKind === "repeated_action");
     expect(target).toBeDefined();
 
     const accepted = acceptSkillProposal(vault, target!.slug, {
@@ -134,15 +132,9 @@ describe("skill proposal learning", () => {
     });
 
     expect(accepted.status).toBe("accepted");
-    expect(existsSync(skillProposalAcceptedPath(vault, target!.slug))).toBe(
-      true,
-    );
+    expect(existsSync(skillProposalAcceptedPath(vault, target!.slug))).toBe(true);
     expect(existsSync(procedurePath(vault, target!.slug))).toBe(true);
-    expect(
-      listPendingSkillProposals(vault).some(
-        (item) => item.slug === target!.slug,
-      ),
-    ).toBe(false);
+    expect(listPendingSkillProposals(vault).some((item) => item.slug === target!.slug)).toBe(false);
   });
 
   test("reject moves proposal and prevents unchanged reappearance", () => {
@@ -162,14 +154,8 @@ describe("skill proposal learning", () => {
     });
 
     expect(rejected.status).toBe("rejected");
-    expect(existsSync(skillProposalRejectedPath(vault, target!.slug))).toBe(
-      true,
-    );
-    expect(
-      listPendingSkillProposals(vault).some(
-        (item) => item.slug === target!.slug,
-      ),
-    ).toBe(false);
+    expect(existsSync(skillProposalRejectedPath(vault, target!.slug))).toBe(true);
+    expect(listPendingSkillProposals(vault).some((item) => item.slug === target!.slug)).toBe(false);
 
     const rerun = learnSkillProposals(vault, {
       now: new Date("2026-06-02T13:00:00Z"),

--- a/tests/mcp/mcp.test.ts
+++ b/tests/mcp/mcp.test.ts
@@ -19,7 +19,12 @@ const savedEnv: Record<string, string | undefined> = {};
 
 beforeEach(() => {
   tmp = mkdtempSync(join(tmpdir(), "o2b-mcp-test-"));
-  for (const k of ["VAULT_AGENT_NAME", "VAULT_TIMEZONE", "VAULT_DIR", "OPEN_SECOND_BRAIN_CONFIG"]) {
+  for (const k of [
+    "VAULT_AGENT_NAME",
+    "VAULT_TIMEZONE",
+    "VAULT_DIR",
+    "OPEN_SECOND_BRAIN_CONFIG",
+  ]) {
     savedEnv[k] = process.env[k];
     delete process.env[k];
   }
@@ -163,7 +168,9 @@ describe("tool listing", () => {
       id: 2,
       method: "tools/list",
     })) as any;
-    const names = r.result.tools.map((tool: { name: string }) => tool.name).toSorted();
+    const names = r.result.tools
+      .map((tool: { name: string }) => tool.name)
+      .toSorted();
     expect(names).toEqual(
       [
         // Runtime capability diagnostics (v0.23.0).
@@ -231,7 +238,9 @@ describe("tool listing", () => {
         // Procedural-learning surfaces (v0.30.0).
         "brain_skill_proposals",
         "brain_procedural_memory",
+        "brain_procedural_graph",
         "brain_recurrence",
+        "brain_attention_flows",
         // Pay Memory (unchanged).
         "payment_memory_init",
         "payment_receipt_append",
@@ -315,7 +324,9 @@ describe("tool calls", () => {
     expect(s.vault.ignore_source).toBeDefined();
     expect(["_brain.yaml", "defaults"]).toContain(s.vault.ignore_source);
     expect(Array.isArray(s.vault.rules)).toBe(true);
-    expect(s.vault.rules.some((r: { raw: string }) => r.raw === ".obsidian")).toBe(true);
+    expect(
+      s.vault.rules.some((r: { raw: string }) => r.raw === ".obsidian"),
+    ).toBe(true);
     expect(typeof s.vault.included.files).toBe("number");
     expect(typeof s.vault.included.dirs).toBe("number");
     expect(typeof s.vault.excluded.dirs).toBe("number");
@@ -376,7 +387,9 @@ describe("tool calls", () => {
     const s = r.result.structuredContent;
     expect(s.limit).toBe(5);
     expect(s.total_pages).toBeGreaterThanOrEqual(1);
-    expect(s.pages.some((p: { title: string }) => p.title.includes("Sandbox"))).toBe(true);
+    expect(
+      s.pages.some((p: { title: string }) => p.title.includes("Sandbox")),
+    ).toBe(true);
   });
 
   // `second_brain_capture` and `event_log_append` are no longer
@@ -443,7 +456,9 @@ describe("tool calls", () => {
     const r = (await callTool(server, "bad_contract")) as any;
     expect(r.result.isError).toBe(true);
     expect(r.result.structuredContent).toBeUndefined();
-    expect(r.result.content[0].text).toContain("bad_contract output contract failed");
+    expect(r.result.content[0].text).toContain(
+      "bad_contract output contract failed",
+    );
   });
 });
 
@@ -496,7 +511,9 @@ describe("stdio loop", () => {
     // + brain_recall_gate (v0.27.0) = 58.
     // + 7 context continuity/session recall tools (v0.29.0) = 65.
     // + 3 procedural-learning tools (v0.30.0) = 68.
-    expect(list.result.tools.length).toBe(68);
+    // + brain_procedural_graph (v0.31.0) = 69.
+    // + brain_attention_flows (v0.31.0) = 70.
+    expect(list.result.tools.length).toBe(70);
   });
 
   test("returns parse error for invalid JSON", async () => {

--- a/tests/mcp/mcp.test.ts
+++ b/tests/mcp/mcp.test.ts
@@ -19,12 +19,7 @@ const savedEnv: Record<string, string | undefined> = {};
 
 beforeEach(() => {
   tmp = mkdtempSync(join(tmpdir(), "o2b-mcp-test-"));
-  for (const k of [
-    "VAULT_AGENT_NAME",
-    "VAULT_TIMEZONE",
-    "VAULT_DIR",
-    "OPEN_SECOND_BRAIN_CONFIG",
-  ]) {
+  for (const k of ["VAULT_AGENT_NAME", "VAULT_TIMEZONE", "VAULT_DIR", "OPEN_SECOND_BRAIN_CONFIG"]) {
     savedEnv[k] = process.env[k];
     delete process.env[k];
   }
@@ -168,9 +163,7 @@ describe("tool listing", () => {
       id: 2,
       method: "tools/list",
     })) as any;
-    const names = r.result.tools
-      .map((tool: { name: string }) => tool.name)
-      .toSorted();
+    const names = r.result.tools.map((tool: { name: string }) => tool.name).toSorted();
     expect(names).toEqual(
       [
         // Runtime capability diagnostics (v0.23.0).
@@ -324,9 +317,7 @@ describe("tool calls", () => {
     expect(s.vault.ignore_source).toBeDefined();
     expect(["_brain.yaml", "defaults"]).toContain(s.vault.ignore_source);
     expect(Array.isArray(s.vault.rules)).toBe(true);
-    expect(
-      s.vault.rules.some((r: { raw: string }) => r.raw === ".obsidian"),
-    ).toBe(true);
+    expect(s.vault.rules.some((r: { raw: string }) => r.raw === ".obsidian")).toBe(true);
     expect(typeof s.vault.included.files).toBe("number");
     expect(typeof s.vault.included.dirs).toBe("number");
     expect(typeof s.vault.excluded.dirs).toBe("number");
@@ -387,9 +378,7 @@ describe("tool calls", () => {
     const s = r.result.structuredContent;
     expect(s.limit).toBe(5);
     expect(s.total_pages).toBeGreaterThanOrEqual(1);
-    expect(
-      s.pages.some((p: { title: string }) => p.title.includes("Sandbox")),
-    ).toBe(true);
+    expect(s.pages.some((p: { title: string }) => p.title.includes("Sandbox"))).toBe(true);
   });
 
   // `second_brain_capture` and `event_log_append` are no longer
@@ -456,9 +445,7 @@ describe("tool calls", () => {
     const r = (await callTool(server, "bad_contract")) as any;
     expect(r.result.isError).toBe(true);
     expect(r.result.structuredContent).toBeUndefined();
-    expect(r.result.content[0].text).toContain(
-      "bad_contract output contract failed",
-    );
+    expect(r.result.content[0].text).toContain("bad_contract output contract failed");
   });
 });
 

--- a/tests/mcp/procedural-learning-tools.test.ts
+++ b/tests/mcp/procedural-learning-tools.test.ts
@@ -4,7 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { appendContinuityRecord } from "../../src/core/brain/continuity/store.ts";
-import { JSONRPC_VERSION, MCPServer, PROTOCOL_VERSION } from "../../src/mcp/index.ts";
+import {
+  JSONRPC_VERSION,
+  MCPServer,
+  PROTOCOL_VERSION,
+} from "../../src/mcp/index.ts";
 import { buildToolTable } from "../../src/mcp/tools.ts";
 
 let vault: string;
@@ -74,8 +78,12 @@ describe("procedural learning tool registration", () => {
       "brain_recurrence",
       "brain_attention_flows",
     ] as const) {
-      expect(buildToolTable("full").find((tool) => tool.name === name)).toBeDefined();
-      expect(buildToolTable("writer").find((tool) => tool.name === name)).toBeUndefined();
+      expect(
+        buildToolTable("full").find((tool) => tool.name === name),
+      ).toBeDefined();
+      expect(
+        buildToolTable("writer").find((tool) => tool.name === name),
+      ).toBeUndefined();
     }
   });
 });
@@ -127,7 +135,9 @@ describe("procedural learning MCP tools", () => {
       operation: "rebuild",
     });
     expect(graphRebuild.operation).toBe("rebuild");
-    expect((graphRebuild.graph as Record<string, unknown>).nodes as number).toBeGreaterThan(0);
+    expect(
+      (graphRebuild.graph as Record<string, unknown>).nodes as number,
+    ).toBeGreaterThan(0);
 
     const graphShow = await callTool(server, "brain_procedural_graph", {
       operation: "show",
@@ -143,13 +153,23 @@ describe("procedural learning MCP tools", () => {
       operation: "list",
     });
     expect(flowsList.total).toBeGreaterThan(0);
-    const flowId = (flowsList.flows as Array<Record<string, unknown>>)[0]!["id"] as string;
+    const flowId = (flowsList.flows as Array<Record<string, unknown>>)[0]![
+      "id"
+    ] as string;
 
     const flowsEval = await callTool(server, "brain_attention_flows", {
       operation: "evaluate",
       flow_id: flowId,
     });
     expect((flowsEval.sections as unknown[]).length).toBeGreaterThan(0);
+
+    const flowsRender = await callTool(server, "brain_attention_flows", {
+      operation: "render",
+      flow_id: flowId,
+    });
+    expect(flowsRender.flow_id).toBe(flowId);
+    expect(typeof flowsRender.text).toBe("string");
+    expect((flowsRender.text as string).length).toBeGreaterThan(0);
 
     const recLearn = await callTool(server, "brain_recurrence", {
       operation: "learn",

--- a/tests/mcp/procedural-learning-tools.test.ts
+++ b/tests/mcp/procedural-learning-tools.test.ts
@@ -4,7 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { appendContinuityRecord } from "../../src/core/brain/continuity/store.ts";
-import { JSONRPC_VERSION, MCPServer, PROTOCOL_VERSION } from "../../src/mcp/index.ts";
+import {
+  JSONRPC_VERSION,
+  MCPServer,
+  PROTOCOL_VERSION,
+} from "../../src/mcp/index.ts";
 import { buildToolTable } from "../../src/mcp/tools.ts";
 
 let vault: string;
@@ -70,16 +74,22 @@ describe("procedural learning tool registration", () => {
     for (const name of [
       "brain_skill_proposals",
       "brain_procedural_memory",
+      "brain_procedural_graph",
       "brain_recurrence",
+      "brain_attention_flows",
     ] as const) {
-      expect(buildToolTable("full").find((tool) => tool.name === name)).toBeDefined();
-      expect(buildToolTable("writer").find((tool) => tool.name === name)).toBeUndefined();
+      expect(
+        buildToolTable("full").find((tool) => tool.name === name),
+      ).toBeDefined();
+      expect(
+        buildToolTable("writer").find((tool) => tool.name === name),
+      ).toBeUndefined();
     }
   });
 });
 
 describe("procedural learning MCP tools", () => {
-  test("skill proposals, procedural memory, and recurrence work end-to-end", async () => {
+  test("skill proposals, procedural memory, procedural graph, and recurrence work end-to-end", async () => {
     const server = new MCPServer({ vault });
     await initialize(server);
 
@@ -120,6 +130,38 @@ describe("procedural learning MCP tools", () => {
       id: entries[0]!["id"],
     });
     expect(marked.usedCount).toBeGreaterThanOrEqual(1);
+
+    const graphRebuild = await callTool(server, "brain_procedural_graph", {
+      operation: "rebuild",
+    });
+    expect(graphRebuild.operation).toBe("rebuild");
+    expect(
+      (graphRebuild.graph as Record<string, unknown>).nodes as number,
+    ).toBeGreaterThan(0);
+
+    const graphShow = await callTool(server, "brain_procedural_graph", {
+      operation: "show",
+    });
+    expect((graphShow.nodes as unknown[]).length).toBeGreaterThan(0);
+
+    const graphHints = await callTool(server, "brain_procedural_graph", {
+      operation: "hints",
+    });
+    expect((graphHints.entries as unknown[]).length).toBeGreaterThan(0);
+
+    const flowsList = await callTool(server, "brain_attention_flows", {
+      operation: "list",
+    });
+    expect(flowsList.total).toBeGreaterThan(0);
+    const flowId = (flowsList.flows as Array<Record<string, unknown>>)[0]![
+      "id"
+    ] as string;
+
+    const flowsEval = await callTool(server, "brain_attention_flows", {
+      operation: "evaluate",
+      flow_id: flowId,
+    });
+    expect((flowsEval.sections as unknown[]).length).toBeGreaterThan(0);
 
     const recLearn = await callTool(server, "brain_recurrence", {
       operation: "learn",

--- a/tests/mcp/procedural-learning-tools.test.ts
+++ b/tests/mcp/procedural-learning-tools.test.ts
@@ -4,11 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { appendContinuityRecord } from "../../src/core/brain/continuity/store.ts";
-import {
-  JSONRPC_VERSION,
-  MCPServer,
-  PROTOCOL_VERSION,
-} from "../../src/mcp/index.ts";
+import { JSONRPC_VERSION, MCPServer, PROTOCOL_VERSION } from "../../src/mcp/index.ts";
 import { buildToolTable } from "../../src/mcp/tools.ts";
 
 let vault: string;
@@ -78,12 +74,8 @@ describe("procedural learning tool registration", () => {
       "brain_recurrence",
       "brain_attention_flows",
     ] as const) {
-      expect(
-        buildToolTable("full").find((tool) => tool.name === name),
-      ).toBeDefined();
-      expect(
-        buildToolTable("writer").find((tool) => tool.name === name),
-      ).toBeUndefined();
+      expect(buildToolTable("full").find((tool) => tool.name === name)).toBeDefined();
+      expect(buildToolTable("writer").find((tool) => tool.name === name)).toBeUndefined();
     }
   });
 });
@@ -135,9 +127,7 @@ describe("procedural learning MCP tools", () => {
       operation: "rebuild",
     });
     expect(graphRebuild.operation).toBe("rebuild");
-    expect(
-      (graphRebuild.graph as Record<string, unknown>).nodes as number,
-    ).toBeGreaterThan(0);
+    expect((graphRebuild.graph as Record<string, unknown>).nodes as number).toBeGreaterThan(0);
 
     const graphShow = await callTool(server, "brain_procedural_graph", {
       operation: "show",
@@ -153,9 +143,7 @@ describe("procedural learning MCP tools", () => {
       operation: "list",
     });
     expect(flowsList.total).toBeGreaterThan(0);
-    const flowId = (flowsList.flows as Array<Record<string, unknown>>)[0]![
-      "id"
-    ] as string;
+    const flowId = (flowsList.flows as Array<Record<string, unknown>>)[0]!["id"] as string;
 
     const flowsEval = await callTool(server, "brain_attention_flows", {
       operation: "evaluate",


### PR DESCRIPTION
## Summary

This PR extends the procedural learning foundations with an operator-visible attention layer and stronger ingestion controls. It adds deterministic procedural graph and hint projections, declarative attention-flow recipes for open loops and recurrent learnings, and scoped session import with filtered write mode. The implementation keeps local-first behavior, preserves explicit review control, and exposes the new surfaces consistently across CLI and MCP.

This PR covers the selected scope and closes:
- t_ee819f4b
- t_02e22d4e
- t_2fe5cffa
- t_25d4dbfb
- t_5d63937b
- t_f935fe84

## Why this matters

```mermaid
flowchart LR
  subgraph Before["Before - procedural signals were hard to operationalize"]
    B1["Session continuity + installed procedures + recurrence evidence"]
    B2["Partial procedural visibility"]
    B3["Manual synthesis by operator"]
    B4["Slow triage and inconsistent next actions"]

    B1 --> B2 --> B3 --> B4
  end

  subgraph After["After - procedural attention suite"]
    A1["Deterministic procedural graph projection"]
    A2["Derived procedural hints projection"]
    A3["Declarative attention-flow recipes"]
    A4["Scoped ingest and filtered write mode"]
    A5["Context-pack attention flow injection"]
    A6["Aligned CLI and MCP operator surfaces"]
    A7["Faster, auditable procedure-level decisions"]

    A1 --> A2
    A1 --> A3
    A4 --> A1
    A3 --> A5 --> A6 --> A7
    A2 --> A6
  end

  Before -->|"replace implicit/manual synthesis with explicit deterministic projections"| After
```

## Concrete benefits

- Faster operator triage: graph, hints, and attention flow renderings are explicit and auditable.
- Better context quality: scoped ingest and flow injection reduce noisy carry-over.
- Stronger consistency: write-time rebuild hooks keep derived projections in sync.
- Stable automation surface: CLI and MCP contracts are covered by targeted tests.

## What ships

- Core:
  - procedural graph projection and procedural hints projection
  - declarative attention-flow evaluator/renderer
  - context-pack attention flow injection
  - scoped session import and filtered write mode
- CLI:
  - brain procedural-graph commands
  - brain attention-flows commands
  - import-session filters for ingest scope, role, and text
- MCP:
  - brain_procedural_graph tool
  - brain_attention_flows tool
  - context-pack support for attention_flow_ids
- Tests:
  - new and extended core, CLI, and MCP suites for all above surfaces

## Validation

- Focused changed-area suites are passing.
- Full project test run is passing.
- Formatting and lint checks executed before commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `brain procedural-graph` (rebuild, show, hints) and `brain attention-flows` (list, evaluate, render) CLI commands.
  * Session import filtering: `--ingest-scope`, `--filter-role`, `--filter-text`.
  * Context packing can include attention-flow context via `attention_flow_ids`.
  * MCP tools updated to expose procedural-graph and attention-flows.

* **Documentation**
  * Added design, plan, variants, prompt, and CLI-output docs for the Procedural Attention Suite.

* **Tests**
  * New and updated tests covering procedural graph, hints, attention-flows, imports, and MCP integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->