### PR TITLE
fix: cross-vault chain-stop reads the max normalized score (v1.18.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "Plugin-first second brain package for AI agents and humans.",
   "author": {
     "name": "Open Second Brain contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "skills": "./skills",
   "hooks": "./hooks/hooks.json",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.1] - 2026-06-24
+
+### Fixed
+
+- **Cross-vault chain-stop reads the max normalized score, not the first
+  result (`t_23c1b929`).** The normalized-confidence chain-stop gated on
+  `results[0].score`, assuming a score-descending order, but `rerank` and MMR
+  reorder results by relevance/diversity, so the positional first element is
+  not always the score maximum. It now gates on the maximum normalized score
+  across the origin's results, so an enabled chain-stop short-circuits exactly
+  when an origin truly answers confidently. Off by default, and byte-identical
+  on the default ranking path where the first result already is the maximum.
+
 ## [1.18.0] - 2026-06-24
 
 Recall precision, coverage, and provenance hardening. Six related

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "open-second-brain",
   "name": "Open Second Brain",
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults.",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "activation": { "onStartup": true },
   "skills": ["./skills"],
   "contracts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "private": false,
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults. Works with Hermes, Claude Code, Codex, and OpenClaw.",
   "keywords": [

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "1.18.0"
+version: "1.18.1"
 description: "Open Second Brain - native Hermes memory provider backed by an Obsidian-compatible Markdown vault."
 author: "Open Second Brain contributors"
 memory_provider: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "author": {
     "name": "Open Second Brain contributors",

--- a/plugins/hermes/plugin.yaml
+++ b/plugins/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "1.18.0"
+version: "1.18.1"
 description: "Open Second Brain - native Hermes memory provider backed by an Obsidian-compatible Markdown vault."
 author: "Open Second Brain contributors"
 memory_provider: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 # CLI entry points (those moved to `package.json` `bin`).
 [project]
 name = "open-second-brain"
-version = "1.18.0"
+version = "1.18.1"
 description = "Hermes Python shim for Open Second Brain. Most of the project (CLI, MCP server, OpenClaw plugin) is TypeScript on Bun; see package.json."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/core/search/cross-vault.ts
+++ b/src/core/search/cross-vault.ts
@@ -123,17 +123,20 @@ export async function searchAcrossVaults(
       total += outcome.total;
       // Chain-stop: if this origin answered confidently (its top NORMALIZED
       // [0,1] result score reached the threshold) and origins remain, skip
-      // them. `results` is ranked score-desc, so `[0]` is the top score; it
-      // is the normalized score, never the raw lane score, so a tiny-corpus
-      // origin with a high raw score does not short-circuit. Only recorded
-      // when origins were actually skipped, keeping the single-origin and
-      // never-triggered paths byte-identical.
+      // them. Take the MAX score over the origin's results rather than `[0]`:
+      // the final result order is not always score-desc (rerank and MMR reorder
+      // by relevance/diversity), so the positional first element is not
+      // necessarily the score-max. The gate reads the normalized result score,
+      // never the raw lane score, so a tiny-corpus origin with a high raw score
+      // does not short-circuit. Only recorded when origins were actually
+      // skipped, keeping the single-origin and never-triggered paths identical.
       const remaining = origins.slice(i + 1);
+      const topScore = outcome.results.reduce((max, r) => Math.max(max, r.score), 0);
       if (
         activeRecall.chainStopEnabled &&
         remaining.length > 0 &&
         outcome.results.length > 0 &&
-        outcome.results[0]!.score >= activeRecall.chainStopScore
+        topScore >= activeRecall.chainStopScore
       ) {
         chainStop = Object.freeze({
           triggered: true as const,


### PR DESCRIPTION
## Summary

Fixes the normalized-confidence cross-vault chain-stop (t_23c1b929, shipped in 1.18.0) so it gates on the maximum normalized score across an origin's results rather than the positional first result.

## Why this matters

`rerank` and MMR reorder a search's results by relevance/diversity, so the first result is not always the score maximum. The chain-stop read the first result's score, so an enabled chain-stop could fail to short-circuit when a later result actually cleared the threshold, or stop on the wrong element.

```mermaid
flowchart LR
  O["origin results"] -->|"rerank or MMR reorder"| R["first result is not the score max"]
  R -->|"old gate on first result"| W["missed or wrong short-circuit"]
  O -->|"new gate on max score"| C["correct short-circuit"]
```

## What ships

| Change | Effect |
| --- | --- |
| `cross-vault.ts` chain-stop | gate on the max normalized score, not the first result |

Off by default; byte-identical on the default ranking path where the first result already is the maximum.

## Test plan
- [x] `bun run validate` green (typecheck, lint, 4941 tests, 0 fail)
- [x] existing `tests/core/search/cross-vault.test.ts` chain-stop cases pass (trigger / normalized-not-raw / default-off)