### PR TITLE
feat: configurable skills_dir + trigger-keyword auto-attach scoring

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "description": "Plugin-first second brain package for AI agents and humans.",
   "author": {
     "name": "Open Second Brain contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "skills": "./skills",
   "hooks": "./hooks/hooks.json",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.0] - 2026-06-28
+
+Two optional, opt-in config keys widen the agent skill surface without
+changing any default behaviour: skill discovery can point at an external
+directory, and skill auto-attach can score on a `triggers` keyword field.
+
+### Added
+
+- **Configurable skill discovery root (`skills_dir` /
+  `OPEN_SECOND_BRAIN_SKILLS_DIR`).** Points `list_skills` / `get_skill` /
+  `skills_attach` at an arbitrary directory (e.g. an external
+  `~/.hermes/skills/`) instead of vault-local `Brain/skills/`, with no
+  symlinks or vault restructuring. `~` is expanded; a relative value is
+  anchored to the resolved config file's directory so the root is
+  deterministic regardless of the process working directory. Unset leaves
+  discovery byte-identical to before.
+- **Trigger-keyword scoring for skill auto-attach (`skills_attach_triggers`
+  / `OPEN_SECOND_BRAIN_SKILLS_ATTACH_TRIGGERS`).** When `"true"` or `"1"`,
+  each skill's `triggers` frontmatter field (a scalar string or an inline
+  array) participates in the lexical scorer as a 2x BM25 tag signal,
+  alongside name (3x) and description (1x). Default off: `triggers` is
+  ignored and scoring stays name + description only. The tokenizer also
+  emits overlapping bigrams for runs of Han characters, so a spaceless CJK
+  query can match a trigger keyword.
+
 ## [1.19.1] - 2026-06-26
 
 Three correctness and hygiene follow-ups deferred from the v1.18.0 review,

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -271,6 +271,26 @@ scorer and returns a char-budgeted block of top matches; it returns
 config key is `"true"`, so default per-turn injection is unchanged. The
 native Hermes provider calls it from `prefetch()` fail-soft.
 
