### PR TITLE
fix(hermes): pass --repo so MCP bridge skill discovery resolves repoRoot

### DIFF
--- a/plugins/hermes/bridge.py
+++ b/plugins/hermes/bridge.py
@@ -129,11 +129,13 @@ class McpBrainBridge:
         self,
         *,
         vault: str | None,
+        repo_root: str | None = None,
         command: tuple[str, ...] = ("o2b", "mcp"),
         spawn: Any = None,
         cwd: str | None = None,
     ) -> None:
         self._vault = vault
+        self._repo_root = repo_root
         self._command = command
         self._spawn = spawn or self._default_spawn
         self._cwd = cwd
@@ -146,6 +148,11 @@ class McpBrainBridge:
         argv = list(self._command)
         if self._vault:
             argv += ["--vault", self._vault]
+        # Without --repo the server's repoRoot is null, so skill discovery
+        # only searches <vault>/Brain/skills and never the in-repo skills/
+        # directory - which silently empties skill_auto_attach.
+        if self._repo_root:
+            argv += ["--repo", self._repo_root]
         return argv
 
     def _default_spawn(self, argv: list[str]) -> Any:

--- a/plugins/hermes/provider.py
+++ b/plugins/hermes/provider.py
@@ -88,11 +88,23 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
                 self._bridge.stop()
             except Exception:  # noqa: BLE001
                 pass
-        self._bridge = self._bridge_override or McpBrainBridge(vault=config.resolve_vault())
+        self._bridge = self._bridge_override or McpBrainBridge(
+            vault=config.resolve_vault(),
+            repo_root=self._repo_root(),
+        )
         try:
             self._bridge.start()
         except Exception:  # noqa: BLE001 - degrade to inert; tool calls surface errors
             pass
+
+    @staticmethod
+    def _repo_root() -> str | None:
+        """Plugin checkout root that ships ``skills/`` (provider lives at
+        ``<root>/plugins/hermes/provider.py``). Passed as ``--repo`` so the TS
+        core's ``repoRoot`` resolves and in-repo skills become discoverable;
+        without it ``skill_auto_attach`` returns an empty list."""
+        root = Path(__file__).resolve().parents[2]
+        return str(root) if (root / "skills").is_dir() else None
 
     def get_tool_schemas(self) -> list[dict[str, Any]]:
         """Return the memory-relevant subset of the server's advertised tools.

--- a/tests/python/test_memory_provider.py
+++ b/tests/python/test_memory_provider.py
@@ -632,6 +632,27 @@ class McpBrainBridgeTests(unittest.TestCase):
         self.assertIn("--vault", captured["argv"])
         self.assertIn("/my/vault", captured["argv"])
 
+    def test_argv_includes_repo_root(self):
+        captured = {}
+
+        def spy(argv):
+            captured["argv"] = argv
+            return _FakeProcess(self._handshake_frames())
+
+        McpBrainBridge(vault="/v", repo_root="/my/repo", spawn=spy).start()
+        self.assertIn("--repo", captured["argv"])
+        self.assertIn("/my/repo", captured["argv"])
+
+    def test_argv_omits_repo_when_unset(self):
+        captured = {}
+
+        def spy(argv):
+            captured["argv"] = argv
+            return _FakeProcess(self._handshake_frames())
+
+        McpBrainBridge(vault="/v", spawn=spy).start()
+        self.assertNotIn("--repo", captured["argv"])
+
     def test_stop_terminates_process(self):
         proc = _FakeProcess(self._handshake_frames())
         bridge = McpBrainBridge(vault="/v", spawn=lambda argv: proc)


### PR DESCRIPTION
## Summary
- `McpBrainBridge._argv()` never emitted `--repo`, so `o2b mcp` started with `ServerContext.repoRoot = null`. `skillRoots()` then searched only `<vault>/Brain/skills/` and never the in-repo `skills/` directory, so `skills_attach` (the `skill_auto_attach` feature) returned an empty list even when the repo ships skills.
- Thread a `repo_root` through `McpBrainBridge.__init__` and emit `--repo <root>` in `_argv()`.
- The provider derives the plugin checkout root from its own location (`<root>/plugins/hermes/provider.py` → `parents[2]`) and passes it into the bridge, guarded by an existing-`skills/` check.

Closes #103

## Verification
- New unit tests: `_argv` includes `--repo` when `repo_root` is set, and omits it when unset.
- Functional check against the live `o2b mcp` server: `list_skills` discovers **5** repo skills with `--repo` vs **0** without — confirming `repoRoot` now resolves and in-repo skills become discoverable (the source `skills_attach` reads from).
- `ruff check` clean on all three files; full `McpBrainBridgeTests` suite passes (9/9).

## Test plan
- [ ] `python3 -m unittest tests.python.test_memory_provider.McpBrainBridgeTests`
- [ ] With `skill_auto_attach: "true"`, confirm `skills_attach` returns a non-empty list in a checkout that ships `skills/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional repository root configuration to the MCP bridge, enabling scoped skill discovery when specified.

* **Tests**
  * Added tests verifying repository root CLI argument handling, covering both configured and unconfigured scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->