### PR TITLE
fix(windows): resolve 3 compatibility issues on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`detectTooling()` fails to find tools on Windows** — PATH was split on
   `:` only (POSIX); now uses `;` on Windows. Executable probing now honours
   `PATHEXT` (`.exe`, `.cmd`, `.bat`, `.com`) instead of hardcoding `.exe`.
-- **MCP `inputSchema` not recognized by Hermes adapters** — Hermes adapters
-  (Anthropic, OpenAI, Bedrock) expect tool schemas under `parameters`, but
-  MCP serves them as `inputSchema`. Both live and static fallback schemas
-  now remap `inputSchema` → `parameters` at the provider boundary.
+- **MCP `inputSchema` not recognized by Hermes adapters (all platforms)** —
+  Hermes adapters (Anthropic, OpenAI, Bedrock) expect tool schemas under
+  `parameters`, but MCP serves them as `inputSchema`. Without this remap
+  brain tools had no visible arguments on any OS. Both live and static
+  fallback schemas now remap `inputSchema` → `parameters` at the provider
+  boundary.
 
 ## [1.23.0] - 2026-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   delegates to `cmd.exe`, not a POSIX shell). Added `_resolve_command()`
   which detects the platform and falls back to `bun run <entry> mcp` when
   `o2b` is not available as a native executable.
+- **`detectTooling()` fails to find tools on Windows** — PATH was split on
+  `:` only (POSIX); now uses `;` on Windows. Executable probing now honours
+  `PATHEXT` (`.exe`, `.cmd`, `.bat`, `.com`) instead of hardcoding `.exe`.
+- **MCP `inputSchema` not recognized by Hermes adapters** — Hermes adapters
+  (Anthropic, OpenAI, Bedrock) expect tool schemas under `parameters`, but
+  MCP serves them as `inputSchema`. Both live and static fallback schemas
+  now remap `inputSchema` → `parameters` at the provider boundary.
 
 ## [1.23.0] - 2026-07-05
 

