### PR TITLE
feat: coverage-driven targeted self-correcting recall on partial misses (v1.18.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Plugin-first second brain package for AI agents and humans.",
   "author": {
     "name": "Open Second Brain contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "skills": "./skills",
   "hooks": "./hooks/hooks.json",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.0] - 2026-06-23
+
+Coverage-driven targeted self-correcting recall on partial misses. The
+self-correcting two-pass recall, previously fired only by a
+zero-candidate first pass, now also fires when a non-empty first pass
+leaves rare query terms uncovered — and the follow-up is aimed at
+exactly those missing facts instead of a generic broadening. Deterministic
+and LLM-free; off when `recall.twoPassEnabled` is false.
+
+### Added
+
+- **Targeted retry on partial coverage (`t_8eb5ca32`).** In evidence-pack
+  mode, when the first pass returns candidates but their IDF-weighted
+  coverage of the query is below `COMPLETENESS_COMPLETE_THRESHOLD` with at
+  least one RARE significant term still uncovered, `search()` issues
+  exactly ONE follow-up FTS pass built from those uncovered rare terms
+  (the specifically-missing high-signal facts), merges the recovered
+  candidates into the pool, and lets them flow through the normal ranking
+  and a regenerated evidence pack. The new pure helper
+  `planTargetedRetry(coverage)` (in `coverage.ts`) is the deterministic
+  trigger: it fires only on a below-threshold coverage WITH uncovered rare
+  terms (a rare gate keeps it off when only corpus-common terms are
+  missing) and returns exactly those terms to re-query. This retry is
+  mutually exclusive with the existing zero-candidate broadened OR retry
+  (one needs an empty pool, the other a non-empty one), so at most one
+  retry fires per query — the same single-retry discipline. The
+  regenerated pack still abstains on any term left uncovered after the
+  retry, so the conservative-on-final-miss posture is unchanged.
+
+- **`SearchOutcome.secondPass.kind` (`t_8eb5ca32`).** The two-pass marker
+  now carries `kind: "broadened" | "targeted"` to distinguish the two
+  triggers, plus `targetedTerms` (the uncovered rare terms re-queried) for
+  the targeted variant. Recovered results carry a
+  `second_pass: targeted retry on uncovered rare terms` reason; first-pass
+  hits they merge with do not.
+
 ## [1.17.0] - 2026-06-21
 
 CodeGraph link-graph depth and MCP exposure. A set of strictly additive
@@ -5869,6 +5905,7 @@ plugin config (vault field)`, and exits with a clear
 - Sandbox vault and plugin manifest fixtures for tests.
 - GitHub release workflow for tag-based and manually dispatched releases.
 
+[1.18.0]: https://github.com/itechmeat/open-second-brain/compare/v1.17.0...v1.18.0
 [1.17.0]: https://github.com/itechmeat/open-second-brain/compare/v1.16.0...v1.17.0
 [1.16.0]: https://github.com/itechmeat/open-second-brain/compare/v1.15.0...v1.16.0
 [1.15.0]: https://github.com/itechmeat/open-second-brain/compare/v1.14.0...v1.15.0

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "open-second-brain",
   "name": "Open Second Brain",
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults.",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "activation": { "onStartup": true },
   "skills": ["./skills"],
   "contracts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "private": false,
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults. Works with Hermes, Claude Code, Codex, and OpenClaw.",
   "keywords": [

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "1.17.0"
+version: "1.18.0"
 description: "Open Second Brain - native Hermes memory provider backed by an Obsidian-compatible Markdown vault."
 author: "Open Second Brain contributors"
 memory_provider: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "author": {
     "name": "Open Second Brain contributors",

--- a/plugins/hermes/plugin.yaml
+++ b/plugins/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "1.17.0"
+version: "1.18.0"
 description: "Open Second Brain - native Hermes memory provider backed by an Obsidian-compatible Markdown vault."
 author: "Open Second Brain contributors"
 memory_provider: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 # CLI entry points (those moved to `package.json` `bin`).
 [project]
 name = "open-second-brain"
-version = "1.17.0"
+version = "1.18.0"
 description = "Hermes Python shim for Open Second Brain. Most of the project (CLI, MCP server, OpenClaw plugin) is TypeScript on Bun; see package.json."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/core/search/coverage.ts
+++ b/src/core/search/coverage.ts
@@ -132,6 +132,35 @@ export function buildCompletenessReport(coverage: CoverageReport): CompletenessR
   });
 }
 
+/**
+ * Targeted self-correcting retry plan (t_8eb5ca32): the deterministic
+ * decision that connects coverage to a follow-up retrieval. A retry
+ * fires only when the IDF-weighted coverage is below the completeness
+ * threshold AND at least one RARE significant term is still uncovered;
+ * the follow-up is then aimed at exactly those uncovered rare terms —
+ * the specifically-missing high-signal facts — never a generic
+ * broadening of the whole query. The rare gate keeps the retry off when
+ * only corpus-common terms are missing (low IDF, low value) and bounds
+ * how often it can fire. `terms` is empty iff `fire` is false.
+ *
+ * Pure and deterministic: a verdict over an already-built report, no
+ * I/O. The caller decides how to turn the terms into a query (FTS OR,
+ * expansion, …) and how to cap the number of passes.
+ */
+export interface TargetedRetryPlan {
+  readonly fire: boolean;
+  readonly terms: ReadonlyArray<string>;
+}
+
+export function planTargetedRetry(coverage: CoverageReport): TargetedRetryPlan {
+  const belowThreshold = coverage.idfWeightedCoverage < COMPLETENESS_COMPLETE_THRESHOLD;
+  const fire = belowThreshold && coverage.uncoveredRareTerms.length > 0;
+  return Object.freeze({
+    fire,
+    terms: fire ? coverage.uncoveredRareTerms : Object.freeze([] as string[]),
+  });
+}
+
 export function buildCoverageReport(inputs: CoverageInputs): CoverageReport {
   const terms: TermCoverage[] = inputs.significantTerms.map((term) => {
     const df = inputs.dfByTerm.get(term) ?? 0;

--- a/src/core/search/search.ts
+++ b/src/core/search/search.ts
@@ -35,7 +35,14 @@ import {
 } from "./activation/store.ts";
 import { extractEntities } from "./entities.ts";
 import { expandQueryEntities } from "./entity-alias.ts";
-import { buildCoverageReport, significantTerms, termIncludedIn } from "./coverage.ts";
+import {
+  buildCoverageReport,
+  COMPLETENESS_COMPLETE_THRESHOLD,
+  planTargetedRetry,
+  significantTerms,
+  termIncludedIn,
+  type CoverageReport,
+} from "./coverage.ts";
 import {
   buildEvidencePack,
   downrankTerminalEvidenceResults,
@@ -426,6 +433,10 @@ export async function search(
     // as alternatives, then let the merged pool flow through the normal
     // ranking, filters, and a recomputed evidence pack.
     let secondPass: SearchOutcome["secondPass"];
+    // Chunk ids the targeted retry below recovered, so only those
+    // results (not the first-pass hits they merge with) get the
+    // second-pass attribution reason.
+    const targetedChunkIds = new Set<number>();
     if (idsList.length === 0 && opts.evidencePack === true && config.recall.twoPassEnabled) {
       const terms = significantTerms(query);
       if (terms.length >= 2) {
@@ -441,8 +452,56 @@ export async function search(
           idsList = Array.from(allChunkIds);
           secondPass = Object.freeze({
             triggered: true,
+            kind: "broadened",
             reason: "zero-candidate first pass; broadened OR retry",
             added: kwHits.length,
+          });
+        }
+      }
+    }
+
+    // Coverage-driven targeted follow-up (t_8eb5ca32): the first pass
+    // DID return candidates, but their IDF-weighted coverage of the
+    // query is below the completeness threshold with rare query terms
+    // still uncovered - a PARTIAL miss, distinct from the zero-candidate
+    // dead end above. Issue exactly ONE targeted retry built from the
+    // specifically-uncovered rare terms (not a generic broadening of the
+    // whole query), merge the recovered candidates into the pool, and
+    // let them flow through the normal ranking and a recomputed evidence
+    // pack. Mutually exclusive with the broadened retry above (that needs
+    // an empty pool, this a non-empty one), so at most one retry fires -
+    // the same single-retry discipline. The trigger is deterministic and
+    // LLM-free; the recomputed pack still abstains on any term left
+    // uncovered after the retry.
+    if (
+      secondPass === undefined &&
+      idsList.length > 0 &&
+      opts.evidencePack === true &&
+      config.recall.twoPassEnabled
+    ) {
+      const poolCoverage = coverageOverChunks(store, query, idsList);
+      const plan = planTargetedRetry(poolCoverage);
+      if (plan.fire) {
+        const targeted = runFtsQueryDetailed(store, plan.terms[0]!, {
+          expandedTerms: plan.terms.slice(1),
+          limit: Math.max(limit * 5, 50),
+          pathPrefix: pathPrefix ?? null,
+        });
+        for (const w of targeted.warnings) warnings.push(w);
+        const newHits = targeted.hits.filter((h) => !allChunkIds.has(h.chunkId));
+        if (newHits.length > 0) {
+          kwHits = kwHits.concat(newHits);
+          for (const h of newHits) {
+            allChunkIds.add(h.chunkId);
+            targetedChunkIds.add(h.chunkId);
+          }
+          idsList = Array.from(allChunkIds);
+          secondPass = Object.freeze({
+            triggered: true,
+            kind: "targeted",
+            reason: `partial coverage ${poolCoverage.idfWeightedCoverage.toFixed(2)} < ${COMPLETENESS_COMPLETE_THRESHOLD}; targeted retry on uncovered rare terms: ${plan.terms.join(", ")}`,
+            added: newHits.length,
+            targetedTerms: plan.terms,
           });
         }
       }
@@ -852,18 +911,24 @@ export async function search(
               : r,
           )
         : withStructuredReasons;
-    // Two-pass attribution (t_ef92dfdc): every surfaced result of a
-    // broadened retry says so - the operator can tell recovered
-    // evidence from a first-pass hit.
+    // Two-pass attribution (t_ef92dfdc; targeted retry t_8eb5ca32): a
+    // surfaced result of a retry says so - the operator can tell
+    // recovered evidence from a first-pass hit. The broadened retry
+    // replaced the whole pool, so every result is recovered; the
+    // targeted retry only ADDED candidates, so only those (tracked in
+    // `targetedChunkIds`) carry the reason - the first-pass hits they
+    // merge with do not.
     const withSecondPassReasons =
-      secondPass !== undefined
-        ? withCanonicalReasons.map((r) =>
-            Object.freeze({
-              ...r,
-              reasons: Object.freeze([...r.reasons, "second_pass: or-broadened retry"]),
-            }),
-          )
-        : withCanonicalReasons;
+      secondPass === undefined
+        ? withCanonicalReasons
+        : withCanonicalReasons.map((r) => {
+            if (secondPass.kind === "targeted" && !targetedChunkIds.has(r.chunkId)) return r;
+            const reason =
+              secondPass.kind === "targeted"
+                ? "second_pass: targeted retry on uncovered rare terms"
+                : "second_pass: or-broadened retry";
+            return Object.freeze({ ...r, reasons: Object.freeze([...r.reasons, reason]) });
+          });
     // Terminal-state downrank (recall-trust-suite) is now structural and
     // language-agnostic: a result is terminal when its frontmatter
     // `status:` field declares a terminal value (controlled vocabulary),
@@ -1069,6 +1134,40 @@ const UNION_RECORDS_TOTAL = 8;
  * fetch up to {@link UNION_RECORDS_PER_TERM} records that DO cover it
  * (evidence can span records the primary ranking never surfaced).
  */
+/**
+ * IDF-weighted coverage of the query over a candidate POOL (the partial
+ * self-correcting retry trigger, t_8eb5ca32). Mirrors the result-set
+ * coverage in {@link buildEvidenceVerification} but scores the
+ * pre-ranking candidate chunks: a term is covered when any candidate's
+ * path/title/content contains it. Corpus document frequencies and the
+ * document count come from the store, exactly as the result-set pass
+ * does, so the two reports share one definition of "covered" and one
+ * IDF scale.
+ */
+function coverageOverChunks(
+  store: Store,
+  query: string,
+  chunkIds: ReadonlyArray<number>,
+): CoverageReport {
+  const terms = significantTerms(query);
+  const dfByTerm = store.documentFrequencies(terms);
+  const documentCount = store.counts().documents;
+  const hydrated = store.hydrateChunks(chunkIds);
+  const covered = new Set<string>();
+  for (const h of hydrated.values()) {
+    const haystack = `${h.path}\n${h.title ?? ""}\n${h.content}`;
+    for (const t of terms) {
+      if (!covered.has(t) && termIncludedIn(haystack, t)) covered.add(t);
+    }
+  }
+  return buildCoverageReport({
+    significantTerms: terms,
+    coveredTerms: covered,
+    documentCount,
+    dfByTerm,
+  });
+}
+
 function buildEvidenceVerification(
   store: Store,
   query: string,

--- a/src/core/search/types.ts
+++ b/src/core/search/types.ts
@@ -436,14 +436,25 @@ export interface SearchOutcome {
   readonly evidencePack?: EvidencePack;
   /**
    * Self-correcting two-pass recall (Time-Aware Recall & Activation
-   * Suite, t_ef92dfdc). Present only when a zero-candidate first pass
-   * in evidence-pack mode triggered the single broadened OR retry.
+   * Suite, t_ef92dfdc; coverage-driven targeted retry, t_8eb5ca32).
+   * Present only when a single follow-up retry fired in evidence-pack
+   * mode. `kind` distinguishes the two triggers, which are mutually
+   * exclusive (at most one retry per query):
+   *   - `"broadened"`: a ZERO-candidate first pass ran one broadened
+   *     OR retry over all significant terms.
+   *   - `"targeted"`: a non-empty first pass left rare query terms
+   *     uncovered (partial coverage below the completeness threshold)
+   *     and ran one retry aimed at exactly those uncovered rare terms,
+   *     listed in `targetedTerms`.
    */
   readonly secondPass?: {
     readonly triggered: true;
+    readonly kind: "broadened" | "targeted";
     readonly reason: string;
-    /** Candidate hits the broadened pass contributed. */
+    /** Candidate hits the retry pass contributed to the pool. */
     readonly added: number;
+    /** The uncovered rare terms re-queried by a `"targeted"` retry. */
+    readonly targetedTerms?: ReadonlyArray<string>;
   };
 }
 
@@ -542,10 +553,14 @@ export interface ResolvedRecallConfig {
    */
   readonly activationEnabled: boolean;
   /**
-   * Self-correcting two-pass recall (t_ef92dfdc). On by default: a
-   * zero-candidate first pass in evidence-pack mode runs exactly one
-   * broadened OR retry instead of dead-ending in an abstention.
-   * Plain (non-evidence-pack) searches never broaden either way.
+   * Self-correcting two-pass recall (t_ef92dfdc; coverage-driven
+   * targeted retry, t_8eb5ca32). On by default and the kill switch for
+   * BOTH retry triggers in evidence-pack mode: a zero-candidate first
+   * pass runs one broadened OR retry, and a non-empty first pass whose
+   * IDF-weighted coverage falls below the completeness threshold with
+   * rare terms still uncovered runs one targeted retry aimed at those
+   * uncovered rare terms. At most one retry fires per query. Plain
+   * (non-evidence-pack) searches never retry either way.
    */
   readonly twoPassEnabled: boolean;
   /**

--- a/tests/core/search/coverage-targeted-recall.test.ts
+++ b/tests/core/search/coverage-targeted-recall.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Coverage-driven targeted self-correcting recall on partial misses
+ * (t_8eb5ca32). Extends the zero-candidate broadened retry: when a
+ * non-empty first pass leaves rare query terms uncovered (IDF-weighted
+ * coverage below the completeness threshold), search issues ONE targeted
+ * follow-up built from exactly those uncovered rare terms, merges the
+ * recovered candidates, and regenerates the evidence pack. The trigger
+ * is deterministic and LLM-free; the pack still abstains on any term
+ * left uncovered after the retry.
+ */
+
+import { test, expect, beforeEach, afterEach, describe } from "bun:test";
+
+import { buildCoverageReport, planTargetedRetry } from "../../../src/core/search/coverage.ts";
+import { indexVault } from "../../../src/core/search/indexer.ts";
+import { search } from "../../../src/core/search/search.ts";
+import { createTempVault, makeConfig, writeMd } from "../../helpers/search-fixtures.ts";
+import type { StructuredRecallQueryDocument } from "../../../src/core/search/structured-query.ts";
+
+describe("planTargetedRetry (pure decision)", () => {
+  const report = (
+    terms: ReadonlyArray<string>,
+    covered: ReadonlyArray<string>,
+    documentCount: number,
+    df: ReadonlyArray<[string, number]>,
+  ) =>
+    buildCoverageReport({
+      significantTerms: terms,
+      coveredTerms: new Set(covered),
+      documentCount,
+      dfByTerm: new Map(df),
+    });
+
+  test("does not fire when coverage is complete", () => {
+    const cov = report(["alpha", "beta"], ["alpha", "beta"], 10, [
+      ["alpha", 3],
+      ["beta", 3],
+    ]);
+    const plan = planTargetedRetry(cov);
+    expect(plan.fire).toBe(false);
+    expect(plan.terms).toEqual([]);
+  });
+
+  test("fires on a partial miss, aimed at the uncovered rare term", () => {
+    const cov = report(["warehouse", "rotation", "chandelier"], ["warehouse", "rotation"], 6, [
+      ["warehouse", 4],
+      ["rotation", 4],
+      ["chandelier", 1],
+    ]);
+    expect(cov.idfWeightedCoverage).toBeLessThan(0.8);
+    const plan = planTargetedRetry(cov);
+    expect(plan.fire).toBe(true);
+    expect(plan.terms).toEqual(["chandelier"]);
+  });
+
+  test("the rare gate: a below-threshold miss on only common terms does not fire", () => {
+    const cov = report(["alpha", "common"], ["alpha"], 10, [
+      ["alpha", 1],
+      ["common", 9],
+    ]);
+    expect(cov.idfWeightedCoverage).toBeLessThan(0.8);
+    expect(cov.uncoveredRareTerms).toEqual([]);
+    expect(planTargetedRetry(cov).fire).toBe(false);
+  });
+
+  test("zero coverage aims at every rare term", () => {
+    const cov = report(["fennel", "warehouse"], [], 4, [
+      ["fennel", 1],
+      ["warehouse", 1],
+    ]);
+    expect(cov.idfWeightedCoverage).toBe(0);
+    expect(planTargetedRetry(cov).terms).toEqual(["fennel", "warehouse"]);
+  });
+});
+
+describe("targeted recall on a partial miss (integration)", () => {
+  let vault: string;
+  let dbPath: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    ({ vault, dbPath, cleanup } = createTempVault("targeted-recall"));
+  });
+  afterEach(() => cleanup());
+
+  // The first-pass keyword lane is restricted to the common terms via a
+  // supplied structured query (lex lane omits the rare term), so the
+  // pool is NON-EMPTY yet misses the rare term `chandelier` - the
+  // partial miss the targeted retry exists for. `chandelier` is still a
+  // significant term of the original query, so coverage flags it.
+  const structured: StructuredRecallQueryDocument = Object.freeze({
+    intent: null,
+    lex: Object.freeze({
+      include: Object.freeze(["warehouse", "rotation"]) as ReadonlyArray<string>,
+      exclude: Object.freeze([]) as ReadonlyArray<string>,
+    }),
+    vec: Object.freeze(["warehouse rotation"]) as ReadonlyArray<string>,
+    hyde: Object.freeze([]) as ReadonlyArray<string>,
+  });
+  const QUERY = "warehouse rotation chandelier";
+
+  async function seed(): Promise<void> {
+    // Four docs make warehouse/rotation common (low IDF); chandelier is
+    // unique (high IDF), present in a doc the common-term lane never
+    // surfaces.
+    writeMd(vault, "Brain/notes/wh1.md", "# WH1\n\nWarehouse rotation schedule, bay seven.\n");
+    writeMd(vault, "Brain/notes/wh2.md", "# WH2\n\nWarehouse rotation plan for spring.\n");
+    writeMd(vault, "Brain/notes/wh3.md", "# WH3\n\nWarehouse rotation audit notes.\n");
+    writeMd(vault, "Brain/notes/wh4.md", "# WH4\n\nWarehouse rotation duties roster.\n");
+    writeMd(
+      vault,
+      "Brain/notes/chandelier.md",
+      "# Chandelier\n\nChandelier handoff log, east hall.\n",
+    );
+    await indexVault(makeConfig({ vault, dbPath, maxHops: 0, mmrLambda: 1 }));
+  }
+
+  test("a partial first pass re-queries the uncovered rare term and recovers it", async () => {
+    await seed();
+    const config = makeConfig({ vault, dbPath, maxHops: 0, mmrLambda: 1 });
+    const outcome = await search(config, {
+      query: QUERY,
+      evidencePack: true,
+      structuredQuery: structured,
+    });
+
+    expect(outcome.secondPass?.triggered).toBe(true);
+    expect(outcome.secondPass?.kind).toBe("targeted");
+    expect(outcome.secondPass?.targetedTerms).toContain("chandelier");
+    expect(outcome.secondPass?.added).toBeGreaterThan(0);
+
+    const paths = outcome.results.map((r) => r.path);
+    expect(paths).toContain("Brain/notes/chandelier.md");
+    // The first-pass common-term docs are still present.
+    expect(paths).toContain("Brain/notes/wh1.md");
+
+    // The recovered record carries the targeted attribution; a first-pass
+    // hit does not.
+    const recovered = outcome.results.find((r) => r.path === "Brain/notes/chandelier.md");
+    expect(recovered?.reasons.some((x) => x.startsWith("second_pass: targeted"))).toBe(true);
+    const firstPass = outcome.results.find((r) => r.path === "Brain/notes/wh1.md");
+    expect(firstPass?.reasons.some((x) => x.startsWith("second_pass:"))).toBe(false);
+
+    // The regenerated pack no longer abstains on the now-covered term.
+    expect(outcome.evidencePack?.uncoveredRareTerms ?? []).not.toContain("chandelier");
+  });
+
+  test("the kill switch disables the targeted retry", async () => {
+    await seed();
+    const off = makeConfig({ vault, dbPath, maxHops: 0, mmrLambda: 1, twoPassEnabled: false });
+    const outcome = await search(off, {
+      query: QUERY,
+      evidencePack: true,
+      structuredQuery: structured,
+    });
+    expect(outcome.secondPass).toBeUndefined();
+    expect(outcome.results.map((r) => r.path)).not.toContain("Brain/notes/chandelier.md");
+    // Conservative on a final miss: the pack still abstains on the rare term.
+    expect(outcome.evidencePack?.uncoveredRareTerms ?? []).toContain("chandelier");
+  });
+
+  test("a plain (non-evidence-pack) search never retries", async () => {
+    await seed();
+    const config = makeConfig({ vault, dbPath, maxHops: 0, mmrLambda: 1 });
+    const outcome = await search(config, { query: QUERY, structuredQuery: structured });
+    expect(outcome.secondPass).toBeUndefined();
+  });
+
+  test("a fully-covered first pass never triggers the retry", async () => {
+    await seed();
+    const config = makeConfig({ vault, dbPath, maxHops: 0, mmrLambda: 1 });
+    // No uncovered rare term: the query is exactly the common-term lane.
+    const outcome = await search(config, {
+      query: "warehouse rotation",
+      evidencePack: true,
+      structuredQuery: structured,
+    });
+    expect(outcome.secondPass).toBeUndefined();
+    expect(outcome.evidencePack?.abstention ?? null).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Extend o2b's self-correcting two-pass recall to fire on a **partial miss** (low IDF-weighted coverage), not only a zero-candidate first pass, and aim the follow-up at the **specifically-missing facts** instead of a generic broadening. Inspired by Argus's "Self-Correcting Retrieval" (`quarqlabs/argus`): when the first pass lacks enough evidence, re-retrieve targeted on the missing data, regenerate, and abstain on a final miss rather than guess.

## Why

o2b already had both halves but they were not connected: it computes IDF-weighted coverage and the uncovered rare terms (`coverage.ts`), and it has a self-correcting retry — but that retry fired **only** on a zero-candidate first pass and broadened generically with a single OR pass. So a first pass that returned results yet left rare query terms uncovered was never re-queried. This wires `uncoveredRareTerms` into a targeted follow-up, gated on the existing completeness threshold.

## How

- **`planTargetedRetry(coverage)`** — new pure, deterministic, LLM-free trigger in `coverage.ts`. Fires only when IDF-weighted coverage is below `COMPLETENESS_COMPLETE_THRESHOLD` **and** at least one RARE significant term is uncovered (a rare gate keeps it off when only corpus-common terms are missing), returning exactly those terms to re-query.
- **`search()`** — in evidence-pack mode, on a non-empty first pass with partial coverage, issues exactly ONE targeted FTS pass built from the uncovered rare terms, merges the recovered candidates into the pool, and lets them flow through normal ranking + a regenerated evidence pack. Mutually exclusive with the existing zero-candidate broadened retry (one needs an empty pool, the other a non-empty one) — at most one retry per query, the same single-retry discipline.
- **`SearchOutcome.secondPass`** — gains `kind: "broadened" | "targeted"` and `targetedTerms`. Recovered results carry a `second_pass: targeted retry on uncovered rare terms` reason; the first-pass hits they merge with do not.
- Off when `recall.twoPassEnabled` is false. The regenerated pack still abstains on any term left uncovered after the retry — conservative-on-final-miss posture unchanged.

## Tests

`tests/core/search/coverage-targeted-recall.test.ts` — 8 tests: pure `planTargetedRetry` decisions (complete → no fire; partial+rare → fire on those terms; rare gate; zero coverage → all rare terms) and end-to-end wiring (partial first pass recovers the uncovered rare term with correct attribution; kill switch; plain-search no-op; fully-covered no-op). Full search suite (650) + mcp/cli/e2e green; typecheck, lint, version-sync, and version test pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Targeted retry mechanism for partial query coverage that re-queries uncovered rare terms to improve search recall
  * Enhanced result attribution distinguishing between different search retry types

* **Documentation**
  * Updated changelog for v1.18.0 release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->