### PR TITLE
fix(hermes): serialize handle_tool_call result to a string (v1.3.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Plugin-first second brain package for AI agents and humans.",
   "author": {
     "name": "Open Second Brain contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "skills": "./skills",
   "hooks": "./hooks/hooks.json",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-06-11
+
+### Fixed
+
+- **Hermes provider returned a dict where the contract requires a string**
+  (`plugins/hermes/provider.py`): `handle_tool_call` forwarded the raw MCP
+  `tools/call` result dict straight back to Hermes, which feeds it to the
+  model as tool-message content. Lenient providers (Anthropic) accept a
+  dict, so the bug stayed hidden; strict ones (DeepSeek) reject it with
+  HTTP 400 (`content should be a string or a list`) on the next API call.
+  The bridge result is now serialized at the boundary through a single
+  `_as_tool_content` seam (lossless JSON, `default=str`, string results
+  passed through), and `handle_tool_call` is typed `-> str` to match the
+  base-class contract. Contract tests now assert the return type against
+  every result shape, closing the gap that let the leak through unnoticed.
+  Reported in #82.
+
 ## [1.3.0] - 2026-06-10
 
 Continuity, Hygiene & Freshness Suite: one conversation stays one
@@ -5167,6 +5184,7 @@ plugin config (vault field)`, and exits with a clear
 - Sandbox vault and plugin manifest fixtures for tests.
 - GitHub release workflow for tag-based and manually dispatched releases.
 
+[1.3.1]: https://github.com/itechmeat/open-second-brain/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/itechmeat/open-second-brain/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/itechmeat/open-second-brain/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/itechmeat/open-second-brain/compare/v1.0.1...v1.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# CLAUDE.md
+
+Guidance for agents working in this repository.
+
+## Versioning
+
+`package.json` `version` is the single source of truth. The version is
+mirrored into several manifests (`plugin.yaml`, `plugins/hermes/plugin.yaml`,
+`.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`,
+`plugins/codex/.codex-plugin/plugin.json`, `openclaw.plugin.json`) and
+`pyproject.toml`.
+
+Never hand-edit the version in those mirrored files. To bump the version,
+edit `package.json` only, then propagate with:
+
+```
+bun run scripts/sync-version.ts
+```
+
+CI gates on `bun run scripts/sync-version.ts --check` (the `validate` job,
+step "Verify manifest version sync"). Hand-editing one file leaves the
+others drifted and fails that gate before any other check runs. Run the
+`--check` form locally before pushing a version change.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "open-second-brain",
   "name": "Open Second Brain",
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "activation": { "onStartup": true },
   "skills": ["./skills"],
   "contracts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": false,
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults. Works with Hermes, Claude Code, Codex, and OpenClaw.",
   "keywords": [

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "1.3.0"
+version: "1.3.1"
 description: "Open Second Brain - native Hermes memory provider backed by an Obsidian-compatible Markdown vault."
 author: "Open Second Brain contributors"
 memory_provider: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "author": {
     "name": "Open Second Brain contributors",

--- a/plugins/hermes/plugin.yaml
+++ b/plugins/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "1.3.0"
+version: "1.3.1"
 description: "Open Second Brain - native Hermes memory provider backed by an Obsidian-compatible Markdown vault."
 author: "Open Second Brain contributors"
 memory_provider: true

--- a/plugins/hermes/provider.py
+++ b/plugins/hermes/provider.py
@@ -111,14 +111,23 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
             return static_tool_schemas()
         return [t for t in tools if t.get("name") in MEMORY_TOOLS]
 
-    def handle_tool_call(self, tool_name: str, args: dict[str, Any], **_kwargs: Any) -> Any:
-        """Forward an agent tool invocation to the TS core over the bridge."""
+    def handle_tool_call(self, tool_name: str, args: dict[str, Any], **_kwargs: Any) -> str:
+        """Forward an agent tool invocation to the TS core over the bridge.
+
+        Hermes feeds the return value back to the model as tool-message
+        content, and the chat-completions contract requires that content to
+        be a string. The bridge yields the MCP ``tools/call`` result dict, so
+        it is serialized here. Lenient providers (Anthropic) tolerate a raw
+        dict, which is why this leaked undetected; strict ones (DeepSeek)
+        reject it with HTTP 400. Coercing at this boundary - not in the
+        caller - is what makes the provider portable across both.
+        """
         if self._bridge is None:
             raise BridgeError("memory provider not initialized")
         if tool_name not in MEMORY_TOOLS:
             # Enforce the curated surface at execution time, not just discovery.
             raise BridgeError(f"unsupported memory tool: {tool_name}")
-        return self._bridge.call_tool(tool_name, args or {})
+        return self._as_tool_content(self._bridge.call_tool(tool_name, args or {}))
 
     def get_config_schema(self) -> list[dict[str, Any]]:
         return [
@@ -262,6 +271,21 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
             return self._bridge.call_tool(name, args)
         except Exception:  # noqa: BLE001 - lifecycle hooks must not raise into Hermes
             return None
+
+    @staticmethod
+    def _as_tool_content(result: Any) -> str:
+        """Coerce a bridge result into tool-message content (always a string).
+
+        The Hermes memory contract types ``handle_tool_call`` as ``-> str``,
+        but the bridge yields an MCP result dict. Serialize losslessly so the
+        model still sees both the ``content`` and ``structuredContent``
+        envelopes. ``default=str`` keeps non-JSON-native values (datetimes,
+        Paths) from raising at the boundary; an already-string result passes
+        through untouched.
+        """
+        if isinstance(result, str):
+            return result
+        return json.dumps(result, ensure_ascii=False, default=str)
 
     @staticmethod
     def _structured(result: Any) -> dict[str, Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 # CLI entry points (those moved to `package.json` `bin`).
 [project]
 name = "open-second-brain"
-version = "1.3.0"
+version = "1.3.1"
 description = "Hermes Python shim for Open Second Brain. Most of the project (CLI, MCP server, OpenClaw plugin) is TypeScript on Bun; see package.json."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/python/test_memory_provider.py
+++ b/tests/python/test_memory_provider.py
@@ -179,8 +179,37 @@ class ProviderRequiredSurfaceTests(unittest.TestCase):
         provider = self._provider(bridge)
         provider.initialize("s", hermes_home="/tmp/hh")
         result = provider.handle_tool_call("brain_note", {"text": "hi"})
-        self.assertEqual(result, {"ok": True})
+        # Hermes feeds the return back as tool-message content, so the
+        # contract is str, not dict. The MCP result is serialized losslessly.
+        self.assertIsInstance(result, str)
+        self.assertEqual(json.loads(result), {"ok": True})
         self.assertEqual(bridge.calls, [("brain_note", {"text": "hi"})])
+
+    def test_handle_tool_call_always_returns_string_for_dict_results(self):
+        # The base-class contract types handle_tool_call as -> str. A raw dict
+        # reaching the model as tool content breaks strict providers (DeepSeek
+        # HTTP 400) while passing on lenient ones (Anthropic), so the boundary
+        # must coerce regardless of the tool's result shape.
+        shapes = {
+            "brain_note": {"content": [{"type": "text", "text": "ok"}], "structuredContent": {"ok": True}},
+            "brain_query": {"structuredContent": {"hits": [1, 2, 3]}},
+            "brain_search": {},
+        }
+        bridge = FakeBrainBridge(results=shapes)
+        provider = self._provider(bridge)
+        provider.initialize("s", hermes_home="/tmp/hh")
+        for tool, shape in shapes.items():
+            result = provider.handle_tool_call(tool, {})
+            self.assertIsInstance(result, str, f"{tool} must return a string")
+            # Lossless: both the content and structuredContent envelopes survive.
+            self.assertEqual(json.loads(result), shape)
+
+    def test_handle_tool_call_passes_through_string_result(self):
+        # A bridge that already yields a string must not be double-encoded.
+        bridge = FakeBrainBridge(results={"brain_note": "plain text"})
+        provider = self._provider(bridge)
+        provider.initialize("s", hermes_home="/tmp/hh")
+        self.assertEqual(provider.handle_tool_call("brain_note", {}), "plain text")
 
     def test_get_config_schema_shape(self):
         schema = self._provider(FakeBrainBridge()).get_config_schema()
@@ -285,7 +314,8 @@ class ProviderStaticSchemaFallbackTests(unittest.TestCase):
         # initialize_all() runs after registration; the model then calls a tool.
         provider.initialize("sess-1", hermes_home="/tmp/hh")
         result = routing_table["brain_note"].handle_tool_call("brain_note", {"text": "hi"})
-        self.assertEqual(result, {"ok": True})
+        self.assertIsInstance(result, str)
+        self.assertEqual(json.loads(result), {"ok": True})
         self.assertEqual(bridge.calls, [("brain_note", {"text": "hi"})])
 
 


### PR DESCRIPTION
Closes #82.

## Problem

The native Hermes `MemoryProvider` forwarded the raw MCP `tools/call` result dict straight back from `handle_tool_call`. Hermes feeds that value to the model as tool-message content, where the chat-completions contract requires a string.

Lenient providers (Anthropic) accept a dict, so the defect stayed hidden. Strict providers (DeepSeek) reject it with HTTP 400 (`content should be a string or a list`) on the next API call.

## Root cause - the larger problem

The one-line return was the symptom. The real gap: nothing coerced bridge results to the base-class string contract, and no test checked `handle_tool_call`'s return type against it. A dict could leak to the model unnoticed on any provider that happened to tolerate it.

I audited every sibling surface where an MCP result dict could cross the boundary to the model:

| Surface | Returns | Status |
|---|---|---|
| `provider.py` `handle_tool_call` | raw dict | **the bug** |
| `provider.py` `system_prompt_block` | `str(...)` coerced | ok |
| `provider.py` `prefetch` | joined strings | ok |
| `provider.py` `_safe_call` (internal) | dict, but all callers extract text / ignore | ok |
| `plugins/hermes/cli.py` | int exit codes (operator-facing) | ok |
| `plugins/opencode/open-second-brain.ts` | gates on `typeof === "string"` before inject | ok |
| TS hooks / session adapters | this is the MCP server - emits a correct envelope | ok |

`handle_tool_call` was the only contract leak.

## Fix

- Serialize at the boundary through a single `_as_tool_content` seam: lossless JSON (`ensure_ascii=False`, `default=str` for datetimes/Paths), with already-string results passed through untouched. Lossless so the model still sees both the `content` and `structuredContent` envelopes.
- Type `handle_tool_call` as `-> str` to match the base-class contract.
- Contract tests now assert the return type across every result shape (dict with/without `structuredContent`, empty dict, plain string), closing the gap that let the leak through.

## Scope

Patch v1.3.1: `package.json` / `pyproject.toml` bumped to 1.3.1, CHANGELOG entry added. No release ceremony (no tag / GitHub release / announcement) per request.

## Tests

`python -m unittest discover -s tests/python` - 72 passing (2 new contract tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hermes memory provider now returns tool-call results as serialized strings to meet the memory contract.

* **Tests**
  * Improved tests verifying string-serialized tool-call outputs and JSON round-trip/coercion behavior.

* **Documentation**
  * Added CHANGELOG entry for v1.3.1 with compare link.

* **Chores**
  * Package and plugin versions bumped to 1.3.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->