### PR TITLE
fix(hermes): root cli.py shim completes the upstream CLI discovery contract

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "Plugin-first second brain package for AI agents and humans.",
   "author": {
     "name": "Open Second Brain contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "skills": "./skills",
   "hooks": "./hooks/hooks.json",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.43.1] - 2026-06-04
+
+Patch release: the Hermes CLI discovery contract is now actually
+satisfied for standalone installs. Hermes'
+`discover_plugin_cli_commands()` scans only `<plugin_root>/cli.py`,
+while the implementation lives in `plugins/hermes/cli.py`, so the
+documented `hermes open-second-brain` CLI subtree was never
+discoverable on a stock Hermes. A root re-export shim closes the gap.
+
+### Fixed
+
+- **Root `cli.py` shim for Hermes CLI discovery.** A relative
+  re-export (`from .plugins.hermes.cli import register_cli, run`)
+  through the synthetic parent packages the upstream loader registers
+  (hermes-agent PR #37366) makes the `hermes open-second-brain`
+  subcommands discoverable before the provider itself loads. The
+  import stays SDK-free. A loader-contract test mirrors the upstream
+  scan's exact import sequence so the contract cannot break silently.
+
 ## [0.43.0] - 2026-06-04
 
 Entity Truth & Self-Improving Dream Suite: a current-truth surface
@@ -4602,6 +4621,7 @@ plugin config (vault field)`, and exits with a clear
 - Sandbox vault and plugin manifest fixtures for tests.
 - GitHub release workflow for tag-based and manually dispatched releases.
 
+[0.43.1]: https://github.com/itechmeat/open-second-brain/compare/v0.43.0...v0.43.1
 [0.43.0]: https://github.com/itechmeat/open-second-brain/compare/v0.42.0...v0.43.0
 [0.42.0]: https://github.com/itechmeat/open-second-brain/compare/v0.41.0...v0.42.0
 [0.41.0]: https://github.com/itechmeat/open-second-brain/compare/v0.40.0...v0.41.0

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,18 @@
+"""Hermes CLI discovery shim.
+
+Hermes' ``discover_plugin_cli_commands()`` performs a lightweight scan: it
+imports ``<plugin_root>/cli.py`` as ``_hermes_user_memory.<name>.cli`` with
+the synthetic parent packages pre-registered (hermes-agent PR #37366) and
+WITHOUT executing the plugin's root ``__init__.py``. The implementation lives
+in ``plugins/hermes/cli.py``; this shim re-exports it through the relative
+path the registered parent shell resolves, so the documented
+``hermes open-second-brain`` CLI subtree is discoverable before the provider
+itself is loaded. The import stays SDK-free: ``plugins/hermes`` soft-imports
+the Hermes ABC with a local fallback.
+"""
+
+from __future__ import annotations
+
+from .plugins.hermes.cli import register_cli, run
+
+__all__ = ["register_cli", "run"]

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "open-second-brain",
   "name": "Open Second Brain",
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults.",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "activation": { "onStartup": true },
   "skills": ["./skills"],
   "contracts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "private": false,
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults. Works with Hermes, Claude Code, Codex, and OpenClaw.",
   "keywords": [

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "0.43.0"
+version: "0.43.1"
 description: "Open Second Brain - native Hermes memory provider backed by an Obsidian-compatible Markdown vault."
 author: "Open Second Brain contributors"
 memory_provider: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "author": {
     "name": "Open Second Brain contributors",

--- a/plugins/hermes/plugin.yaml
+++ b/plugins/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "0.43.0"
+version: "0.43.1"
 description: "Open Second Brain - native Hermes memory provider backed by an Obsidian-compatible Markdown vault."
 author: "Open Second Brain contributors"
 memory_provider: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 # CLI entry points (those moved to `package.json` `bin`).
 [project]
 name = "open-second-brain"
-version = "0.43.0"
+version = "0.43.1"
 description = "Hermes Python shim for Open Second Brain. Most of the project (CLI, MCP server, OpenClaw plugin) is TypeScript on Bun; see package.json."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/python/test_hermes_plugin.py
+++ b/tests/python/test_hermes_plugin.py
@@ -140,6 +140,44 @@ class HermesLoaderContractTests(unittest.TestCase):
         self.assertNotIn("spec_from_file_location", source)
         self.assertIn("from .plugins.hermes import", source)
 
+    def test_root_cli_shim_loads_through_the_lightweight_scan(self):
+        """Mirror ``discover_plugin_cli_commands()`` for a user plugin.
+
+        The scan imports ``<plugin_root>/cli.py`` as
+        ``_hermes_user_memory.<name>.cli`` after registering the synthetic
+        parent packages (the parent shell carries the plugin dir as its
+        search location) and never executes the root ``__init__.py``. The
+        root ``cli.py`` shim must resolve ``register_cli`` through that
+        exact sequence and wire an argparse subtree.
+        """
+        import argparse
+
+        synthetic_cli = f"{self.SYNTHETIC_PARENT}.{PLUGIN_NAME}.cli"
+        # Parent shells exactly as the loader registers them: the namespace
+        # root with no search locations, the per-provider shell with the
+        # plugin directory.
+        for mod_name, locations in (
+            (self.SYNTHETIC_PARENT, []),
+            (f"{self.SYNTHETIC_PARENT}.{PLUGIN_NAME}", [str(ROOT)]),
+        ):
+            spec = importlib.util.spec_from_loader(mod_name, loader=None, is_package=True)
+            spec.submodule_search_locations = locations
+            sys.modules[mod_name] = importlib.util.module_from_spec(spec)
+        spec = importlib.util.spec_from_file_location(synthetic_cli, ROOT / "cli.py")
+        cli_mod = importlib.util.module_from_spec(spec)
+        sys.modules[synthetic_cli] = cli_mod
+        try:
+            spec.loader.exec_module(cli_mod)
+            self.assertTrue(callable(cli_mod.register_cli))
+            self.assertTrue(callable(cli_mod.run))
+            parser = argparse.ArgumentParser()
+            sub = parser.add_subparsers().add_parser(PLUGIN_NAME)
+            cli_mod.register_cli(sub)  # must not raise
+        finally:
+            for name in list(sys.modules):
+                if name == self.SYNTHETIC_PARENT or name.startswith(self.SYNTHETIC_PARENT + "."):
+                    sys.modules.pop(name, None)
+
     def test_register_does_not_raise_on_minimal_context(self):
         class Context:
             pass


### PR DESCRIPTION
## Summary

Standalone installs of the Hermes plugin now expose the documented `hermes open-second-brain` CLI subtree. Hermes' `discover_plugin_cli_commands()` scans only `<plugin_root>/cli.py`, while the implementation lives in `plugins/hermes/cli.py` - so the subtree was never discoverable on a stock Hermes. An 18-line root re-export shim completes the contract, and a loader-contract test mirrors the upstream scan's exact import sequence so the gap cannot reopen silently.

## Why this matters

```mermaid
flowchart LR
    subgraph before [Before]
        A1[Hermes CLI scan<br/>plugin_root/cli.py] -->|file missing| B1[subtree never registered]
        B1 --> C1[hermes open-second-brain<br/>unknown command]
    end
    subgraph after [After]
        A2[Hermes CLI scan<br/>plugin_root/cli.py] -->|root shim re-exports| B2[plugins/hermes/cli.py]
        B2 --> C2[hermes open-second-brain<br/>discoverable before provider load]
    end
    before --> after
```

The CLI surface was documented and implemented but unreachable through the upstream discovery path - the one entry point a stock Hermes actually scans. The shim is the smallest change that satisfies the contract: a relative re-export through the synthetic parent packages the upstream loader registers (hermes-agent PR #37366), with no SDK import at scan time.

## Concrete benefits

- The documented `hermes open-second-brain` subcommands work on a stock Hermes install with zero configuration.
- The shim is SDK-free at import time: `plugins/hermes` soft-imports the Hermes ABC with a local fallback, so the scan never pays a heavy import.
- `HermesLoaderContractTests` reproduces the upstream loader's import sequence (synthetic parent packages, no root `__init__.py` execution), pinning the contract against silent regressions on either side.

## What ships

| Artifact | Role |
| --- | --- |
| `cli.py` (repo root, 18 lines) | Re-exports `register_cli` / `run` from `plugins/hermes/cli.py` through the loader's synthetic parent path |
| `tests/python/test_hermes_plugin.py` (+38) | `HermesLoaderContractTests`: mirrors `discover_plugin_cli_commands()` import sequence |
| `CHANGELOG.md`, 8 version manifests | v0.43.1 patch entry + `sync-version` across plugin manifests |

## Test plan

- [x] `python3 -m unittest discover -s tests/python` - 61 tests, OK (was 60 on main; +1 contract test class)
- [x] `bun test` - 3973 pass / 0 fail across 510 files
- [x] `bun run typecheck` - clean
- [x] `bun run lint` - 111 warnings / 0 errors (baseline)
- [x] `bun run sync-version:check` - all 8 manifests at 0.43.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Hermes CLI discovery for standalone installations.

* **Chores**
  * Bumped version to 0.43.1 across all package manifests.

* **Tests**
  * Added loader contract validation test to prevent CLI discovery regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->