### PR TITLE
fix(hermes): resolve o2b when memory provider PATH is tiny

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "description": "Plugin-first second brain package for AI agents and humans.",
   "author": {
     "name": "Open Second Brain contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "skills": "./skills",
   "hooks": "./hooks/hooks.json",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.27.1] - 2026-07-10
+
+A robustness fix for the Hermes memory provider's executable resolution. No kernel behavior changes.
+
+### Fixed
+
+- **Resolve `o2b`/`bun` when the memory provider inherits a tiny `PATH`.** When Hermes starts the provider from a process with a minimal inherited `PATH`, `shutil.which("o2b")` cannot see a user-local install and `subprocess.Popen` later fails with `No such file or directory: 'o2b'`. Resolution now falls back to a curated scan of user-local and system executable directories (`~/.local/bin`, `~/.bun/bin`, `~/.hermes/node/bin`, `/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`, `/bin`) and uses the resolved absolute path for both `o2b` and `bun`. `shutil.which` still wins first, the POSIX-only `o2b` branch and the repo-local `bun run <entry> mcp` fallback are preserved, and on Windows the scan matches `PATHEXT` suffixes rather than gating on the POSIX execute bit.
+
 ## [1.27.0] - 2026-07-10
 
 An ingestion and import robustness layer that hardens and extends the source pipeline in one coherent scope: interrupted batches resume, more memory stores import, deterministic refresh skips when nothing changed, and sources distill into citeable claims. Every new surface is additive and off by default where it changes an existing path; the kernel still calls no LLM.
