### PR TITLE
feat: governance visibility - vitals scorecard + batch-inflation lint (v1.30.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "description": "Plugin-first second brain package for AI agents and humans.",
   "author": {
     "name": "Open Second Brain contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "skills": "./skills",
   "hooks": "./hooks/hooks.json",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.30.0] - 2026-07-11
+
+A governance-visibility release that adds two aggregate views over the preference set the existing per-item hygiene lints could not answer, plus an efficiency refinement to how one of them sources its data. Both new surfaces are additive and read-only over `Brain/preferences/`; the release adds no new dependency and the kernel still calls no LLM.
+
+### Added
+
+- **Aggregate governance scorecard (`o2b brain vitals`).** A single read-only scorecard over confirmed preferences that the per-item lints (`doctor`, `health`, `moc-audit`) do not surface: `domain_diversity` (normalised Shannon entropy of the `scope` distribution), `connectivity_index` (mean `evidenced_by` count per preference), `orphan_preferences` (confirmed preferences below an evidence threshold, default 2, `--orphan-threshold`), and `gap_pressure` (open `concept-gap` findings, reused from the semantic-health pass, divided by preference count). Text or `--json`; records one `vault_vitals` metric per run, following the existing `clusters`/`benchmark` surface pattern.
+- **Batch-concept-inflation lint.** The existing `duplicate-preferences` lint only catches near-identical pairs (Jaccard >= 0.7 within one topic/scope). `detectBatchInflation` is a deterministic, non-overlapping window scan over confirmed preferences' `confirmed_at` timestamps (default 24h window, burst size >= 5, both configurable) that flags a burst of individually-distinct preferences confirmed together - the signal that a batch or concurrent ingestion session skipped its dedup/consolidation pass. Wired end to end: `reconcileSemanticHealth`, the `batch-concept-inflation` doctor lint, `o2b brain health` (CLI) and `brain_health` (MCP), and a new `batch_inflation` Workspace Insight trigger kind.
+
+### Changed
+
+- **Vault vitals sources `gap_pressure` from a semantic-only health pass.** `computeVaultVitals` now calls a new exported `computeSemanticHealth` instead of the full `runDoctor` sweep to read the open concept-gap count. Both route through the same detector over the same inputs, so `gap_pressure` is byte-for-byte identical (proven by an equivalence test), but vitals no longer pays for the structural config, signals, backlinks, logs, and entities checks it never reads. `runDoctor`'s own report is unchanged.
+
 ## [1.29.0] - 2026-07-10
 
 An operability, safety, and first-run release that makes Open Second Brain robust and pleasant to set up and operate: a guided first-run checklist, actionable config diagnostics, resilient hooks and rate-limit handling, safe mutating operations, a hardened optional HTTP transport, and usage visibility. Every new surface is additive and off by default or byte-identical when its condition is absent; the release adds no new dependency and the kernel still calls no LLM.
@@ -6447,6 +6460,7 @@ plugin config (vault field)`, and exits with a clear
 - Sandbox vault and plugin manifest fixtures for tests.
 - GitHub release workflow for tag-based and manually dispatched releases.
 
+[1.30.0]: https://github.com/itechmeat/open-second-brain/compare/v1.29.0...v1.30.0
 [1.29.0]: https://github.com/itechmeat/open-second-brain/compare/v1.28.0...v1.29.0
 [1.28.0]: https://github.com/itechmeat/open-second-brain/compare/v1.27.1...v1.28.0
 [1.27.1]: https://github.com/itechmeat/open-second-brain/compare/v1.27.0...v1.27.1

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "open-second-brain",
   "name": "Open Second Brain",
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults.",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "activation": { "onStartup": true },
   "skills": ["./skills"],
   "contracts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "private": false,
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults. Works with Hermes, Claude Code, Codex, and OpenClaw.",
   "keywords": [

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "1.29.0"
+version: "1.30.0"
 description: "Open Second Brain - native Hermes memory provider backed by an Obsidian-compatible Markdown vault."
 author: "Open Second Brain contributors"
 memory_provider: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "author": {
     "name": "Open Second Brain contributors",

--- a/plugins/hermes/plugin.yaml
+++ b/plugins/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "1.29.0"
+version: "1.30.0"
 description: "Open Second Brain - native Hermes memory provider backed by an Obsidian-compatible Markdown vault."
 author: "Open Second Brain contributors"
 memory_provider: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 # CLI entry points (those moved to `package.json` `bin`).
 [project]
 name = "open-second-brain"
-version = "1.29.0"
+version = "1.30.0"
 description = "Hermes Python shim for Open Second Brain. Most of the project (CLI, MCP server, OpenClaw plugin) is TypeScript on Bun; see package.json."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/core/brain/doctor.ts
+++ b/src/core/brain/doctor.ts
@@ -492,6 +492,42 @@ export function runDoctor(vault: string, opts: RunDoctorOptions = {}): RunDoctor
 
 // ----- Semantic health (v0.14.0) --------------------------------------------
 
+/**
+ * Compute only the semantic-health report, skipping the structural
+ * doctor sweep. {@link runDoctor} attaches the identical report via its
+ * inline pass; a caller that needs nothing but the semantic findings
+ * (e.g. vault vitals reading `conceptGaps` for gap pressure) can call
+ * this directly instead of paying for the full config / signals /
+ * backlinks / logs / entities sweep. Both paths route through the same
+ * {@link checkSemanticHealth} detector over the same inputs
+ * (`readAllPreferenceRecords`, `resolveHealth(cfg)` or the defaults, and
+ * `now`), so the findings are byte-for-byte identical.
+ *
+ * Best-effort and never throws: returns `undefined` only when the pass
+ * itself throws, mirroring `runDoctor`'s attach-on-success contract. Any
+ * lint issues the pass would emit into the doctor stream are discarded
+ * here, which is exactly what a report-only caller wants.
+ */
+export function computeSemanticHealth(
+  vault: string,
+  opts: { readonly now?: Date } = {},
+): SemanticHealthReport | undefined {
+  const now = opts.now ?? new Date();
+  let cfg;
+  try {
+    cfg = loadBrainConfigDetailed(vault).config;
+  } catch {
+    cfg = undefined;
+  }
+  try {
+    const prefRecords = readAllPreferenceRecords(vault);
+    const health = cfg ? resolveHealth(cfg) : BRAIN_HEALTH_DEFAULTS;
+    return checkSemanticHealth(vault, prefRecords, [], health, now);
+  } catch {
+    return undefined;
+  }
+}
+
 /** Minimal signal projection the semantic-health pass needs. */
 interface SignalSignRecord {
   readonly id: string;

--- a/src/core/brain/vitals.ts
+++ b/src/core/brain/vitals.ts
@@ -18,8 +18,8 @@
  *                            threshold (thin backing, candidates for
  *                            re-confirmation or retirement).
  *   - `gap_pressure`       — open `concept-gap` findings (reused from
- *                            {@link runDoctor}'s semantic-health pass,
- *                            not recomputed here) divided by preference
+ *                            {@link computeSemanticHealth}'s pass, not
+ *                            recomputed here) divided by preference
  *                            count: are gaps piling up faster than
  *                            they're being distilled into preferences?
  *
@@ -34,7 +34,7 @@ import { join } from "node:path";
 
 import { brainDirs } from "./paths.ts";
 import { parsePreference } from "./preference.ts";
-import { runDoctor } from "./doctor.ts";
+import { computeSemanticHealth } from "./doctor.ts";
 import { BRAIN_PREFERENCE_STATUS, type BrainPreference } from "./types.ts";
 
 export interface VaultVitalsOptions {
@@ -110,10 +110,12 @@ function scopeDiversity(prefs: ReadonlyArray<BrainPreference>): {
 
 /**
  * Compute the vault vitals scorecard. `gap_pressure`'s numerator reuses
- * {@link runDoctor}'s semantic-health `conceptGaps` count rather than
+ * {@link computeSemanticHealth}'s `conceptGaps` count rather than
  * re-running the detector — one source of truth for "how many gaps are
- * open". A doctor failure degrades `gap_pressure` to `0` rather than
- * failing the whole report: vitals is observability, not correctness.
+ * open" — and takes the semantic-only path so vitals does not pay for
+ * the full structural doctor sweep just to read one number. A pass
+ * failure degrades `gap_pressure` to `0` rather than failing the whole
+ * report: vitals is observability, not correctness.
  */
 export function computeVaultVitals(
   vault: string,
@@ -133,11 +135,15 @@ export function computeVaultVitals(
     .map((p) => ({ id: p.id, scope: p.scope, evidence_count: p.evidenced_by.length }))
     .toSorted((a, b) => a.evidence_count - b.evidence_count || a.id.localeCompare(b.id));
 
+  // Semantic-only path: same detector `runDoctor` runs, without the
+  // structural sweep vitals never reads. `computeSemanticHealth` already
+  // swallows its own failures (returns undefined); the guard is belt and
+  // suspenders so gap_pressure degrades to 0 rather than failing.
   let gapCount = 0;
   try {
-    gapCount = runDoctor(vault).semantic_health?.conceptGaps.length ?? 0;
+    gapCount = computeSemanticHealth(vault)?.conceptGaps.length ?? 0;
   } catch {
-    // Vitals is observability, not correctness — a doctor failure
+    // Vitals is observability, not correctness — a probe failure
     // should not block the rest of the report.
   }
   const gapPressure = prefs.length > 0 ? round2(gapCount / prefs.length) : 0;

--- a/tests/core/brain/doctor-semantic.test.ts
+++ b/tests/core/brain/doctor-semantic.test.ts
@@ -12,7 +12,7 @@ import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { runDoctor } from "../../../src/core/brain/doctor.ts";
+import { computeSemanticHealth, runDoctor } from "../../../src/core/brain/doctor.ts";
 import { brainDirs } from "../../../src/core/brain/paths.ts";
 import { writeSignal } from "../../../src/core/brain/signal.ts";
 import { writePreference } from "../../../src/core/brain/preference.ts";
@@ -106,5 +106,25 @@ describe("runDoctor semantic health", () => {
   test("does not throw on a vault and always returns a semantic_health report", () => {
     expect(() => runDoctor(vault, { now: NOW })).not.toThrow();
     expect(runDoctor(vault, { now: NOW }).semantic_health).toBeDefined();
+  });
+
+  test("computeSemanticHealth returns exactly runDoctor's semantic_health report", () => {
+    // The semantic-only path (used by vault vitals) must be byte-for-byte
+    // equal to the report the full doctor attaches: same detector, same
+    // inputs, just without the structural sweep. A non-trivial vault
+    // (contradiction) exercises the findings, not just empty domains.
+    const pos = sig("tabs-pos", BRAIN_SIGNAL_SIGN.positive, "use tabs");
+    const neg = sig("tabs-neg", BRAIN_SIGNAL_SIGN.negative, "use spaces");
+    confirmedPref("tabs-rule", "tabs-rule", "always indent source with tabs not spaces", [
+      `[[${pos}]]`,
+    ]);
+    confirmedPref("spaces-rule", "spaces-rule", "never indent source with tabs always spaces", [
+      `[[${neg}]]`,
+    ]);
+
+    const standalone = computeSemanticHealth(vault, { now: NOW });
+    const viaDoctor = runDoctor(vault, { now: NOW }).semantic_health;
+    expect(standalone).toEqual(viaDoctor);
+    expect(standalone?.conceptGaps).toEqual(viaDoctor?.conceptGaps);
   });
 });


### PR DESCRIPTION
## Governance visibility (v1.30.0)

Cuts the v1.30.0 release around two aggregate governance views over `Brain/preferences/` that the per-item hygiene lints could not answer, plus an efficiency refinement to how one of them sources its data. Both new surfaces are additive and read-only; the release adds no new dependency and the kernel still calls no LLM.

The two features landed as-is in #135 (thanks to @Starlight143 for a clean, well-scoped contribution). This PR carries the semantic-only efficiency refinement on top, plus the version bump and the CHANGELOG entry covering all three - the external-fork reconcile path we agreed on, where the release-bearing commit is this follow-up.

### Shipped scope

- **`o2b brain vitals` scorecard (#135).** A read-only scorecard over confirmed preferences: `domain_diversity` (normalised Shannon entropy of the `scope` distribution), `connectivity_index` (mean `evidenced_by` count), `orphan_preferences` (below `--orphan-threshold`, default 2), and `gap_pressure` (open concept-gap findings over preference count). Text or `--json`; records one `vault_vitals` metric.
- **batch-concept-inflation lint (#135).** `detectBatchInflation` is a deterministic, non-overlapping window scan over `confirmed_at` timestamps (default 24h, burst >= 5, both configurable) that flags a burst of individually-distinct preferences confirmed together - the signal a batch ingest skipped its dedup pass. Wired through `reconcileSemanticHealth`, the doctor lint, `o2b brain health` / `brain_health`, and a new `batch_inflation` trigger kind.
- **Semantic-only `gap_pressure` (this PR).** `computeVaultVitals` no longer calls the full `runDoctor` sweep just to read the concept-gap count. A new exported `computeSemanticHealth` runs the semantic-only pass; vitals routes through it and skips the structural config / signals / backlinks / logs / entities checks it never reads.

### Design

Both `computeSemanticHealth` and `runDoctor` route through the same `checkSemanticHealth` detector over the same inputs (`readAllPreferenceRecords`, `resolveHealth(cfg)` or the defaults, `now`), so `gap_pressure` is byte-for-byte identical. `runDoctor`'s inline pass and its attached report are untouched - the refactor adds a leaner entry point, it does not change the doctor. A pass failure still degrades `gap_pressure` to `0`: vitals is observability, not correctness.

### Validation

- New equivalence test asserts `computeSemanticHealth(vault)` equals `runDoctor(vault).semantic_health` on a non-trivial vault (proves the refactor preserves the value); the #135 test suites for vitals and batch-inflation carry over.
- `bun run validate` green: 5687 pass / 0 fail, zero lint errors; `bun run check:paths:strict` clean.
- Version `1.30.0` with the CHANGELOG entry (covering all three items) in this PR; `sync-version:check` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the read-only `o2b brain vitals` governance scorecard.
  * Added a batch concept-inflation lint for preference data.
* **Improvements**
  * Updated vault health reporting to use the semantic-health results while preserving existing gap-pressure metrics.
* **Release**
  * Released version 1.30.0 with updated plugin and package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->