### PR TITLE
fix(hermes): use semantic search for prefetch recall

### DIFF
--- a/plugins/hermes/provider.py
+++ b/plugins/hermes/provider.py
@@ -560,11 +560,19 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
         parts: list[str] = []
         gate = self._structured(self._safe_call("brain_recall_gate", {"prompt": query}))
         if gate.get("retrieve"):
-            pack = self._safe_call(
-                "brain_context_pack",
-                {"max_tokens": _PREFETCH_MAX_TOKENS, "query": query},
+            search = self._structured(
+                self._safe_call(
+                    "brain_search",
+                    {
+                        "query": query,
+                        "limit": 5,
+                        "disclosure": "cards",
+                        "profile": "thorough",
+                        "record_access": False,
+                    },
+                )
             )
-            recalled = self._text(pack)
+            recalled = self._search_text(search)
             if recalled:
                 parts.append(recalled)
         # Skill auto-attach (Agent Surface Suite): the TS side gates on the
@@ -719,6 +727,33 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
             if isinstance(first, dict) and isinstance(first.get("text"), str):
                 return first["text"]
         return ""
+
+    @staticmethod
+    def _search_text(result: dict[str, Any]) -> str:
+        """Format semantic search cards without expanding the prefetch budget.
+
+        ``brain_context_pack.query`` is a literal substring filter on topic and
+        principle, while Hermes supplies a natural-language turn prompt. Use
+        O2B's semantic ``brain_search`` surface instead and keep only bounded
+        cards so the recall block remains a hint, not a second prompt.
+        """
+        rows = result.get("results") or result.get("cards")
+        if not isinstance(rows, list):
+            return ""
+        blocks: list[str] = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            path = row.get("path")
+            text = row.get("content") or row.get("snippet")
+            if not isinstance(text, str) or not text.strip():
+                continue
+            prefix = f"[{path}]\n" if isinstance(path, str) and path else ""
+            blocks.append(prefix + text.strip())
+        # Cards are already bounded by the server; this final cap preserves the
+        # provider's historical ~1024-token prefetch ceiling if that envelope
+        # grows in a future O2B release.
+        return "\n\n".join(blocks)[: _PREFETCH_MAX_TOKENS * 4]
 
     def _append_turn(self, user: str, assistant: str, session_id: str) -> None:
         with self._lock:

--- a/plugins/hermes/provider.py
+++ b/plugins/hermes/provider.py
@@ -560,7 +560,10 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
         parts: list[str] = []
         gate = self._structured(self._safe_call("brain_recall_gate", {"prompt": query}))
         if gate.get("retrieve"):
-            pack = self._safe_call("brain_context_pack", {"max_tokens": _PREFETCH_MAX_TOKENS})
+            pack = self._safe_call(
+                "brain_context_pack",
+                {"max_tokens": _PREFETCH_MAX_TOKENS, "query": query},
+            )
             recalled = self._text(pack)
             if recalled:
                 parts.append(recalled)

--- a/plugins/hermes/provider.py
+++ b/plugins/hermes/provider.py
@@ -560,19 +560,34 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
         parts: list[str] = []
         gate = self._structured(self._safe_call("brain_recall_gate", {"prompt": query}))
         if gate.get("retrieve"):
-            search = self._structured(
-                self._safe_call(
-                    "brain_search",
-                    {
-                        "query": query,
-                        "limit": 5,
-                        "disclosure": "cards",
-                        "profile": "thorough",
-                        "record_access": False,
-                    },
-                )
-            )
-            recalled = self._search_text(search)
+            search_results = [
+                self._structured(
+                    self._safe_call(
+                        "brain_search",
+                        {
+                            "query": query,
+                            "limit": 3,
+                            "disclosure": "cards",
+                            "profile": "thorough",
+                            "properties": {"kind": ["brain-preference"]},
+                            "record_access": False,
+                        },
+                    )
+                ),
+                self._structured(
+                    self._safe_call(
+                        "brain_search",
+                        {
+                            "query": query,
+                            "limit": 5,
+                            "disclosure": "cards",
+                            "profile": "thorough",
+                            "record_access": False,
+                        },
+                    )
+                ),
+            ]
+            recalled = self._search_text(search_results)
             if recalled:
                 parts.append(recalled)
         # Skill auto-attach (Agent Surface Suite): the TS side gates on the
@@ -729,27 +744,36 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
         return ""
 
     @staticmethod
-    def _search_text(result: dict[str, Any]) -> str:
-        """Format semantic search cards without expanding the prefetch budget.
+    def _search_text(results: Iterable[dict[str, Any]]) -> str:
+        """Format two semantic search lanes without expanding the prefetch budget.
 
         ``brain_context_pack.query`` is a literal substring filter on topic and
         principle, while Hermes supplies a natural-language turn prompt. Use
-        O2B's semantic ``brain_search`` surface instead and keep only bounded
-        cards so the recall block remains a hint, not a second prompt.
+        O2B's semantic ``brain_search`` surface instead. The preference-filtered
+        lane comes first because active rules are the highest-value recall for
+        the provider; paths are deduplicated before the bounded output is built.
         """
-        rows = result.get("results") or result.get("cards")
-        if not isinstance(rows, list):
-            return ""
         blocks: list[str] = []
-        for row in rows:
-            if not isinstance(row, dict):
+        seen_paths: set[str] = set()
+        for result in results:
+            rows = result.get("results") or result.get("cards")
+            if not isinstance(rows, list):
                 continue
-            path = row.get("path")
-            text = row.get("content") or row.get("snippet")
-            if not isinstance(text, str) or not text.strip():
-                continue
-            prefix = f"[{path}]\n" if isinstance(path, str) and path else ""
-            blocks.append(prefix + text.strip())
+            for row in rows:
+                if not isinstance(row, dict):
+                    continue
+                path = row.get("path")
+                text = row.get("content") or row.get("snippet")
+                if not isinstance(text, str) or not text.strip():
+                    continue
+                if isinstance(path, str) and path:
+                    if path in seen_paths:
+                        continue
+                    seen_paths.add(path)
+                    prefix = f"[{path}]\n"
+                else:
+                    prefix = ""
+                blocks.append(prefix + text.strip())
         # Cards are already bounded by the server; this final cap preserves the
         # provider's historical ~1024-token prefetch ceiling if that envelope
         # grows in a future O2B release.

--- a/tests/python/test_memory_provider.py
+++ b/tests/python/test_memory_provider.py
@@ -698,7 +698,11 @@ class ProviderLifecycleTests(unittest.TestCase):
         bridge = FakeBrainBridge(
             results={
                 "brain_recall_gate": {"structuredContent": {"retrieve": True, "reason": "hit"}},
-                "brain_context_pack": {"content": [{"type": "text", "text": "RECALLED"}]},
+                "brain_search": {
+                    "structuredContent": {
+                        "cards": [{"path": "Brain/preferences/pref-test.md", "snippet": "RECALLED"}]
+                    }
+                },
             }
         )
         provider = self._init(bridge, hermes_home="/tmp/hh")

--- a/tests/python/test_memory_provider.py
+++ b/tests/python/test_memory_provider.py
@@ -708,6 +708,7 @@ class ProviderLifecycleTests(unittest.TestCase):
         provider = self._init(bridge, hermes_home="/tmp/hh")
         out = provider.prefetch("what did we decide", session_id="sess-1")
         self.assertIn("RECALLED", out)
+        self.assertEqual(out.count("Brain/preferences/pref-test.md"), 1)
         self.assertIn("@pf-agent", out)
 
     def test_prefetch_appends_skills_attach_block_when_enabled(self):

--- a/tests/python/test_static_schemas.py
+++ b/tests/python/test_static_schemas.py
@@ -477,11 +477,19 @@ class ProviderPayloadConformanceTests(unittest.TestCase):
             [
                 {
                     "query": "what did we decide",
+                    "limit": 3,
+                    "disclosure": "cards",
+                    "profile": "thorough",
+                    "properties": {"kind": ["brain-preference"]},
+                    "record_access": False,
+                },
+                {
+                    "query": "what did we decide",
                     "limit": 5,
                     "disclosure": "cards",
                     "profile": "thorough",
                     "record_access": False,
-                }
+                },
             ],
         )
 

--- a/tests/python/test_static_schemas.py
+++ b/tests/python/test_static_schemas.py
@@ -405,7 +405,7 @@ class ProviderPayloadConformanceTests(unittest.TestCase):
         {
             "brain_context",
             "brain_recall_gate",
-            "brain_context_pack",
+            "brain_search",
             "brain_pre_compact_extract",
         }
     )
@@ -426,7 +426,11 @@ class ProviderPayloadConformanceTests(unittest.TestCase):
             results={
                 "brain_context": {"structuredContent": {"content": "ACTIVE PREFS"}},
                 "brain_recall_gate": {"structuredContent": {"retrieve": True}},
-                "brain_context_pack": {"content": [{"type": "text", "text": "RECALLED"}]},
+                "brain_search": {
+                    "structuredContent": {
+                        "cards": [{"path": "Brain/preferences/pref-test.md", "snippet": "RECALLED"}]
+                    }
+                },
                 "brain_pre_compact_extract": {"structuredContent": {}},
             }
         )
@@ -464,13 +468,21 @@ class ProviderPayloadConformanceTests(unittest.TestCase):
         # path must fail here rather than read as a clean run.
         self.assertEqual(exercised, self._PROVIDER_BUILT)
 
-    def test_prefetch_passes_query_to_context_pack(self):
+    def test_prefetch_passes_query_to_semantic_search(self):
         with tempfile.TemporaryDirectory() as tmp:
             calls = self._drive_lifecycle(tmp)
-        packs = [args for name, args in calls if name == "brain_context_pack"]
+        searches = [args for name, args in calls if name == "brain_search"]
         self.assertEqual(
-            packs,
-            [{"max_tokens": 1024, "query": "what did we decide"}],
+            searches,
+            [
+                {
+                    "query": "what did we decide",
+                    "limit": 5,
+                    "disclosure": "cards",
+                    "profile": "thorough",
+                    "record_access": False,
+                }
+            ],
         )
 
     def test_the_flush_payload_carries_both_turn_bounds_as_strings(self):

--- a/tests/python/test_static_schemas.py
+++ b/tests/python/test_static_schemas.py
@@ -464,6 +464,15 @@ class ProviderPayloadConformanceTests(unittest.TestCase):
         # path must fail here rather than read as a clean run.
         self.assertEqual(exercised, self._PROVIDER_BUILT)
 
+    def test_prefetch_passes_query_to_context_pack(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            calls = self._drive_lifecycle(tmp)
+        packs = [args for name, args in calls if name == "brain_context_pack"]
+        self.assertEqual(
+            packs,
+            [{"max_tokens": 1024, "query": "what did we decide"}],
+        )
+
     def test_the_flush_payload_carries_both_turn_bounds_as_strings(self):
         with tempfile.TemporaryDirectory() as tmp:
             calls = self._drive_lifecycle(tmp)


### PR DESCRIPTION
## Summary

Hermes' native O2B provider gates per-turn recall with `brain_recall_gate`, but the old prefetch path used `brain_context_pack` for a natural-language prompt. O2B documents `brain_context_pack.query` as a literal substring filter over `topic + principle`; passing a full user prompt there can produce an empty pack and is not semantic recall.

This PR uses O2B's existing semantic `brain_search` surface for gated prefetch recall:

- first runs a bounded `kind=brain-preference` lane (`limit=3`) so active rules are not buried by long concept pages;
- then runs the normal semantic lane (`limit=5`) so concept/lesson/skill memories remain reachable;
- deduplicates paths and keeps the existing provider prefetch cap (~1024 tokens);
- disables access-ledger writes for automatic prefetch.

## Evidence

On the fixed active-memory dataset (`36` queries; original retired/tombstoned targets excluded from the positive set), five repeated no-write CLI probes produced the same union result:

- single normal lane: hit@5 `9/36 = 0.25`, MRR `0.1967592593`;
- preference-only lane: hit@5 `26/36 = 0.7222222222`, MRR `0.6481481481`;
- dual lane (preference 3 + normal 5, path-deduplicated): hit@10 `30/36 = 0.8333333333`, MRR `0.6962962963`.

The dual-lane number is a probe of the two official search calls, not a claim that the unmerged PR is already live in Hermes.

## Scope

- `plugins/hermes/provider.py`: two bounded O2B search lanes, path deduplication, fixed output cap.
- `tests/python/test_static_schemas.py`: exact bridge payload regression.
- `tests/python/test_memory_provider.py`: recall and deduplication regression.
- No O2B core, schema, config, budget, reindex, dream, or MCP changes.
- Separate from #172, which addresses structured context-pack preview handling.

## Verification

- `uv run python -m unittest tests/python/test_static_schemas.py tests/python/test_memory_provider.py tests/python/test_hermes_plugin.py` — 119 tests passed.
- `bun run fmt:check` — passed.
- `bun run typecheck` — passed locally and in pre-push.
- `git diff --check` — passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prefetch recall by combining preference-filtered and general semantic search results.
  * Prioritized preference-matched content while removing duplicate results.
  * Preserved the existing content limit and improved handling of cards, snippets, source paths, and invalid content.

* **Tests**
  * Expanded regression coverage for dual search requests, filtering, result limits, disclosure settings, access recording, and structured recall content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->