@@ -6404,6 +6412,7 @@ plugin config (vault field)`, and exits with a clear
 - Sandbox vault and plugin manifest fixtures for tests.
 - GitHub release workflow for tag-based and manually dispatched releases.
 
+[1.27.1]: https://github.com/itechmeat/open-second-brain/compare/v1.27.0...v1.27.1
 [1.27.0]: https://github.com/itechmeat/open-second-brain/compare/v1.26.1...v1.27.0
 [1.24.0]: https://github.com/itechmeat/open-second-brain/compare/v1.23.1...v1.24.0
 [1.23.1]: https://github.com/itechmeat/open-second-brain/compare/v1.23.0...v1.23.1

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "open-second-brain",
   "name": "Open Second Brain",
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults.",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "activation": { "onStartup": true },
   "skills": ["./skills"],
   "contracts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "private": false,
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults. Works with Hermes, Claude Code, Codex, and OpenClaw.",
   "keywords": [

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "1.27.0"
+version: "1.27.1"
 description: "Open Second Brain - native Hermes memory provider backed by an Obsidian-compatible Markdown vault."
 author: "Open Second Brain contributors"
 memory_provider: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "author": {
     "name": "Open Second Brain contributors",

--- a/plugins/hermes/plugin.yaml
+++ b/plugins/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "1.27.0"
+version: "1.27.1"
 description: "Open Second Brain - native Hermes memory provider backed by an Obsidian-compatible Markdown vault."
 author: "Open Second Brain contributors"
 memory_provider: true

--- a/plugins/hermes/provider.py
+++ b/plugins/hermes/provider.py
@@ -18,7 +18,10 @@ import re
 import shutil
 import threading
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 from . import config
 from ._base import MemoryProvider
@@ -50,6 +53,53 @@ _CONFIG_KEYS: tuple[str, ...] = ("vault", "agent_name", "timezone")
 
 # Token budget for the recall slice fetched on each prefetch.
 _PREFETCH_MAX_TOKENS = 1024
+
+
+def _fallback_exe_dirs() -> tuple[Path, ...]:
+    """Directories scanned for an executable when a tiny inherited ``PATH``
+    hides it from ``shutil.which``. Computed per call so it tracks the current
+    ``$HOME`` (and stays patchable in tests)."""
+    home = Path.home()
+    return (
+        home / ".local" / "bin",
+        home / ".bun" / "bin",
+        home / ".hermes" / "node" / "bin",
+        Path("/opt/homebrew/bin"),
+        Path("/usr/local/bin"),
+        Path("/usr/bin"),
+        Path("/bin"),
+    )
+
+
+def _find_executable(name: str, search_dirs: Iterable[Path] | None = None) -> str | None:
+    """Resolve ``name`` to an absolute executable path.
+
+    ``shutil.which`` (which honours ``PATH``) wins when it can see the binary.
+    Hermes can start the provider from a process with a minimal inherited
+    ``PATH``; then ``which`` returns nothing even though the executable exists
+    in a user-local bin, so fall back to scanning a curated directory set.
+
+    On Windows the scan appends ``PATHEXT`` suffixes (``.EXE``/``.CMD``/...) to
+    a bare name and does not gate on the POSIX execute bit, which has no meaning
+    there; on POSIX it matches the exact name and requires ``X_OK``.
+    """
+    found = shutil.which(name)
+    if found:
+        return found
+    dirs = tuple(search_dirs) if search_dirs is not None else _fallback_exe_dirs()
+    if os.name == "nt" and not os.path.splitext(name)[1]:
+        exts = [e for e in os.environ.get("PATHEXT", ".COM;.EXE;.BAT;.CMD").split(os.pathsep) if e]
+        candidate_names = [name + ext for ext in exts]
+    else:
+        candidate_names = [name]
+    for directory in dirs:
+        for candidate_name in candidate_names:
+            candidate = directory / candidate_name
+            if not candidate.is_file():
+                continue
+            if os.name == "nt" or os.access(candidate, os.X_OK):
+                return str(candidate)
+    return None
 
 
 class OpenSecondBrainMemoryProvider(MemoryProvider):
@@ -111,32 +161,19 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
     def _resolve_command(cls) -> tuple[str, ...]:
         """Determine the right argv prefix for the ``o2b mcp`` subprocess.
 
-        Hermes memory providers can run with a tiny inherited ``PATH``. Resolve
-        absolute executable paths before falling back to bare command names.
+        Hermes memory providers can run with a tiny inherited ``PATH``, so
+        resolve absolute executable paths via :func:`_find_executable` (which
+        scans user-local and system bins when ``PATH`` hides the binary) before
+        falling back to a bare command name.
+
+        On Windows the ``scripts/o2b`` bash wrapper is not directly executable
+        by ``subprocess.Popen``, so the o2b branch is POSIX-only; the
+        cross-platform path is the repo-local TypeScript entry point via
+        ``bun run``.
         """
-        path_dirs = [
-            Path.home() / ".local" / "bin",
-            Path.home() / ".bun" / "bin",
-            Path.home() / ".hermes" / "node" / "bin",
-            Path("/opt/homebrew/bin"),
-            Path("/usr/local/bin"),
-            Path("/usr/bin"),
-            Path("/bin"),
-        ]
-
-        def find_exe(name: str) -> str | None:
-            found = shutil.which(name)
-            if found:
-                return found
-            for directory in path_dirs:
-                candidate = directory / name
-                if candidate.is_file() and os.access(candidate, os.X_OK):
-                    return str(candidate)
-            return None
-
         # On non-Windows, a globally installed or user-local o2b works directly.
         if os.name != "nt":
-            o2b = find_exe("o2b")
+            o2b = _find_executable("o2b")
             if o2b:
                 return (o2b, "mcp")
 
@@ -145,7 +182,7 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
         if root:
             entry = Path(root) / "src" / "cli" / "main.ts"
             if entry.is_file():
-                bun = find_exe("bun")
+                bun = _find_executable("bun")
                 if bun:
                     return (bun, "run", str(entry), "mcp")
 

--- a/plugins/hermes/provider.py
+++ b/plugins/hermes/provider.py
@@ -111,33 +111,41 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
     def _resolve_command(cls) -> tuple[str, ...]:
         """Determine the right argv prefix for the ``o2b mcp`` subprocess.
 
-        On POSIX, ``scripts/o2b`` is a bash wrapper that ``install-cli`` may
-        have symlinked into ``~/.local/bin``; ``shutil.which("o2b")`` finds it
-        and ``Popen`` can execute it directly.
-
-        On Windows, bash scripts are not directly executable by
-        ``subprocess.Popen`` (it delegates to ``cmd.exe``, not a POSIX shell).
-        Even if ``o2b`` were on PATH, Popen would fail with ``[WinError 193]``
-        or ``[WinError 2]``.  The correct cross-platform fallback is to invoke
-        the TypeScript entry point through ``bun run``, which works identically
-        on every OS.
-
-        Resolution order:
-        1. POSIX + ``o2b`` in PATH → ``("o2b", "mcp")``
-        2. ``bun`` in PATH + repo root has ``src/cli/main.ts`` →
-           ``("bun", "run", "<entry>", "mcp")``
-        3. Fallback → ``("o2b", "mcp")`` (will surface a clear Popen error)
+        Hermes memory providers can run with a tiny inherited ``PATH``. Resolve
+        absolute executable paths before falling back to bare command names.
         """
-        # On non-Windows, a globally installed o2b works out of the box.
-        if os.name != "nt" and shutil.which("o2b"):
-            return ("o2b", "mcp")
+        path_dirs = [
+            Path.home() / ".local" / "bin",
+            Path.home() / ".bun" / "bin",
+            Path.home() / ".hermes" / "node" / "bin",
+            Path("/opt/homebrew/bin"),
+            Path("/usr/local/bin"),
+            Path("/usr/bin"),
+            Path("/bin"),
+        ]
 
-        # Resolve via the repo-local TypeScript entry point + bun.
+        def find_exe(name: str) -> str | None:
+            found = shutil.which(name)
+            if found:
+                return found
+            for directory in path_dirs:
+                candidate = directory / name
+                if candidate.is_file() and os.access(candidate, os.X_OK):
+                    return str(candidate)
+            return None
+
+        # On non-Windows, a globally installed or user-local o2b works directly.
+        if os.name != "nt":
+            o2b = find_exe("o2b")
+            if o2b:
+                return (o2b, "mcp")
+
+        # Resolve via repo-local TypeScript entry point + bun.
         root = cls._repo_root()
         if root:
             entry = Path(root) / "src" / "cli" / "main.ts"
             if entry.is_file():
-                bun = shutil.which("bun")
+                bun = find_exe("bun")
                 if bun:
                     return (bun, "run", str(entry), "mcp")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 # CLI entry points (those moved to `package.json` `bin`).
 [project]
 name = "open-second-brain"
-version = "1.27.0"
+version = "1.27.1"
 description = "Hermes Python shim for Open Second Brain. Most of the project (CLI, MCP server, OpenClaw plugin) is TypeScript on Bun; see package.json."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/python/test_memory_provider.py
+++ b/tests/python/test_memory_provider.py
@@ -342,6 +342,21 @@ class ProviderStaticSchemaFallbackTests(unittest.TestCase):
         self.assertEqual(json.loads(result), {"ok": True})
         self.assertEqual(bridge.calls, [("brain_note", {"text": "hi"})])
 
+    def test_resolve_command_uses_user_local_o2b_when_path_is_tiny(self):
+        saved_path = os.environ.get("PATH")
+        try:
+            os.environ["PATH"] = ""
+            command = OpenSecondBrainMemoryProvider._resolve_command()
+        finally:
+            if saved_path is None:
+                os.environ.pop("PATH", None)
+            else:
+                os.environ["PATH"] = saved_path
+
+        self.assertNotEqual(command[0], "o2b")
+        self.assertTrue(Path(command[0]).is_absolute())
+        self.assertIn(command[1], {"mcp", "run"})
+
 
 class CliTests(unittest.TestCase):
     _ENV_KEYS = ("VAULT_AGENT_NAME", "VAULT_DIR", "OPEN_SECOND_BRAIN_CONFIG")

--- a/tests/python/test_memory_provider.py
+++ b/tests/python/test_memory_provider.py
@@ -14,6 +14,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
@@ -35,6 +36,7 @@ from plugins.hermes.bridge import (  # noqa: E402
 from plugins.hermes.provider import (  # noqa: E402
     MEMORY_TOOLS,
     OpenSecondBrainMemoryProvider,
+    _find_executable,
 )
 from plugins.hermes.cli import register_cli  # noqa: E402
 
@@ -342,20 +344,54 @@ class ProviderStaticSchemaFallbackTests(unittest.TestCase):
         self.assertEqual(json.loads(result), {"ok": True})
         self.assertEqual(bridge.calls, [("brain_note", {"text": "hi"})])
 
+    @unittest.skipIf(os.name == "nt", "o2b bash wrapper is POSIX-only")
     def test_resolve_command_uses_user_local_o2b_when_path_is_tiny(self):
-        saved_path = os.environ.get("PATH")
-        try:
-            os.environ["PATH"] = ""
-            command = OpenSecondBrainMemoryProvider._resolve_command()
-        finally:
-            if saved_path is None:
-                os.environ.pop("PATH", None)
-            else:
-                os.environ["PATH"] = saved_path
+        # A tiny inherited PATH hides o2b from shutil.which; the fallback scan
+        # must still find a real user-local o2b. Hermetic: a fake ~/.local/bin
+        # under a temp HOME, so the assertion never depends on what the test
+        # machine happens to have installed.
+        with tempfile.TemporaryDirectory() as home:
+            local_bin = Path(home) / ".local" / "bin"
+            local_bin.mkdir(parents=True)
+            fake_o2b = local_bin / "o2b"
+            fake_o2b.write_text("#!/bin/sh\n")
+            os.chmod(fake_o2b, 0o755)
 
-        self.assertNotEqual(command[0], "o2b")
+            with (
+                patch.dict(os.environ, {"PATH": ""}),
+                patch.object(Path, "home", return_value=Path(home)),
+                patch("shutil.which", return_value=None),
+            ):
+                command = OpenSecondBrainMemoryProvider._resolve_command()
+
+        self.assertEqual(command, (str(fake_o2b), "mcp"))
         self.assertTrue(Path(command[0]).is_absolute())
-        self.assertIn(command[1], {"mcp", "run"})
+
+    def test_find_executable_prefers_which(self):
+        with patch("shutil.which", return_value="/somewhere/on/path/o2b"):
+            self.assertEqual(_find_executable("o2b"), "/somewhere/on/path/o2b")
+
+    def test_find_executable_returns_none_when_nothing_resolves(self):
+        with tempfile.TemporaryDirectory() as empty, patch("shutil.which", return_value=None):
+            self.assertIsNone(_find_executable("o2b", search_dirs=[Path(empty)]))
+
+    def test_find_executable_matches_windows_pathext_suffix(self):
+        # On Windows a bare `bun` never matches on disk; the scan must try the
+        # PATHEXT suffixes (bun.CMD / bun.EXE). Execute-bit gating is a POSIX
+        # concept and must be skipped there. Build the Path objects before
+        # patching os.name, since pathlib picks its flavour at instantiation.
+        with tempfile.TemporaryDirectory() as bindir:
+            bindir_path = Path(bindir)
+            shim = bindir_path / "bun.CMD"
+            shim.write_text("@echo off\n")
+            with (
+                patch("os.name", "nt"),
+                patch("os.pathsep", ";"),
+                patch.dict(os.environ, {"PATHEXT": ".COM;.EXE;.BAT;.CMD"}),
+                patch("shutil.which", return_value=None),
+            ):
+                resolved = _find_executable("bun", search_dirs=[bindir_path])
+        self.assertEqual(resolved, str(shim))
 
 
 class CliTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- resolve `o2b` and `bun` from user-local and standard executable paths before falling back to bare command names
- keep the Hermes memory provider working when the parent process inherits a minimal `PATH`
- add a regression test that forces `PATH=''` and asserts `_resolve_command()` returns an absolute executable path

## Problem
On POSIX, the provider currently prefers `shutil.which("o2b")` and then falls back to bare `("o2b", "mcp")`.

That breaks when Hermes starts the memory provider from a process with a minimal inherited `PATH`: `o2b` exists in a user-local bin directory, but `which()` cannot see it, so `subprocess.Popen()` later fails with `No such file or directory: 'o2b'`.

## Fix
- add a small executable resolver that checks common user-local and system executable paths
- use the resolved absolute path for both `o2b` and `bun`
- preserve the existing repo-local `bun run <entry> mcp` fallback path

## Regression coverage
- new Python test forces `PATH=''`
- asserts command[0] is absolute and not bare `o2b`
- keeps scope narrow to the provider contract

## Validation
- `bun run test`
- `bun run typecheck`
- `hermes mcp test open-second-brain`
- `hermes mcp test open-second-brain-writer`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hermes memory provider reliability when locating `o2b` and `bun`, including environments with limited `PATH` settings.
  * Added support for resolving executable paths across common user and system locations on Windows and other platforms.

* **Release**
  * Updated the project and plugin version to **1.27.1**.

* **Tests**
  * Expanded coverage for executable discovery and command resolution across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->