### PR TITLE
fix(ci): treat an existing release as success in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,9 +152,16 @@ jobs:
             prerelease_args+=(--prerelease)
           fi
 
+          # The normal flow publishes a curated release (notes, image assets)
+          # via `gh release create` BEFORE this workflow runs — creating the
+          # tag is what triggers it. An existing release is therefore the
+          # expected end state, not an error: verify stays the safety net and
+          # this step only creates a release when none exists yet (e.g. a
+          # bare `git push --tags` or a workflow_dispatch run).
           if gh release view "${TAG}" >/dev/null 2>&1; then
-            echo "Release ${TAG} already exists" >&2
-            exit 1
+            echo "Release ${TAG} already exists — keeping the curated release as-is."
+            echo "::notice title=Release exists::${TAG} was already published; skipped auto-creation."
+            exit 0
           fi
 
           gh release create "${TAG}" \


### PR DESCRIPTION
## Summary

Every recent run of the `Release` workflow is red for the same non-reason: the release flow publishes a curated GitHub release (long-form notes, animated overview, image assets) **before** the tag-triggered workflow runs - creating the tag is precisely what triggers it. The "Publish GitHub release" step then finds the release already present and exits 1. All ten most recent Release runs failed this way, including v1.0.0 (run 27021632596).

This change makes the existing release the recognized happy path: the step logs a `::notice` and exits 0 instead of failing. Auto-creation with `--generate-notes` still happens whenever no release exists for the tag (bare `git push --tags`, `workflow_dispatch`), so the workflow keeps its fallback role. The `verify` job is untouched and remains the real gate (tests, typecheck, manifest sync, OpenClaw bundle diff, packaging).

## Why this matters

- The Release workflow becomes a meaningful signal again - red will mean a real verification failure, not "the curated release won".
- No more confusion after each release ("прошлый релиз прошел с ошибками") for a state that is actually correct.

## What ships

| File | Change |
| --- | --- |
| `.github/workflows/release.yml` | "already exists" branch: `exit 1` -> notice + `exit 0`, with a comment documenting the curated-release-first flow |

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` - YAML parses
- [x] Branch logic unchanged for the no-release case: `gh release view` fails -> `gh release create --generate-notes` runs as before
- [ ] Post-merge: next tag push shows a green Release run with the skip notice


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow stability by enhancing how the system handles existing releases, ensuring more reliable and streamlined release cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->