### PR TITLE
fix(windows): normalize vault path and resolve o2b command

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "Plugin-first second brain package for AI agents and humans.",
   "author": {
     "name": "Open Second Brain contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "skills": "./skills",
   "hooks": "./hooks/hooks.json",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.1] - 2026-07-06
+
+### Fixed
+
+- **`o2b init` fails on native Windows** — `resolve()` produces backslash
+  paths that `setConfigValue()` rejects via `CONFIG_VALUE_REJECTED_CHARS`.
+  Vault path is now normalized to forward slashes before persisting; forward
+  slashes work identically in Node/Bun fs APIs on Windows. (#119)
+- **Hermes memory provider bridge fails on Windows** — `scripts/o2b` is a
+  bash script that `subprocess.Popen` cannot execute directly (Windows
+  delegates to `cmd.exe`, not a POSIX shell). Added `_resolve_command()`
+  which detects the platform and falls back to `bun run <entry> mcp` when
+  `o2b` is not available as a native executable.
+
 ## [1.23.0] - 2026-07-05
 
 Two optional precision layers that complete the retrieval-precision loop

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "open-second-brain",
   "name": "Open Second Brain",
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults.",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "activation": { "onStartup": true },
   "skills": ["./skills"],
   "contracts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "private": false,
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults. Works with Hermes, Claude Code, Codex, and OpenClaw.",
   "keywords": [

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "1.23.0"
+version: "1.23.1"
 description: "Open Second Brain - native Hermes memory provider backed by an Obsidian-compatible Markdown vault."
 author: "Open Second Brain contributors"
 memory_provider: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "author": {
     "name": "Open Second Brain contributors",

--- a/plugins/hermes/plugin.yaml
+++ b/plugins/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "1.23.0"
+version: "1.23.1"
 description: "Open Second Brain - native Hermes memory provider backed by an Obsidian-compatible Markdown vault."
 author: "Open Second Brain contributors"
 memory_provider: true

--- a/plugins/hermes/provider.py
+++ b/plugins/hermes/provider.py
@@ -13,7 +13,9 @@ are added alongside.
 from __future__ import annotations
 
 import json
+import os
 import re
+import shutil
 import threading
 from pathlib import Path
 from typing import Any
@@ -89,6 +91,7 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
         self._bridge = self._bridge_override or McpBrainBridge(
             vault=config.resolve_vault(),
             repo_root=self._repo_root(),
+            command=self._resolve_command(),
         )
         try:
             self._bridge.start()
@@ -103,6 +106,44 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
         without it ``skill_auto_attach`` returns an empty list."""
         root = Path(__file__).resolve().parents[2]
         return str(root) if (root / "skills").is_dir() else None
+
+    @classmethod
+    def _resolve_command(cls) -> tuple[str, ...]:
+        """Determine the right argv prefix for the ``o2b mcp`` subprocess.
+
+        On POSIX, ``scripts/o2b`` is a bash wrapper that ``install-cli`` may
+        have symlinked into ``~/.local/bin``; ``shutil.which("o2b")`` finds it
+        and ``Popen`` can execute it directly.
+
+        On Windows, bash scripts are not directly executable by
+        ``subprocess.Popen`` (it delegates to ``cmd.exe``, not a POSIX shell).
+        Even if ``o2b`` were on PATH, Popen would fail with ``[WinError 193]``
+        or ``[WinError 2]``.  The correct cross-platform fallback is to invoke
+        the TypeScript entry point through ``bun run``, which works identically
+        on every OS.
+
+        Resolution order:
+        1. POSIX + ``o2b`` in PATH → ``("o2b", "mcp")``
+        2. ``bun`` in PATH + repo root has ``src/cli/main.ts`` →
+           ``("bun", "run", "<entry>", "mcp")``
+        3. Fallback → ``("o2b", "mcp")`` (will surface a clear Popen error)
+        """
+        # On non-Windows, a globally installed o2b works out of the box.
+        if os.name != "nt" and shutil.which("o2b"):
+            return ("o2b", "mcp")
+
+        # Resolve via the repo-local TypeScript entry point + bun.
+        root = cls._repo_root()
+        if root:
+            entry = Path(root) / "src" / "cli" / "main.ts"
+            if entry.is_file():
+                bun = shutil.which("bun")
+                if bun:
+                    return (bun, "run", str(entry), "mcp")
+
+        # Last resort: hope o2b is reachable (e.g. npm global install on
+        # Windows created an o2b.cmd shim, or the user's shell can run it).
+        return ("o2b", "mcp")
 
     def get_tool_schemas(self) -> list[dict[str, Any]]:
         """Return the memory-relevant subset of the server's advertised tools.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 # CLI entry points (those moved to `package.json` `bin`).
 [project]
 name = "open-second-brain"
-version = "1.23.0"
+version = "1.23.1"
 description = "Hermes Python shim for Open Second Brain. Most of the project (CLI, MCP server, OpenClaw plugin) is TypeScript on Bun; see package.json."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -138,7 +138,7 @@ async function cmdInit(argv: string[]): Promise<number> {
   void flags["name"]; // accepted for backward CLI compat; unused
   let configPath: string;
   try {
-    configPath = setConfigValue("vault", resolve(vault));
+    configPath = setConfigValue("vault", resolve(vault).replace(/\\/g, "/"));
     if (agentName) setConfigValue("agent_name", agentName);
     if (timezone) setConfigValue("timezone", timezone);
   } catch (exc) {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -136,9 +136,10 @@ async function cmdInit(argv: string[]): Promise<number> {
   // a --vault flag.
   void flags["force"]; // accepted for backward CLI compat; unused
   void flags["name"]; // accepted for backward CLI compat; unused
+  const resolvedVault = resolve(vault).replace(/\\/g, "/");
   let configPath: string;
   try {
-    configPath = setConfigValue("vault", resolve(vault).replace(/\\/g, "/"));
+    configPath = setConfigValue("vault", resolvedVault);
     if (agentName) setConfigValue("agent_name", agentName);
     if (timezone) setConfigValue("timezone", timezone);
   } catch (exc) {
@@ -147,7 +148,7 @@ async function cmdInit(argv: string[]): Promise<number> {
     );
     return 1;
   }
-  process.stdout.write(`initialized vault: ${resolve(vault)}\n`);
+  process.stdout.write(`initialized vault: ${resolvedVault}\n`);
   process.stdout.write(`vault path persisted to: ${configPath}\n`);
   if (agentName) {
     process.stdout.write(`agent name registered: ${agentName}\n`);


### PR DESCRIPTION
## Summary

- **`src/cli/main.ts`**: `o2b init --vault <path>` fails on native Windows because `resolve()` returns backslash paths (`C:\Users\...`) which `setConfigValue()` rejects via `CONFIG_VALUE_REJECTED_CHARS`. Fix: normalize to forward slashes before persisting — they work identically in Node/Bun fs APIs on Windows.
- **`plugins/hermes/provider.py`**: The Hermes memory provider bridge fails on Windows because `scripts/o2b` is a bash script that `subprocess.Popen` cannot execute (it delegates to `cmd.exe`, not a POSIX shell). Fix: add `_resolve_command()` with a resolution chain — POSIX `o2b` in PATH → `bun run <repo>/src/cli/main.ts mcp` → fallback.

Closes #119

## Test plan

- [x] `o2b init --vault "D:/www/test-vault"` succeeds on Windows 11 (was failing with backslash rejection)
- [x] Config file written with forward-slash vault path
- [x] `_resolve_command()` resolves to `bun run <entry> mcp` on Windows
- [x] Hermes loads provider with `is_available() = True`
- [x] `brain_context` tool call returns vault data through live MCP bridge
- [x] `brain_note` write operation persists to vault on disk
- [ ] Verify no regression on POSIX (o2b in PATH should still be preferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved command detection so the app can start its bridge more reliably across different environments, including local and installed setups.

* **Bug Fixes**
  * Fixed vault path persistence during initialization to store a normalized forward-slash format (improves consistency across Windows and other platforms).
  * Updated the initialization success output to display the normalized vault path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->