### PR TITLE
chore(release): bump version to 1.5.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Plugin-first second brain package for AI agents and humans.",
   "author": {
     "name": "Open Second Brain contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "skills": "./skills",
   "hooks": "./hooks/hooks.json",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,3 +21,30 @@ CI gates on `bun run scripts/sync-version.ts --check` (the `validate` job,
 step "Verify manifest version sync"). Hand-editing one file leaves the
 others drifted and fails that gate before any other check runs. Run the
 `--check` form locally before pushing a version change.
+
+### WHEN to bump: inside the feature PR, before the first push
+
+The version bump is part of the change itself, NOT a separate later step.
+Bump `package.json` (and run `sync-version.ts`) on the feature branch and
+include it in the SAME pull request as the feature, before you push. Every
+release-bearing squash commit on `main` carries its version in the title -
+e.g. `feat: … (v1.5.0) (#NN)` - because the bump rode in with the feature.
+
+Concretely, for any feature/fix PR that ships a release:
+
+1. Add the `CHANGELOG.md` entry under the new `## [X.Y.Z] - <date>` heading
+   AND its `[X.Y.Z]: …/compare/…` link-reference at the bottom of the file.
+2. Bump `package.json` to `X.Y.Z` and run `bun run scripts/sync-version.ts`.
+3. Commit both, then push the branch and open the PR.
+
+Do this even though `main` is protected (direct pushes are rejected; all
+changes go through a PR) - which is exactly why the bump cannot be a
+post-merge step: a forgotten bump means `package.json` and the `CHANGELOG`
+heading disagree on `main` and a second PR is needed to reconcile them.
+
+This OVERRIDES the generic `feature-release-playbook` default ("do not bump
+version mid-PR; bump once in the release phase"). That default assumes a
+maintainer can push the bump straight to `main` at release time; this repo
+cannot, so the bump belongs in the feature PR. The GitHub release
+(`gh release create vX.Y.Z`) is published AFTER that PR merges and only tags
+the already-bumped commit - it never changes the version.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "open-second-brain",
   "name": "Open Second Brain",
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults.",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "activation": { "onStartup": true },
   "skills": ["./skills"],
   "contracts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": false,
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults. Works with Hermes, Claude Code, Codex, and OpenClaw.",
   "keywords": [

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "1.4.0"
+version: "1.5.0"
 description: "Open Second Brain - native Hermes memory provider backed by an Obsidian-compatible Markdown vault."
 author: "Open Second Brain contributors"
 memory_provider: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "author": {
     "name": "Open Second Brain contributors",

--- a/plugins/hermes/plugin.yaml
+++ b/plugins/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "1.4.0"
+version: "1.5.0"
 description: "Open Second Brain - native Hermes memory provider backed by an Obsidian-compatible Markdown vault."
 author: "Open Second Brain contributors"
 memory_provider: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 # CLI entry points (those moved to `package.json` `bin`).
 [project]
 name = "open-second-brain"
-version = "1.4.0"
+version = "1.5.0"
 description = "Hermes Python shim for Open Second Brain. Most of the project (CLI, MCP server, OpenClaw plugin) is TypeScript on Bun; see package.json."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Bumps the canonical version to **1.5.0** for the Search & Recall Quality Suite (#93) and propagates it across the mirrored manifests via `scripts/sync-version.ts`.

This is the version-bump companion to #93 (the feature PR shipped at the pre-bump version). `bun run scripts/sync-version.ts --check` passes.

- [x] `sync-version.ts --check` ok

No code or behaviour changes - manifest version strings only.