### PR TITLE
chore(release): v0.31.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "Plugin-first second brain package for AI agents and humans.",
   "author": {
     "name": "Open Second Brain contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "skills": "./skills",
   "hooks": "./hooks/hooks.json",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.31.0] - 2026-06-01
+
+Procedural attention suite. The procedural-learning foundations gain an operator-visible attention layer and stronger ingestion controls: deterministic procedural graph and hint projections, declarative attention-flow recipes for open loops and recurrent learnings, and scoped session import with a filtered write mode. Behavior stays local-first and review-first, and the new surfaces are exposed consistently across CLI and MCP.
+
+### Added
+
+- Deterministic procedural graph projection and derived procedural hints projection over installed procedures and recurrence evidence, rebuilt through write-time hooks. CLI `o2b brain procedural-graph <rebuild|show|hints>` and MCP `brain_procedural_graph`.
+- Declarative attention-flow recipes for open loops and recurrent learnings, with an evaluator/renderer surface. CLI `o2b brain attention-flows <list|evaluate|render>` and MCP `brain_attention_flows`.
+- Context-pack attention-flow injection: `brain_context_pack` accepts `attention_flow_ids` to fold evaluated flows into the assembled context.
+- Scoped session import and filtered write mode: `o2b brain import-session` gains `--ingest-scope`, `--filter-role`, and `--filter-text` to reduce noisy carry-over while preserving default import behavior.
+
+### Changed
+
+- CLI help/verb registry and the MCP tool listing now expose the procedural-graph and attention-flow surfaces.
+
+### Notes
+
+- Procedural graph, hints, and attention-flow projections are deterministic and local-first by default; derived projections are kept in sync through write-time rebuild hooks rather than hidden background mutation.
+- Full suite green on merge: 3042 tests passing, typecheck clean, lint warning-only on the existing baseline; canonical version `0.31.0` synced across all manifests.
+
 ## [0.30.0] - 2026-06-01
 
 Self-learning procedural memory foundations. Open Second Brain can now detect repeatable workflows from continuity records, route them through a reviewable proposal queue, index procedural artifacts, and track recurrence/support evidence across scopes.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "open-second-brain",
   "name": "Open Second Brain",
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults.",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "activation": { "onStartup": true },
   "skills": ["./skills"],
   "contracts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "private": false,
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults. Works with Hermes, Claude Code, Codex, and OpenClaw.",
   "keywords": [

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "0.30.0"
+version: "0.31.0"
 description: "Hermes plugin entrypoint for OpenSecondBrain vault health checks and the optional MCP tool server."
 author: "OpenSecondBrain contributors"
 kind: standalone

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "author": {
     "name": "Open Second Brain contributors",

--- a/plugins/hermes/plugin.yaml
+++ b/plugins/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "0.30.0"
+version: "0.31.0"
 description: "Hermes adapter for OpenSecondBrain vault health checks and optional MCP tool server."
 author: "OpenSecondBrain contributors"
 kind: standalone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 # CLI entry points (those moved to `package.json` `bin`).
 [project]
 name = "open-second-brain"
-version = "0.30.0"
+version = "0.31.0"
 description = "Hermes Python shim for Open Second Brain. Most of the project (CLI, MCP server, OpenClaw plugin) is TypeScript on Bun; see package.json."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Release-prep for v0.31.0. Bumps the canonical version `0.30.0 -> 0.31.0`, syncs it across all runtime manifests, and adds the `CHANGELOG.md` entry for the Procedural Attention Suite shipped in #58 (whose merge did not include the version bump or changelog entry).

## What changes

- `package.json` version `0.30.0 -> 0.31.0`; propagated to plugin/manifest targets via `bun run sync-version`.
- New `CHANGELOG.md [0.31.0]` entry describing the procedural graph/hints projections, declarative attention-flow recipes, context-pack attention-flow injection, and scoped/filtered session import from #58.

No source or behavior changes - manifests and changelog only.

## Test plan

- [x] `bun run sync-version:check` - all manifests aligned at `0.31.0`.
- [x] `bun test tests/version.test.ts` - 7 pass (SERVER_VERSION + manifest sync).
