### PR TITLE
fix(windows): resolve Windows compat issues (PATH, PATHEXT, inputSchema)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   delegates to `cmd.exe`, not a POSIX shell). Added `_resolve_command()`
   which detects the platform and falls back to `bun run <entry> mcp` when
   `o2b` is not available as a native executable.
+- **`detectTooling()` fails to find tools on Windows** — PATH was split on
+  `:` only (POSIX); now uses `;` on Windows. Executable probing now honours
+  `PATHEXT` (`.exe`, `.cmd`, `.bat`, `.com`) instead of hardcoding `.exe`.
+- **MCP `inputSchema` not recognized by Hermes adapters** — Hermes adapters
+  (Anthropic, OpenAI, Bedrock) expect tool schemas under `parameters`, but
+  MCP serves them as `inputSchema`. Both live and static fallback schemas
+  now remap `inputSchema` → `parameters` at the provider boundary.
 
 ## [1.23.0] - 2026-07-05
 

--- a/plugins/hermes/_schemas.py
+++ b/plugins/hermes/_schemas.py
@@ -458,5 +458,13 @@ STATIC_TOOL_SCHEMAS: tuple[dict[str, Any], ...] = (
 
 
 def static_tool_schemas() -> list[dict[str, Any]]:
-    """Deep copies of the vendored schemas; callers may mutate freely."""
-    return [copy.deepcopy(schema) for schema in STATIC_TOOL_SCHEMAS]
+    """Deep copies of the vendored schemas; callers may mutate freely.
+
+    Converts MCP ``inputSchema`` to ``parameters`` so Hermes adapters
+    (Anthropic, OpenAI, Bedrock) can see the tool's expected arguments.
+    """
+    schemas = [copy.deepcopy(schema) for schema in STATIC_TOOL_SCHEMAS]
+    for s in schemas:
+        if "inputSchema" in s and "parameters" not in s:
+            s["parameters"] = s.pop("inputSchema")
+    return schemas

--- a/plugins/hermes/provider.py
+++ b/plugins/hermes/provider.py
@@ -166,7 +166,8 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
                 continue
             # MCP uses "inputSchema"; Hermes adapters expect "parameters"
             if "inputSchema" in t and "parameters" not in t:
-                t = {**t, "parameters": t.pop("inputSchema")}
+                t = dict(t)
+                t["parameters"] = t.pop("inputSchema")
             filtered.append(t)
         return filtered
 

--- a/plugins/hermes/provider.py
+++ b/plugins/hermes/provider.py
@@ -119,7 +119,15 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
             tools = self._bridge.list_tools()
         except Exception:  # noqa: BLE001 - static fallback rather than a crash
             return static_tool_schemas()
-        return [t for t in tools if t.get("name") in MEMORY_TOOLS]
+        filtered = []
+        for t in tools:
+            if t.get("name") not in MEMORY_TOOLS:
+                continue
+            # MCP uses "inputSchema"; Hermes adapters expect "parameters"
+            if "inputSchema" in t and "parameters" not in t:
+                t = {**t, "parameters": t.pop("inputSchema")}
+            filtered.append(t)
+        return filtered
 
     def handle_tool_call(self, tool_name: str, args: dict[str, Any], **_kwargs: Any) -> str:
         """Forward an agent tool invocation to the TS core over the bridge.

--- a/src/core/brain/snapshot.ts
+++ b/src/core/brain/snapshot.ts
@@ -134,11 +134,15 @@ interface ToolAvailability {
 function detectTooling(): ToolAvailability {
   const pathEnv = process.env["PATH"] ?? "";
   const dirs = pathEnv.split(process.platform === "win32" ? ";" : ":").filter((d) => d.length > 0);
+  const winExts = process.platform === "win32"
+    ? (process.env["PATHEXT"] ?? ".COM;.EXE;.BAT;.CMD").split(";")
+    : [];
   const probe = (cmd: string): boolean => {
     for (const d of dirs) {
       if (existsSync(join(d, cmd))) return true;
-      // On Windows, executables have .exe extension
-      if (process.platform === "win32" && existsSync(join(d, cmd + ".exe"))) return true;
+      for (const ext of winExts) {
+        if (existsSync(join(d, cmd + ext.toLowerCase()))) return true;
+      }
     }
     return false;
   };

--- a/src/core/brain/snapshot.ts
+++ b/src/core/brain/snapshot.ts
@@ -133,10 +133,12 @@ interface ToolAvailability {
  */
 function detectTooling(): ToolAvailability {
   const pathEnv = process.env["PATH"] ?? "";
-  const dirs = pathEnv.split(":").filter((d) => d.length > 0);
+  const dirs = pathEnv.split(process.platform === "win32" ? ";" : ":").filter((d) => d.length > 0);
   const probe = (cmd: string): boolean => {
     for (const d of dirs) {
       if (existsSync(join(d, cmd))) return true;
+      // On Windows, executables have .exe extension
+      if (process.platform === "win32" && existsSync(join(d, cmd + ".exe"))) return true;
     }
     return false;
   };


### PR DESCRIPTION
## Summary

Supersedes #123 by @hittosuy — merges their fixes with main (which now includes #122), addresses CodeRabbit review comments, and adds CHANGELOG entries.

**Original fixes from #123:**
- `snapshot.ts`: Split PATH on `;` on Windows (was `:` only)
- `provider.py` + `_schemas.py`: Convert MCP `inputSchema` → `parameters` so Hermes adapters (Anthropic, OpenAI, Bedrock) see tool arguments

**Review fixes applied:**
- `provider.py`: Copy dict before popping `inputSchema` — the original `{**t, "parameters": t.pop("inputSchema")}` left `inputSchema` in the result because `**t` unpacks before `pop()` executes
- `snapshot.ts`: Honour `PATHEXT` env var (`.COM;.EXE;.BAT;.CMD`) instead of hardcoding `.exe`, so npm-global `.cmd`/`.bat` shims are also detected

Closes #119 (combined with #122 already merged)

## Test plan

- [x] `brain_note` write operation works on Windows 11
- [x] `brain_context` returns vault data through live MCP bridge
- [x] All 10 `brain_*` tools have `parameters` (not `inputSchema`) in schemas
- [x] `brain dream` completes successfully (snapshot uses `detectTooling`)
- [x] No regression on merged #122 fixes (vault path normalization, `_resolve_command`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)