### PR TITLE
fix(hermes): preserve context-pack recall (v1.50.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.50.1",
+  "version": "1.50.2",
   "description": "Plugin-first second brain package for AI agents and humans.",
   "author": {
     "name": "Open Second Brain contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.50.1",
+  "version": "1.50.2",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "skills": "./skills",
   "hooks": "./hooks/hooks.json",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.50.2] - 2026-08-20
+
+Hermes asked Open Second Brain for a token-bounded context pack before each substantive turn, then read only the MCP transport text. The transport deliberately replaces a large result with a 2,000-character preview envelope, even though the complete structured context pack is present beside it, so the provider injected transport metadata instead of the recalled memory bodies.
+
+### Fixed
+
+- **Hermes per-turn recall now uses the structured, token-budgeted context pack.** The provider joins non-empty `structuredContent.items[*].body` values and bypasses the `preview_truncated` transport envelope. The existing 1,024-token context-pack ceiling is unchanged, and text-only older servers retain their existing fallback.
+- **The transport-boundary regression has a test that fails on the old path.** The fixture returns both structured memory bodies and the exact preview-envelope shape; it requires both bodies to reach the prompt and every envelope marker to stay out.
+
 ## [1.50.1] - 2026-08-17
 
 The Hermes dashboard could not save this provider's configuration, and reported the failure in the one way an operator cannot act on: a provider that was fully configured showed as needing setup, and every attempt to configure it from the panel returned HTTP 400. Reported as [#170](https://github.com/itechmeat/open-second-brain/issues/170) with the root cause already traced to where the two sides look for the same values. Two unrelated repairs ride along, both surfaced by running the suite on a later day than the one it was written on: a test pinned to a date literal, and the build step that was meant to notice the vendored-schema test skipping.
@@ -7277,6 +7286,7 @@ plugin config (vault field)`, and exits with a clear
 - Sandbox vault and plugin manifest fixtures for tests.
 - GitHub release workflow for tag-based and manually dispatched releases.
 
+[1.50.2]: https://github.com/itechmeat/open-second-brain/compare/v1.50.1...v1.50.2
 [1.50.1]: https://github.com/itechmeat/open-second-brain/compare/v1.50.0...v1.50.1
 [1.50.0]: https://github.com/itechmeat/open-second-brain/compare/v1.49.0...v1.50.0
 [1.49.0]: https://github.com/itechmeat/open-second-brain/compare/v1.48.0...v1.49.0

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "open-second-brain",
   "name": "Open Second Brain",
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults.",
-  "version": "1.50.1",
+  "version": "1.50.2",
   "activation": { "onStartup": true },
   "skills": ["./skills"],
   "contracts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.50.1",
+  "version": "1.50.2",
   "private": false,
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults. Works with Hermes, Claude Code, Codex, and OpenClaw.",
   "keywords": [

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "1.50.1"
+version: "1.50.2"
 description: "Open Second Brain - native Hermes memory provider backed by an Obsidian-compatible Markdown vault."
 author: "Open Second Brain contributors"
 memory_provider: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.50.1",
+  "version": "1.50.2",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "author": {
     "name": "Open Second Brain contributors",

--- a/plugins/hermes/plugin.yaml
+++ b/plugins/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "1.50.1"
+version: "1.50.2"
 description: "Open Second Brain - native Hermes memory provider backed by an Obsidian-compatible Markdown vault."
 author: "Open Second Brain contributors"
 memory_provider: true

--- a/plugins/hermes/provider.py
+++ b/plugins/hermes/provider.py
@@ -561,7 +561,7 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
         gate = self._structured(self._safe_call("brain_recall_gate", {"prompt": query}))
         if gate.get("retrieve"):
             pack = self._safe_call("brain_context_pack", {"max_tokens": _PREFETCH_MAX_TOKENS})
-            recalled = self._text(pack)
+            recalled = self._context_pack_text(pack)
             if recalled:
                 parts.append(recalled)
         # Skill auto-attach (Agent Surface Suite): the TS side gates on the
@@ -716,6 +716,24 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
             if isinstance(first, dict) and isinstance(first.get("text"), str):
                 return first["text"]
         return ""
+
+    @staticmethod
+    def _context_pack_text(result: Any) -> str:
+        """Recall text from ``brain_context_pack``: prefer structured bodies.
+
+        Structured item bodies are the budgeted recall payload; using them also
+        bypasses the MCP transport's preview envelope. Fall back to
+        ``content[0].text`` for older servers that only expose legacy text.
+        """
+        structured = OpenSecondBrainMemoryProvider._structured(result)
+        bodies = [
+            str(item.get("body"))
+            for item in (structured.get("items") or [])
+            if isinstance(item, dict) and str(item.get("body") or "").strip()
+        ]
+        if bodies:
+            return "\n\n".join(bodies)
+        return OpenSecondBrainMemoryProvider._text(result)
 
     def _append_turn(self, user: str, assistant: str, session_id: str) -> None:
         with self._lock:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 # CLI entry points (those moved to `package.json` `bin`).
 [project]
 name = "open-second-brain"
-version = "1.50.1"
+version = "1.50.2"
 description = "Hermes Python shim for Open Second Brain. Most of the project (CLI, MCP server, OpenClaw plugin) is TypeScript on Bun; see package.json."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/python/test_memory_provider.py
+++ b/tests/python/test_memory_provider.py
@@ -706,6 +706,47 @@ class ProviderLifecycleTests(unittest.TestCase):
         self.assertIn("RECALLED", out)
         self.assertIn("@pf-agent", out)
 
+    def test_prefetch_uses_structured_items_bodies_and_skips_preview_envelope(self):
+        # Regression: when brain_context_pack returns both structuredContent
+        # items[*].body AND a content[0].text envelope carrying the
+        # preview-truncation marker (preview_truncated + artifact_id +
+        # bytes_preview), prefetch must assemble recall from the structured
+        # bodies — the envelope is a transport artefact, not recall text.
+        os.environ["VAULT_AGENT_NAME"] = "pf-agent"
+        preview_text = json.dumps(
+            {
+                "preview_truncated": True,
+                "artifact_id": "art-deadbeef",
+                "full_chars": 44261,
+                "bytes_preview": "...truncated...",
+            }
+        )
+        bridge = FakeBrainBridge(
+            results={
+                "brain_recall_gate": {"structuredContent": {"retrieve": True, "reason": "hit"}},
+                "brain_context_pack": {
+                    "structuredContent": {
+                        "items": [
+                            {"title": "note-a", "body": "BODY ALPHA from item A"},
+                            {"title": "note-b", "body": "BODY BETA from item B"},
+                        ]
+                    },
+                    "content": [{"type": "text", "text": preview_text}],
+                },
+            }
+        )
+        provider = self._init(bridge, hermes_home="/tmp/hh")
+        out = provider.prefetch("any query", session_id="sess-1")
+
+        # Both structured bodies must reach the prefetch output.
+        self.assertIn("BODY ALPHA from item A", out)
+        self.assertIn("BODY BETA from item B", out)
+        # The MCP preview envelope must NOT leak into the prompt.
+        self.assertNotIn("preview_truncated", out)
+        self.assertNotIn("artifact_id", out)
+        self.assertNotIn("bytes_preview", out)
+        self.assertNotIn("art-deadbeef", out)
+
     def test_prefetch_appends_skills_attach_block_when_enabled(self):
         os.environ["VAULT_AGENT_NAME"] = "pf-agent"
         bridge = FakeBrainBridge(


### PR DESCRIPTION
## Problem

Hermes asks Open Second Brain for a `brain_context_pack(max_tokens=1024)` before substantive turns, but the provider read only `content[0].text`. When the MCP preview budget protects a large serialized result, that field is a `preview_truncated` envelope rather than recalled memory. The full structured context pack is present beside it.

## Fix

- Assemble per-turn recall from non-empty `structuredContent.items[*].body` values.
- Keep the existing text-only fallback for older servers.
- Keep the 1,024-token context-pack ceiling unchanged.
- Add a regression fixture containing both real structured bodies and the exact preview-envelope shape.

## Verification

- Regression sabotage: restoring the old `_text(pack)` line makes the new test fail; restoring the fix passes.
- `python3.11 -m unittest discover -s tests/python -v` — 120 passed.
- `bun run sync-version:check && bun run typecheck` — passed.
- `bun run lint` — 0 errors (145 existing warnings).
- `bun test tests/version.test.ts` — 7 passed.
- Real vault/MCP E2E: 999/1,024 tokens used, all 19 non-empty bodies present, and no `preview_truncated`, `artifact_id`, or `bytes_preview` in Hermes prefetch output.

## Baseline note

The repository-wide Bun suite is already red on the unchanged upstream checkout in this environment (80 failures). The isolated branch reports 72 failures, all in unrelated TypeScript suites; this Python/provider change introduces no new Bun-test failure.

## Scope and risk

Hermes provider only. No vault format, MCP output schema, configuration, or runtime budget changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved recall of structured context-pack content during prefetch operations.
  * Preserved compatibility with legacy recall content formats.
* **Bug Fixes**
  * Prevented MCP preview-truncation text from appearing in generated prompts.
* **Documentation**
  * Added release notes for version 1.50.2.
* **Chores**
  * Updated package and plugin versions to 1.50.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->