+Two optional config keys (each with a matching environment variable)
+tune the surface; both are off/unset by default, so behaviour is
+unchanged unless an operator opts in:
+
+- `skills_dir` (`OPEN_SECOND_BRAIN_SKILLS_DIR`) overrides the skill
+  discovery root, replacing vault-local `Brain/skills/` with an arbitrary
+  path (e.g. an external `~/.hermes/skills/`) without symlinks. `~` is
+  expanded; a relative value is anchored to the directory of the resolved
+  config file so the root is the same regardless of the process working
+  directory. The shipped `skills/` root is still scanned.
+- `skills_attach_triggers` (`OPEN_SECOND_BRAIN_SKILLS_ATTACH_TRIGGERS`),
+  when `"true"` or `"1"`, folds each skill's `triggers` frontmatter field
+  into the scorer as a 2x BM25 tag signal (alongside name at 3x and
+  description at 1x). When unset, `triggers` is ignored and scoring stays
+  name + description only. The `triggers` field accepts a scalar string
+  (`triggers: "research lookup"`) or an inline array
+  (`triggers: [research, lookup]`); the scorer also emits overlapping
+  bigrams for runs of Han characters, so a spaceless CJK query can match a
+  trigger keyword.
+
 ## Workspace Insight Suite tools (since v0.38.0)
 
 `brain_search` accepts `global: true` for cross-vault union search:

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "open-second-brain",
   "name": "Open Second Brain",
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults.",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "activation": { "onStartup": true },
   "skills": ["./skills"],
   "contracts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "private": false,
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults. Works with Hermes, Claude Code, Codex, and OpenClaw.",
   "keywords": [

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "1.19.1"
+version: "1.20.0"
 description: "Open Second Brain - native Hermes memory provider backed by an Obsidian-compatible Markdown vault."
 author: "Open Second Brain contributors"
 memory_provider: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "author": {
     "name": "Open Second Brain contributors",

--- a/plugins/hermes/plugin.yaml
+++ b/plugins/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "1.19.1"
+version: "1.20.0"
 description: "Open Second Brain - native Hermes memory provider backed by an Obsidian-compatible Markdown vault."
 author: "Open Second Brain contributors"
 memory_provider: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 # CLI entry points (those moved to `package.json` `bin`).
 [project]
 name = "open-second-brain"
-version = "1.19.1"
+version = "1.20.0"
 description = "Hermes Python shim for Open Second Brain. Most of the project (CLI, MCP server, OpenClaw plugin) is TypeScript on Bun; see package.json."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -10,7 +10,7 @@
 import { mkdirSync, readFileSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 
 import lockfile from "proper-lockfile";
 
@@ -284,13 +284,20 @@ export function resolveMcpToolProfile(configPath?: string): string | null {
 /**
  * Optional skills directory override (Agent Surface Suite). When set,
  * `skills_attach` / `list_skills` / `get_skill` read from this path
- * instead of `<vault>/Brain/skills/`. Supports `~` expansion.
- * Falls back to null (use the default vault-local path).
+ * instead of `<vault>/Brain/skills/`. Supports `~` expansion. A relative
+ * value is anchored to the directory of the resolved config file so the
+ * skill root is deterministic regardless of the process working
+ * directory (a bare `skills_dir: nested/skills` would otherwise resolve
+ * against an unpredictable CWD). Falls back to null (use the default
+ * vault-local path).
  */
 export function resolveSkillsDir(configPath?: string): string | null {
+  const discovery = discoverConfig(configPath);
   const env = process.env["OPEN_SECOND_BRAIN_SKILLS_DIR"]?.trim();
-  const raw = env || discoverConfig(configPath).data["skills_dir"]?.trim();
-  return raw && raw.length > 0 ? expandTilde(raw) : null;
+  const raw = env || discovery.data["skills_dir"]?.trim();
+  if (!raw || raw.length === 0) return null;
+  const expanded = expandTilde(raw);
+  return isAbsolute(expanded) ? expanded : resolve(dirname(discovery.path), expanded);
 }
 
 /**

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -294,6 +294,19 @@ export function resolveSkillsDir(configPath?: string): string | null {
 }
 
 /**
+ * Skill-attach triggers gate (Agent Surface Suite). When enabled (default
+ * OFF), the `triggers` field from each skill's SKILL.md frontmatter is
+ * included in the lexical scorer as a 2x-BM25 tag signal. When disabled
+ * or unset, triggers are ignored and scoring is name (3x) + description
+ * (1x) only.
+ */
+export function resolveSkillsAttachTriggers(configPath?: string): boolean {
+  const env = process.env["OPEN_SECOND_BRAIN_SKILLS_ATTACH_TRIGGERS"]?.trim();
+  const raw = env || discoverConfig(configPath).data["skills_attach_triggers"]?.trim();
+  return raw === "true" || raw === "1";
+}
+
+/**
  * Skill auto-attach gate (Agent Surface Suite). Default OFF: the
  * skills_attach tool returns an empty block unless the operator sets
  * `skill_auto_attach: "true"` (or the matching env override), so the

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -282,6 +282,18 @@ export function resolveMcpToolProfile(configPath?: string): string | null {
 }
 
 /**
+ * Optional skills directory override (Agent Surface Suite). When set,
+ * `skills_attach` / `list_skills` / `get_skill` read from this path
+ * instead of `<vault>/Brain/skills/`. Supports `~` expansion.
+ * Falls back to null (use the default vault-local path).
+ */
+export function resolveSkillsDir(configPath?: string): string | null {
+  const env = process.env["OPEN_SECOND_BRAIN_SKILLS_DIR"]?.trim();
+  const raw = env || discoverConfig(configPath).data["skills_dir"]?.trim();
+  return raw && raw.length > 0 ? expandTilde(raw) : null;
+}
+
+/**
  * Skill auto-attach gate (Agent Surface Suite). Default OFF: the
  * skills_attach tool returns an empty block unless the operator sets
  * `skill_auto_attach: "true"` (or the matching env override), so the

--- a/src/core/surface/descriptor.ts
+++ b/src/core/surface/descriptor.ts
@@ -32,6 +32,8 @@ export interface DescribableSkill {
   readonly name: string;
   readonly description: string;
   readonly path: string;
+  /** Flattened trigger keywords from frontmatter `triggers` field. */
+  readonly triggers?: string;
 }
 
 /** First non-empty line, trimmed. Empty input stays empty. */
@@ -81,16 +83,18 @@ export function toolDescriptors(
 /** Build sorted, frozen descriptors for discovered skills. */
 export function skillDescriptors(
   skills: ReadonlyArray<DescribableSkill>,
+  includeTriggers?: boolean,
 ): ReadonlyArray<SurfaceDescriptor> {
-  const out = skills.map((s) =>
-    freezeDescriptor({
+  const out = skills.map((s) => {
+    const tags: string[] = s.triggers && includeTriggers ? [s.triggers] : [];
+    return freezeDescriptor({
       kind: "skill",
       name: s.name,
       description: firstLine(s.description),
       group: "skill",
-      tags: [],
-    }),
-  );
+      tags,
+    });
+  });
   out.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
   return Object.freeze(out);
 }

--- a/src/core/surface/lexical-score.ts
+++ b/src/core/surface/lexical-score.ts
@@ -33,11 +33,23 @@ const DEFAULTS = Object.freeze({ nameWeight: 3, tagWeight: 2, k1: 1.2, b: 0.75 }
 /**
  * Lowercase, split on non-alphanumerics, drop 1-char tokens. Plain
  * toLowerCase keeps tokenisation identical across host locales.
+ * CJK text without spaces (e.g. "实现方式") gets overlapping bigrams
+ * so queries like "gbrain的实现方式" can match trigger/description
+ * tokens like "实现方式".
  */
 export function tokenize(text: string): string[] {
   const out: string[] = [];
   for (const raw of text.toLowerCase().split(/[^\p{L}\p{N}]+/u)) {
-    if (raw.length >= 2) out.push(raw);
+    if (raw.length < 2) continue;
+    // CJK bigram pass: any token containing 2+ CJK characters also
+    // emits overlapping 2-char windows so "实现方式" and "的实现方式"
+    // share the bigram "实现".
+    if (/[\u4e00-\u9fff]/.test(raw) && raw.length > 2) {
+      for (let i = 0; i < raw.length - 1; i++) {
+        out.push(raw.slice(i, i + 2));
+      }
+    }
+    out.push(raw);
   }
   return out;
 }

--- a/src/core/surface/lexical-score.ts
+++ b/src/core/surface/lexical-score.ts
@@ -33,15 +33,19 @@ const DEFAULTS = Object.freeze({ nameWeight: 3, tagWeight: 2, k1: 1.2, b: 0.75 }
 /**
  * Lowercase, split on non-alphanumerics, drop 1-char tokens. Plain
  * toLowerCase keeps tokenisation identical across host locales.
- * CJK text without spaces (e.g. "实现方式") gets overlapping bigrams
- * so queries like "gbrain的实现方式" can match trigger/description
- * tokens like "实现方式".
+ * Han text without spaces (e.g. "实现方式") additionally gets overlapping
+ * bigrams so queries like "gbrain的实现方式" can match trigger/description
+ * tokens like "实现方式". This bigram pass is intentionally global to the
+ * tokenizer (not gated behind skills_attach_triggers): ASCII tokenisation
+ * is provably unchanged, and the only consumer of scoreDescriptors today
+ * is the skill-attach path. The range covers Han Unified Ideographs only;
+ * kana / Hangul / CJK extensions are not bigram-split.
  */
 export function tokenize(text: string): string[] {
   const out: string[] = [];
   for (const raw of text.toLowerCase().split(/[^\p{L}\p{N}]+/u)) {
     if (raw.length < 2) continue;
-    // CJK bigram pass: any token containing 2+ CJK characters also
+    // Han bigram pass: a token with a Han character and length > 2 also
     // emits overlapping 2-char windows so "实现方式" and "的实现方式"
     // share the bigram "实现".
     if (/[\u4e00-\u9fff]/.test(raw) && raw.length > 2) {

--- a/src/core/surface/skill-attach.ts
+++ b/src/core/surface/skill-attach.ts
@@ -34,6 +34,12 @@ export interface BuildSkillAttachmentOptions {
   readonly maxSkills?: number;
   /** Char budget for the rendered block. Default 1200. */
   readonly maxChars?: number;
+  /**
+   * When set, the `triggers` field from each skill's frontmatter is
+   * included in the lexical scorer as a 2x-BM25 tag signal. Default
+   * false (name 3x + description 1x only).
+   */
+  readonly includeTriggers?: boolean;
 }
 
 const DEFAULT_MAX_SKILLS = 3;
@@ -48,7 +54,10 @@ export function buildSkillAttachment(opts: BuildSkillAttachmentOptions): SkillAt
   const maxSkills = opts.maxSkills ?? DEFAULT_MAX_SKILLS;
   const maxChars = opts.maxChars ?? DEFAULT_MAX_CHARS;
   const byName = new Map(opts.skills.map((s) => [s.name, s]));
-  const ranked = scoreDescriptors(opts.query, skillDescriptors(opts.skills)).slice(0, maxSkills);
+  const ranked = scoreDescriptors(
+    opts.query,
+    skillDescriptors(opts.skills, opts.includeTriggers),
+  ).slice(0, maxSkills);
 
   const items: SkillAttachItem[] = [];
   const lines: string[] = [];

--- a/src/core/surface/skills.ts
+++ b/src/core/surface/skills.ts
@@ -13,6 +13,7 @@
 import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { isAbsolute, join, resolve, sep } from "node:path";
 
+import type { FrontmatterValue } from "../types.ts";
 import { parseFrontmatter } from "../vault.ts";
 import { firstLine } from "./descriptor.ts";
 
@@ -78,24 +79,20 @@ export function skillRoots(opts: SkillRootsOptions): string[] {
 }
 
 /**
- * Recursively flatten the frontmatter `triggers` field into a
- * space-separated keyword string. Handles nested arrays and objects:
+ * Flatten the frontmatter `triggers` field into a space-separated
+ * keyword string. The vault frontmatter parser yields only the two
+ * shapes a SKILL.md author can write - a scalar string or an inline
+ * array - so those are the cases handled:
  *
- *   triggers:
- *     - research: "调研/search"
- *     - social:
- *         - 小红书: "xiaohongshu/红书"
+ *   triggers: "research lookup 调研"        → "research lookup 调研"
+ *   triggers: [research, lookup, 调研]      → "research lookup 调研"
  *
- *   → "调研/search xiaohongshu/红书"
+ * A non-string scalar (number/boolean) is not a meaningful keyword
+ * source and flattens to the empty string.
  */
-function flattenTriggers(raw: unknown): string {
+function flattenTriggers(raw: FrontmatterValue): string {
   if (typeof raw === "string") return raw;
-  if (Array.isArray(raw)) {
-    return raw.map(flattenTriggers).filter(Boolean).join(" ");
-  }
-  if (typeof raw === "object" && raw !== null) {
-    return Object.values(raw).map(flattenTriggers).filter(Boolean).join(" ");
-  }
+  if (Array.isArray(raw)) return raw.join(" ");
   return "";
 }
 

--- a/src/core/surface/skills.ts
+++ b/src/core/surface/skills.ts
@@ -43,6 +43,13 @@ export interface SkillRootsOptions {
   readonly repoRoot?: string | null;
   /** Vault root; vault-local skills live at `Brain/skills/`. */
   readonly vault?: string | null;
+  /**
+   * Explicit skills directory override. When set, takes precedence over
+   * the vault-local `Brain/skills/` path, letting operators point the
+   * skill surface at an external directory (e.g. `~/.hermes/skills/`)
+   * without symlinks. Supports ~ expansion via the caller.
+   */
+  readonly skillsDir?: string | null;
 }
 
 export const SKILL_FILE_NAME = "SKILL.md";
@@ -51,7 +58,11 @@ export const SKILL_FILE_NAME = "SKILL.md";
 export function skillRoots(opts: SkillRootsOptions): string[] {
   const candidates: string[] = [];
   if (opts.repoRoot) candidates.push(join(opts.repoRoot, "skills"));
-  if (opts.vault) candidates.push(join(opts.vault, "Brain", "skills"));
+  if (opts.skillsDir) {
+    candidates.push(opts.skillsDir);
+  } else if (opts.vault) {
+    candidates.push(join(opts.vault, "Brain", "skills"));
+  }
   return candidates.filter((root) => {
     try {
       return statSync(root).isDirectory();

--- a/src/core/surface/skills.ts
+++ b/src/core/surface/skills.ts
@@ -32,6 +32,11 @@ export interface SkillEntry {
   readonly name: string;
   /** Frontmatter `description`, falling back to the first body line. */
   readonly description: string;
+  /**
+   * Flattened trigger keywords from frontmatter `triggers` field.
+   * Empty string when no triggers are declared.
+   */
+  readonly triggers: string;
   /** Absolute path to the skill directory. */
   readonly path: string;
   /** Absolute path to the SKILL.md file. */
@@ -72,6 +77,28 @@ export function skillRoots(opts: SkillRootsOptions): string[] {
   });
 }
 
+/**
+ * Recursively flatten the frontmatter `triggers` field into a
+ * space-separated keyword string. Handles nested arrays and objects:
+ *
+ *   triggers:
+ *     - research: "调研/search"
+ *     - social:
+ *         - 小红书: "xiaohongshu/红书"
+ *
+ *   → "调研/search xiaohongshu/红书"
+ */
+function flattenTriggers(raw: unknown): string {
+  if (typeof raw === "string") return raw;
+  if (Array.isArray(raw)) {
+    return raw.map(flattenTriggers).filter(Boolean).join(" ");
+  }
+  if (typeof raw === "object" && raw !== null) {
+    return Object.values(raw).map(flattenTriggers).filter(Boolean).join(" ");
+  }
+  return "";
+}
+
 function readSkillEntry(root: string, dir: string): SkillEntry | null {
   const path = join(root, dir);
   const skillFile = join(path, SKILL_FILE_NAME);
@@ -79,9 +106,12 @@ function readSkillEntry(root: string, dir: string): SkillEntry | null {
   const [meta, body] = parseFrontmatter(skillFile);
   const metaName = typeof meta["name"] === "string" ? meta["name"].trim() : "";
   const metaDescription = typeof meta["description"] === "string" ? meta["description"].trim() : "";
+  const rawTriggers = meta["triggers"];
+  const triggers = rawTriggers !== undefined ? flattenTriggers(rawTriggers) : "";
   return Object.freeze({
     name: metaName.length > 0 ? metaName : dir,
     description: metaDescription.length > 0 ? metaDescription : firstBodyLine(body),
+    triggers,
     path,
     skillFile,
   });

--- a/src/mcp/skill-tools.ts
+++ b/src/mcp/skill-tools.ts
@@ -10,7 +10,7 @@
  * with the shared lexical scorer and returns a char-budgeted block.
  */
 
-import { resolveSkillAutoAttach } from "../core/config.ts";
+import { resolveSkillAutoAttach, resolveSkillsDir } from "../core/config.ts";
 import { buildSkillAttachment } from "../core/surface/skill-attach.ts";
 import { discoverSkills, readSkillFile, skillRoots, SkillError } from "../core/surface/skills.ts";
 import { coerceInt, coerceStr } from "./coerce.ts";
@@ -19,7 +19,8 @@ import { INVALID_PARAMS, MCPError } from "./protocol.ts";
 import type { ServerContext, ToolDefinition } from "./tools.ts";
 
 function rootsFor(ctx: ServerContext): string[] {
-  return skillRoots({ repoRoot: ctx.repoRoot, vault: ctx.vault });
+  const skillsDir = resolveSkillsDir(ctx.configPath ?? undefined);
+  return skillRoots({ repoRoot: ctx.repoRoot, vault: ctx.vault, skillsDir });
 }
 
 function toolListSkills(ctx: ServerContext): Record<string, unknown> {

--- a/src/mcp/skill-tools.ts
+++ b/src/mcp/skill-tools.ts
@@ -10,7 +10,11 @@
  * with the shared lexical scorer and returns a char-budgeted block.
  */
 
-import { resolveSkillAutoAttach, resolveSkillsDir } from "../core/config.ts";
+import {
+  resolveSkillAutoAttach,
+  resolveSkillsDir,
+  resolveSkillsAttachTriggers,
+} from "../core/config.ts";
 import { buildSkillAttachment } from "../core/surface/skill-attach.ts";
 import { discoverSkills, readSkillFile, skillRoots, SkillError } from "../core/surface/skills.ts";
 import { coerceInt, coerceStr } from "./coerce.ts";
@@ -69,10 +73,12 @@ function toolSkillsAttach(
   if (!resolveSkillAutoAttach(ctx.configPath ?? undefined)) {
     return { enabled: false, block: "", skills: [] };
   }
+  const includeTriggers = resolveSkillsAttachTriggers(ctx.configPath ?? undefined);
   const attachment = buildSkillAttachment({
     query,
     skills: discoverSkills(rootsFor(ctx)),
     maxSkills,
+    includeTriggers,
   });
   return {
     enabled: true,

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 
 import {
   defaultConfigPath,
@@ -10,6 +10,8 @@ import {
   redactMapping,
   resolveAgentName,
   resolveLinkOutputFormat,
+  resolveSkillsAttachTriggers,
+  resolveSkillsDir,
   resolveTimezone,
   resolveVault,
   setConfigValue,
@@ -28,6 +30,8 @@ beforeEach(() => {
     "VAULT_AGENT_NAME",
     "VAULT_TIMEZONE",
     "OBSIDIAN_LINK_FORMAT",
+    "OPEN_SECOND_BRAIN_SKILLS_DIR",
+    "OPEN_SECOND_BRAIN_SKILLS_ATTACH_TRIGGERS",
   ]) {
     savedEnv[k] = process.env[k];
     delete process.env[k];
@@ -271,5 +275,85 @@ describe("resolveTimezone", () => {
     const cfg = join(tmp, "config.yaml");
     writeFileSync(cfg, 'timezone: "Europe/Belgrade"\n');
     expect(resolveTimezone(cfg)).toBe("UTC");
+  });
+});
+
+describe("resolveSkillsDir", () => {
+  test("returns null when neither env nor config", () => {
+    expect(resolveSkillsDir(join(tmp, "missing.yaml"))).toBeNull();
+  });
+
+  test("returns null for an empty or whitespace value", () => {
+    const cfg = join(tmp, "config.yaml");
+    writeFileSync(cfg, 'skills_dir: "   "\n');
+    expect(resolveSkillsDir(cfg)).toBeNull();
+  });
+
+  test("reads an absolute path from config verbatim", () => {
+    const cfg = join(tmp, "config.yaml");
+    writeFileSync(cfg, 'skills_dir: "/srv/skills"\n');
+    expect(resolveSkillsDir(cfg)).toBe("/srv/skills");
+  });
+
+  test("env wins over config", () => {
+    process.env["OPEN_SECOND_BRAIN_SKILLS_DIR"] = "/env/skills";
+    const cfg = join(tmp, "config.yaml");
+    writeFileSync(cfg, 'skills_dir: "/cfg/skills"\n');
+    expect(resolveSkillsDir(cfg)).toBe("/env/skills");
+  });
+
+  test("expands ~ in config value", () => {
+    const cfg = join(tmp, "config.yaml");
+    writeFileSync(cfg, 'skills_dir: "~/my-skills"\n');
+    const got = resolveSkillsDir(cfg);
+    expect(got).not.toBeNull();
+    expect(got!.startsWith("~")).toBe(false);
+    expect(isAbsolute(got!)).toBe(true);
+  });
+
+  test("anchors a relative config value to the config-file directory", () => {
+    const cfg = join(tmp, "config.yaml");
+    writeFileSync(cfg, "skills_dir: nested/skills\n");
+    expect(resolveSkillsDir(cfg)).toBe(resolve(dirname(cfg), "nested/skills"));
+  });
+
+  test("anchors a relative env value to the config-file directory (CWD-independent)", () => {
+    process.env["OPEN_SECOND_BRAIN_SKILLS_DIR"] = "rel/skills";
+    const cfg = join(tmp, "config.yaml");
+    writeFileSync(cfg, "instance_name: x\n");
+    const got = resolveSkillsDir(cfg);
+    expect(got).toBe(resolve(dirname(cfg), "rel/skills"));
+    expect(isAbsolute(got!)).toBe(true);
+  });
+});
+
+describe("resolveSkillsAttachTriggers", () => {
+  test("defaults to false when nothing configured", () => {
+    expect(resolveSkillsAttachTriggers(join(tmp, "missing.yaml"))).toBe(false);
+  });
+
+  test("reads true from config", () => {
+    const cfg = join(tmp, "config.yaml");
+    writeFileSync(cfg, 'skills_attach_triggers: "true"\n');
+    expect(resolveSkillsAttachTriggers(cfg)).toBe(true);
+  });
+
+  test("accepts 1 as truthy", () => {
+    const cfg = join(tmp, "config.yaml");
+    writeFileSync(cfg, 'skills_attach_triggers: "1"\n');
+    expect(resolveSkillsAttachTriggers(cfg)).toBe(true);
+  });
+
+  test("any other value stays false", () => {
+    const cfg = join(tmp, "config.yaml");
+    writeFileSync(cfg, 'skills_attach_triggers: "yes"\n');
+    expect(resolveSkillsAttachTriggers(cfg)).toBe(false);
+  });
+
+  test("env wins over config", () => {
+    process.env["OPEN_SECOND_BRAIN_SKILLS_ATTACH_TRIGGERS"] = "true";
+    const cfg = join(tmp, "config.yaml");
+    writeFileSync(cfg, 'skills_attach_triggers: "false"\n');
+    expect(resolveSkillsAttachTriggers(cfg)).toBe(true);
   });
 });

--- a/tests/core/surface/descriptor.test.ts
+++ b/tests/core/surface/descriptor.test.ts
@@ -56,6 +56,26 @@ test("skillDescriptors maps skill entries with the skill group", () => {
   expect(out[0]!.name).toBe("brain-memory");
 });
 
+test("skillDescriptors omits triggers tags unless includeTriggers is set", () => {
+  const skills = [
+    {
+      name: "agent-search",
+      description: "Search the web.",
+      path: "skills/agent-search",
+      triggers: "research lookup",
+    },
+  ];
+  const off = skillDescriptors(skills);
+  expect(off[0]!.tags).toEqual([]);
+  const on = skillDescriptors(skills, true);
+  expect(on[0]!.tags).toEqual(["research lookup"]);
+});
+
+test("skillDescriptors with includeTriggers still emits no tag for an empty triggers field", () => {
+  const skills = [{ name: "bare", description: "No triggers.", path: "skills/bare", triggers: "" }];
+  expect(skillDescriptors(skills, true)[0]!.tags).toEqual([]);
+});
+
 test("firstLine trims and collapses to the first non-empty line", () => {
   expect(firstLine("  hello world \n second")).toBe("hello world");
   expect(firstLine("\n\nlate start\nrest")).toBe("late start");

--- a/tests/core/surface/lexical-score.test.ts
+++ b/tests/core/surface/lexical-score.test.ts
@@ -29,6 +29,30 @@ test("tokenize lowercases, splits punctuation, drops 1-char tokens", () => {
   ]);
 });
 
+test("a CJK run longer than 2 chars also emits overlapping bigrams", () => {
+  // Han text has no spaces, so a query like "...的实现方式" only matches a
+  // skill trigger "实现方式" if both share the "实现" / "方式" bigrams.
+  expect(tokenize("实现方式")).toEqual(["实现", "现方", "方式", "实现方式"]);
+});
+
+test("a 2-char CJK token is kept whole without extra bigrams", () => {
+  expect(tokenize("实现")).toEqual(["实现"]);
+});
+
+test("ASCII tokenization is unaffected by the CJK bigram pass", () => {
+  expect(tokenize("Hello World")).toEqual(["hello", "world"]);
+});
+
+test("CJK bigram overlap lets a spaceless query match a tag token", () => {
+  const corpus = [
+    d("doc_a", "documentation", ["实现方式"]),
+    d("doc_b", "documentation", ["其他内容"]),
+  ];
+  const ranked = scoreDescriptors("新的实现方式", corpus);
+  expect(ranked).toHaveLength(1);
+  expect(ranked[0]!.descriptor.name).toBe("doc_a");
+});
+
 test("query matching a description ranks that descriptor first", () => {
   const ranked = scoreDescriptors("semantic vault search", CORPUS);
   expect(ranked[0]!.descriptor.name).toBe("brain_search");

--- a/tests/core/surface/skill-attach.test.ts
+++ b/tests/core/surface/skill-attach.test.ts
@@ -7,6 +7,7 @@ function entry(name: string, description: string): SkillEntry {
   return Object.freeze({
     name,
     description,
+    triggers: "",
     path: `/skills/${name}`,
     skillFile: `/skills/${name}/SKILL.md`,
   });

--- a/tests/core/surface/skill-attach.test.ts
+++ b/tests/core/surface/skill-attach.test.ts
@@ -3,11 +3,11 @@ import { test, expect } from "bun:test";
 import { buildSkillAttachment } from "../../../src/core/surface/skill-attach.ts";
 import type { SkillEntry } from "../../../src/core/surface/skills.ts";
 
-function entry(name: string, description: string): SkillEntry {
+function entry(name: string, description: string, triggers = ""): SkillEntry {
   return Object.freeze({
     name,
     description,
-    triggers: "",
+    triggers,
     path: `/skills/${name}`,
     skillFile: `/skills/${name}/SKILL.md`,
   });
@@ -59,6 +59,27 @@ test("maxChars budget drops whole trailing entries, never truncates mid-line", (
 test("empty skill list and empty query fail soft", () => {
   expect(buildSkillAttachment({ query: "anything", skills: [] }).items).toHaveLength(0);
   expect(buildSkillAttachment({ query: "", skills: SKILLS }).items).toHaveLength(0);
+});
+
+test("includeTriggers lets a triggers-only keyword surface a skill", () => {
+  const skills = [
+    entry("agent-search", "A general capability.", "调研 reconnaissance"),
+    entry("brain-memory", "Record taste signals."),
+  ];
+  // The query word matches only the triggers field, not name or description.
+  const without = buildSkillAttachment({ query: "reconnaissance", skills });
+  expect(without.items).toHaveLength(0);
+  const withTriggers = buildSkillAttachment({
+    query: "reconnaissance",
+    skills,
+    includeTriggers: true,
+  });
+  expect(withTriggers.items[0]!.name).toBe("agent-search");
+});
+
+test("includeTriggers is off by default", () => {
+  const skills = [entry("agent-search", "A general capability.", "reconnaissance")];
+  expect(buildSkillAttachment({ query: "reconnaissance", skills }).items).toHaveLength(0);
 });
 
 test("the block is deterministic and headed", () => {

--- a/tests/core/surface/skills.test.ts
+++ b/tests/core/surface/skills.test.ts
@@ -42,6 +42,34 @@ test("discoverSkills reads frontmatter name and description", () => {
   expect(skills[0]!.description).toBe("Does alpha things.");
 });
 
+test("parses a scalar triggers field into the flattened keyword string", () => {
+  const root = join(tmp, "skills");
+  writeSkill(
+    root,
+    "agent-search",
+    'name: agent-search\ndescription: "Search."\ntriggers: "research lookup 调研"',
+    "# Search",
+  );
+  expect(discoverSkills([root])[0]!.triggers).toBe("research lookup 调研");
+});
+
+test("parses an inline-array triggers field by joining on space", () => {
+  const root = join(tmp, "skills");
+  writeSkill(
+    root,
+    "agent-search",
+    "name: agent-search\ndescription: d\ntriggers: [research, lookup, 调研]",
+    "# Search",
+  );
+  expect(discoverSkills([root])[0]!.triggers).toBe("research lookup 调研");
+});
+
+test("a skill without a triggers field exposes an empty triggers string", () => {
+  const root = join(tmp, "skills");
+  writeSkill(root, "plain", "name: plain\ndescription: d", "# Plain");
+  expect(discoverSkills([root])[0]!.triggers).toBe("");
+});
+
 test("falls back to directory name and first body line without frontmatter", () => {
   const root = join(tmp, "skills");
   writeSkill(root, "bare", null, "# Bare Skill\n\nFirst real paragraph line.\n\nMore.");

--- a/tests/core/surface/skills.test.ts
+++ b/tests/core/surface/skills.test.ts
@@ -114,6 +114,32 @@ test("skillRoots returns existing repo and vault roots only", () => {
   expect(skillRoots({ repoRoot: join(tmp, "ghost"), vault: null })).toEqual([]);
 });
 
+test("skillsDir overrides the vault-local Brain/skills root", () => {
+  const vault = join(tmp, "vault");
+  mkdirSync(join(vault, "Brain", "skills"), { recursive: true });
+  const external = join(tmp, "external-skills");
+  mkdirSync(external, { recursive: true });
+  // With skillsDir set, the vault-local path is replaced, not appended.
+  expect(skillRoots({ vault, skillsDir: external })).toEqual([external]);
+});
+
+test("skillsDir alongside repoRoot keeps the repo root and replaces the vault root", () => {
+  const repoRoot = join(tmp, "repo");
+  mkdirSync(join(repoRoot, "skills"), { recursive: true });
+  const vault = join(tmp, "vault");
+  mkdirSync(join(vault, "Brain", "skills"), { recursive: true });
+  const external = join(tmp, "external-skills");
+  mkdirSync(external, { recursive: true });
+  expect(skillRoots({ repoRoot, vault, skillsDir: external })).toEqual([
+    join(repoRoot, "skills"),
+    external,
+  ]);
+});
+
+test("a non-existent skillsDir falls soft to an empty root list", () => {
+  expect(skillRoots({ vault: null, skillsDir: join(tmp, "ghost-skills") })).toEqual([]);
+});
+
 test("readSkillFile returns SKILL.md by default and auxiliary files by relative path", () => {
   const root = join(tmp, "skills");
   const dir = writeSkill(root, "rich", "name: rich\ndescription: r", "# Rich");


### PR DESCRIPTION
## Summary

Two optional, opt-in config keys widen the agent skill surface without changing any default behaviour:

- **`skills_dir`** (`OPEN_SECOND_BRAIN_SKILLS_DIR`) points `list_skills` / `get_skill` / `skills_attach` at an arbitrary skill-discovery directory (e.g. an external `~/.hermes/skills/`) instead of vault-local `Brain/skills/`, with no symlinks or vault restructuring. The shipped `skills/` root is still scanned.
- **`skills_attach_triggers`** (`OPEN_SECOND_BRAIN_SKILLS_ATTACH_TRIGGERS`) folds each skill's `triggers` frontmatter field into the lexical scorer as a 2x BM25 tag signal (alongside name at 3x and description at 1x), so a skill can be surfaced by intent keywords its name and description don't contain.

Both default off/unset, so per-turn injection and discovery stay byte-identical until an operator opts in.

## What ships

| Area | Change |
|---|---|
| `skills_dir` | New config key + env var; relative values are anchored to the resolved config file's directory so the discovery root is deterministic regardless of the process working directory. `~` expanded; env over config; empty → vault-local default. |
| `skills_attach_triggers` | New config key + env var gating the `triggers` tag signal. `triggers` frontmatter accepts a scalar string or an inline array; parsed into `SkillEntry` and fed to scoring only when the gate is on. |
| Lexical scorer | Han-character runs additionally emit overlapping bigrams, so a spaceless CJK query (no word boundaries) can match a trigger keyword. ASCII tokenization is provably unchanged. |
| Tests | Coverage for relative-path anchoring (incl. CWD-independence), triggers parsing (scalar / inline-array / empty), the include-triggers gate, `skillRoots` override precedence, and the CJK bigram pass. |
| Docs | `docs/mcp.md` Skill-surface section + `CHANGELOG.md` v1.20.0. |

## Test plan

- [x] `bun test` — full suite green (4991 pass, 0 fail)
- [x] `npx tsc --noEmit` — clean
- [x] `bun run sync-version:check` — manifests in sync at 1.20.0
- [x] Senior-reviewer pass — no Critical/Important findings

## Notes

Picks up @bitfrost7's original implementation (the two `feat` commits + the triggers-parse and CJK commits) and finishes it to release: deterministic relative-`skills_dir` resolution (was CWD-relative), a type-honest `flattenTriggers`, full test coverage, docs, and the version bump. Rebased onto current `main`. Full credit to @bitfrost7 for the idea and the initial implementation.