--- a/plugins/hermes/_schemas.py
+++ b/plugins/hermes/_schemas.py
@@ -458,5 +458,13 @@ STATIC_TOOL_SCHEMAS: tuple[dict[str, Any], ...] = (
 
 
 def static_tool_schemas() -> list[dict[str, Any]]:
-    """Deep copies of the vendored schemas; callers may mutate freely."""
-    return [copy.deepcopy(schema) for schema in STATIC_TOOL_SCHEMAS]
+    """Deep copies of the vendored schemas; callers may mutate freely.
+
+    Converts MCP ``inputSchema`` to ``parameters`` so Hermes adapters
+    (Anthropic, OpenAI, Bedrock) can see the tool's expected arguments.
+    """
+    schemas = [copy.deepcopy(schema) for schema in STATIC_TOOL_SCHEMAS]
+    for s in schemas:
+        if "inputSchema" in s and "parameters" not in s:
+            s["parameters"] = s.pop("inputSchema")
+    return schemas

--- a/plugins/hermes/provider.py
+++ b/plugins/hermes/provider.py
@@ -166,7 +166,8 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
                 continue
             # MCP uses "inputSchema"; Hermes adapters expect "parameters"
             if "inputSchema" in t and "parameters" not in t:
-                t = {**t, "parameters": t.pop("inputSchema")}
+                t = dict(t)
+                t["parameters"] = t.pop("inputSchema")
             filtered.append(t)
         return filtered
 

--- a/plugins/hermes/provider.py
+++ b/plugins/hermes/provider.py
@@ -119,7 +119,15 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
             tools = self._bridge.list_tools()
         except Exception:  # noqa: BLE001 - static fallback rather than a crash
             return static_tool_schemas()
-        return [t for t in tools if t.get("name") in MEMORY_TOOLS]
+        filtered = []
+        for t in tools:
+            if t.get("name") not in MEMORY_TOOLS:
+                continue
+            # MCP uses "inputSchema"; Hermes adapters expect "parameters"
+            if "inputSchema" in t and "parameters" not in t:
+                t = {**t, "parameters": t.pop("inputSchema")}
+            filtered.append(t)
+        return filtered
 
     def handle_tool_call(self, tool_name: str, args: dict[str, Any], **_kwargs: Any) -> str:
         """Forward an agent tool invocation to the TS core over the bridge.

--- a/src/core/brain/snapshot.ts
+++ b/src/core/brain/snapshot.ts
@@ -134,11 +134,15 @@ interface ToolAvailability {
 function detectTooling(): ToolAvailability {
   const pathEnv = process.env["PATH"] ?? "";
   const dirs = pathEnv.split(process.platform === "win32" ? ";" : ":").filter((d) => d.length > 0);
+  const winExts = process.platform === "win32"
+    ? (process.env["PATHEXT"] ?? ".COM;.EXE;.BAT;.CMD").split(";")
+    : [];
   const probe = (cmd: string): boolean => {
     for (const d of dirs) {
       if (existsSync(join(d, cmd))) return true;
-      // On Windows, executables have .exe extension
-      if (process.platform === "win32" && existsSync(join(d, cmd + ".exe"))) return true;
+      for (const ext of winExts) {
+        if (existsSync(join(d, cmd + ext.toLowerCase()))) return true;
+      }
     }
     return false;
   };

--- a/src/core/brain/snapshot.ts
+++ b/src/core/brain/snapshot.ts
@@ -133,10 +133,12 @@ interface ToolAvailability {
  */
 function detectTooling(): ToolAvailability {
   const pathEnv = process.env["PATH"] ?? "";
-  const dirs = pathEnv.split(":").filter((d) => d.length > 0);
+  const dirs = pathEnv.split(process.platform === "win32" ? ";" : ":").filter((d) => d.length > 0);
   const probe = (cmd: string): boolean => {
     for (const d of dirs) {
       if (existsSync(join(d, cmd))) return true;
+      // On Windows, executables have .exe extension
+      if (process.platform === "win32" && existsSync(join(d, cmd + ".exe"))) return true;
     }
     return false;
   };

--- a/src/core/brain/snapshot.ts
+++ b/src/core/brain/snapshot.ts
@@ -134,9 +134,10 @@ interface ToolAvailability {
 function detectTooling(): ToolAvailability {
   const pathEnv = process.env["PATH"] ?? "";
   const dirs = pathEnv.split(process.platform === "win32" ? ";" : ":").filter((d) => d.length > 0);
-  const winExts = process.platform === "win32"
-    ? (process.env["PATHEXT"] ?? ".COM;.EXE;.BAT;.CMD").split(";")
-    : [];
+  const winExts =
+    process.platform === "win32"
+      ? (process.env["PATHEXT"] ?? ".COM;.EXE;.BAT;.CMD").split(";")
+      : [];
   const probe = (cmd: string): boolean => {
     for (const d of dirs) {
       if (existsSync(join(d, cmd))) return true;

--- a/tests/python/test_memory_provider.py
+++ b/tests/python/test_memory_provider.py
@@ -293,7 +293,8 @@ class ProviderStaticSchemaFallbackTests(unittest.TestCase):
         self.assertEqual({s["name"] for s in schemas}, set(MEMORY_TOOLS))
         for schema in schemas:
             self.assertTrue(schema["description"])
-            self.assertEqual(schema["inputSchema"].get("type"), "object")
+            # static_tool_schemas() remaps inputSchema -> parameters
+            self.assertEqual(schema["parameters"].get("type"), "object")
 
     def test_get_tool_schemas_after_initialize_keeps_name_set(self):
         bridge = FakeBrainBridge(tools=self._curated_live_tools())

--- a/tests/python/test_static_schemas.py
+++ b/tests/python/test_static_schemas.py
@@ -51,11 +51,12 @@ class StaticSchemaIntegrityTests(unittest.TestCase):
 
     def test_accessor_returns_deep_copies(self):
         first = static_tool_schemas()
-        first[0]["inputSchema"]["properties"]["__mutated__"] = True
+        # static_tool_schemas() remaps inputSchema -> parameters
+        first[0]["parameters"]["properties"]["__mutated__"] = True
         first[0]["name"] = "mutated"
         second = static_tool_schemas()
         self.assertNotEqual(second[0]["name"], "mutated")
-        self.assertNotIn("__mutated__", second[0]["inputSchema"]["properties"])
+        self.assertNotIn("__mutated__", second[0]["parameters"]["properties"])
 
 
 def _live_memory_tool_projection() -> list[dict]:


### PR DESCRIPTION
## Summary

Three fixes that unblock open-second-brain on Windows, plus one cross-platform fix:

**Windows-specific:**
- `snapshot.ts`: Split PATH on `;` on Windows (was `:` only), honour `PATHEXT` env var instead of hardcoding `.exe`
- (from #122, already merged) `main.ts`: normalize vault path to forward slashes; `provider.py`: `_resolve_command()` fallback to `bun run`

**Cross-platform:**
- `provider.py` + `_schemas.py`: Remap MCP `inputSchema` → `parameters` so Hermes adapters (Anthropic, OpenAI, Bedrock) can see tool arguments. Without this, brain tools had no visible parameters on **any** OS — not just Windows.

## Changes
- `src/core/brain/snapshot.ts`: platform-aware PATH split + PATHEXT probing
- `plugins/hermes/provider.py`: `inputSchema` → `parameters` conversion for live schemas
- `plugins/hermes/_schemas.py`: same conversion for static fallback schemas
- `tests/python/`: updated tests to match remapped schema key
- `CHANGELOG.md`: entries for all fixes

*Original PR by @hittosuy. Review fixes, main merge, and test updates by maintainer.*

Closes #119

## Test plan

- [x] All 10 `brain_*` tools have `parameters` (not `inputSchema`) in schemas
- [x] `brain_note` write + `brain_context` read work in real Hermes on Windows 11
- [x] `brain dream` completes (snapshot/detectTooling finds tar via PATHEXT)
- [x] CI passes (formatting, lint, typecheck, TS tests, Python tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)