### PR TITLE
fix: keep full MCP status output and normalize codegraph paths

### DIFF
--- a/src/core/partner/codegraph-report.ts
+++ b/src/core/partner/codegraph-report.ts
@@ -246,6 +246,15 @@ export function buildCodegraphReport(
   };
 }
 
+/**
+ * Canonicalize the reported project path so it matches the shape callers
+ * already hold. On macOS `/var` is a symlink to `/private/var`, so
+ * `realpathSync` resolves temp roots (Node's `tmpdir()` -> `/var/folders/...`)
+ * to `/private/var/...`; stripping the `/private` prefix restores the
+ * user-facing `/var/...` form. The narrow prefix is deliberate - only the
+ * `/var` firmlink is rewritten this way, never an arbitrary `/private/*` path.
+ * Display-only: index resolution above runs against the raw `project`.
+ */
 function displayPath(path: string): string {
   try {
     const real = realpathSync(path);

--- a/src/core/partner/codegraph-report.ts
+++ b/src/core/partner/codegraph-report.ts
@@ -14,7 +14,7 @@
  * errors and not silent no-ops.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 
 import {
@@ -238,12 +238,21 @@ export function buildCodegraphReport(
 
   return {
     schema_version: 1,
-    project,
+    project: displayPath(project),
     cli,
     index,
     cargo_workspace: cargo.workspace,
     cargo_workspace_reason: cargo.reason,
   };
+}
+
+function displayPath(path: string): string {
+  try {
+    const real = realpathSync(path);
+    return real.startsWith("/private/var/") ? real.slice("/private".length) : real;
+  } catch {
+    return path.startsWith("/private/var/") ? path.slice("/private".length) : path;
+  }
 }
 
 function resolveIndexState(

--- a/src/mcp/registry-guard.ts
+++ b/src/mcp/registry-guard.ts
@@ -98,6 +98,8 @@ export const PREVIEW_BUDGET_EXEMPT: Readonly<Record<string, string>> = Object.fr
 
   // Bounded-by-construction reads.
   second_brain_capabilities: "fixed-size capability report",
+  second_brain_status:
+    "diagnostic contract; callers need full brain/search/config blocks, not a preview envelope",
   brain_context:
     "session bootstrap; deliberately returns the full preference set - it is the full-view target the budgeted SessionStart injection points at",
   brain_pre_compress_pack: "self-budgeting; enforces its own char budget internally",

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -347,7 +347,13 @@ export function buildToolTable(scope: ToolScope = "full"): ToolDefinition[] {
         properties: {},
         additionalProperties: false,
       },
-      previewBudget: MCP_PREVIEW_BUDGET,
+      // No previewBudget: a vault with an indexed search and a populated
+      // Brain layer easily exceeds the default MCP preview cap, and
+      // the `search.*` / `brain.*` blocks are the whole point of the
+      // tool. Without this override, large payloads came back wrapped
+      // in a `{ preview_truncated, artifact_id, bytes_preview }`
+      // envelope — tests parsing `content[0].text` as JSON then lost
+      // every block the operator asked for.
       handler: toolStatus,
     },
     {


### PR DESCRIPTION
## Summary

This fixes two test failures that currently reproduce on `main`:

- keep `second_brain_status` unwrapped so callers can read the full diagnostic payload, including the `search` block after indexing
- normalize macOS `/private/var/...` temp paths to `/var/...` in the codegraph partner report so the CLI output matches Node's `tmpdir()` path shape used by the test fixture

## Why

`second_brain_status` is a diagnostic tool. When its output includes indexed search metadata, the default preview budget can wrap `content[0].text` in a preview envelope. That makes callers parsing the text payload lose the top-level `search` field even though the structured payload still has it.

The codegraph partner test fails on macOS because `process.cwd()` can resolve a temp directory through `/private/var/...`, while the fixture path is built from `tmpdir()` as `/var/...`.

## Test plan

- `bun test tests/mcp/search.test.ts tests/cli/partner-codegraph.test.ts tests/mcp/registry-guard.test.ts`
- `npm test`

Both pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved display of project paths in code graph reports for clearer, more consistent output.
  * Marked `second_brain_status` as exempt from preview-budget enforcement.

* **Bug Fixes**
  * Prevented tool responses from being wrapped in a truncated preview envelope, preserving full structured JSON content.
  * Made project path rendering more reliable by handling platform-specific path formats and private-directory prefix differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->