### PR TITLE
ci: adopt Bun 1.4.0 - pin the toolchain and rebuild the bundle it gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.4.0
 
       - name: Set up Python (Hermes plugin tests)
         uses: actions/setup-python@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.4.0
 
       - name: Set up Python (Hermes plugin tests)
         uses: actions/setup-python@v5
@@ -114,7 +114,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.4.0
 
       - name: Resolve release version
         id: version

--- a/openclaw/index.js
+++ b/openclaw/index.js
@@ -19,12 +19,14 @@ var __toESM = (mod, isNodeMode, target) => {
   }
   target = mod != null ? __create(__getProtoOf(mod)) : {};
   const to = isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target;
-  for (let key of __getOwnPropNames(mod))
-    if (!__hasOwnProp.call(to, key))
-      __defProp(to, key, {
-        get: __accessProp.bind(mod, key),
-        enumerable: true
-      });
+  if (mod && typeof mod === "object" || typeof mod === "function") {
+    for (let key of __getOwnPropNames(mod))
+      if (!__hasOwnProp.call(to, key))
+        __defProp(to, key, {
+          get: __accessProp.bind(mod, key),
+          enumerable: true
+        });
+  }
   if (canCache)
     cache.set(mod, to);
   return to;
@@ -33,7 +35,7 @@ var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, 
 var __require = /* @__PURE__ */ createRequire(import.meta.url);
 
 // node_modules/graceful-fs/polyfills.js
-var require_polyfills = __commonJS((exports, module) => {
+var require_polyfills = __commonJS(function(exports, module) {
   var constants = __require("constants");
   var origCwd = process.cwd;
   var cwd = null;
@@ -336,7 +338,7 @@ var require_polyfills = __commonJS((exports, module) => {
 });
 
 // node_modules/graceful-fs/legacy-streams.js
-var require_legacy_streams = __commonJS((exports, module) => {
+var require_legacy_streams = __commonJS(function(exports, module) {
   var Stream = __require("stream").Stream;
   module.exports = legacy;
   function legacy(fs) {
@@ -433,7 +435,7 @@ var require_legacy_streams = __commonJS((exports, module) => {
 });
 
 // node_modules/graceful-fs/clone.js
-var require_clone = __commonJS((exports, module) => {
+var require_clone = __commonJS(function(exports, module) {
   module.exports = clone;
   var getPrototypeOf = Object.getPrototypeOf || function(obj) {
     return obj.__proto__;
@@ -453,7 +455,7 @@ var require_clone = __commonJS((exports, module) => {
 });
 
 // node_modules/graceful-fs/graceful-fs.js
-var require_graceful_fs = __commonJS((exports, module) => {
+var require_graceful_fs = __commonJS(function(exports, module) {
   var fs = __require("fs");
   var polyfills = require_polyfills();
   var legacy = require_legacy_streams();
@@ -811,7 +813,7 @@ GFS4: `);
 });
 
 // node_modules/retry/lib/retry_operation.js
-var require_retry_operation = __commonJS((exports, module) => {
+var require_retry_operation = __commonJS(function(exports, module) {
   function RetryOperation(timeouts, options) {
     if (typeof options === "boolean") {
       options = { forever: options };
@@ -940,7 +942,7 @@ var require_retry_operation = __commonJS((exports, module) => {
 });
 
 // node_modules/retry/lib/retry.js
-var require_retry = __commonJS((exports) => {
+var require_retry = __commonJS(function(exports) {
   var RetryOperation = require_retry_operation();
   exports.operation = function(options) {
     var timeouts = exports.timeouts(options);
@@ -1024,7 +1026,7 @@ var require_retry = __commonJS((exports) => {
 });
 
 // node_modules/signal-exit/signals.js
-var require_signals = __commonJS((exports, module) => {
+var require_signals = __commonJS(function(exports, module) {
   module.exports = [
     "SIGABRT",
     "SIGALRM",
@@ -1041,7 +1043,7 @@ var require_signals = __commonJS((exports, module) => {
 });
 
 // node_modules/signal-exit/index.js
-var require_signal_exit = __commonJS((exports, module) => {
+var require_signal_exit = __commonJS(function(exports, module) {
   var process2 = global.process;
   var processOk = function(process3) {
     return process3 && typeof process3 === "object" && typeof process3.removeListener === "function" && typeof process3.emit === "function" && typeof process3.reallyExit === "function" && typeof process3.listeners === "function" && typeof process3.kill === "function" && typeof process3.pid === "number" && typeof process3.on === "function";
@@ -1194,7 +1196,7 @@ var require_signal_exit = __commonJS((exports, module) => {
 });
 
 // node_modules/proper-lockfile/lib/mtime-precision.js
-var require_mtime_precision = __commonJS((exports, module) => {
+var require_mtime_precision = __commonJS(function(exports, module) {
   var cacheSymbol = Symbol();
   function probe(file, fs, callback) {
     const cachedPrecision = fs[cacheSymbol];
@@ -1233,7 +1235,7 @@ var require_mtime_precision = __commonJS((exports, module) => {
 });
 
 // node_modules/proper-lockfile/lib/lockfile.js
-var require_lockfile = __commonJS((exports, module) => {
+var require_lockfile = __commonJS(function(exports, module) {
   var path = __require("path");
   var fs = require_graceful_fs();
   var retry = require_retry();
@@ -1458,7 +1460,7 @@ var require_lockfile = __commonJS((exports, module) => {
 });
 
 // node_modules/proper-lockfile/lib/adapter.js
-var require_adapter = __commonJS((exports, module) => {
+var require_adapter = __commonJS(function(exports, module) {
   var fs = require_graceful_fs();
   function createSyncFs(fs2) {
     const methods = ["mkdir", "realpath", "stat", "rmdir", "utimes"];
@@ -1520,7 +1522,7 @@ var require_adapter = __commonJS((exports, module) => {
 });
 
 // node_modules/proper-lockfile/index.js
-var require_proper_lockfile = __commonJS((exports, module) => {
+var require_proper_lockfile = __commonJS(function(exports, module) {
   var lockfile = require_lockfile();
   var { toPromise, toSync, toSyncOptions } = require_adapter();
   async function lock(file, options) {


### PR DESCRIPTION
## Summary

The "OpenClaw bundle is in sync with sources" step byte-compares a committed bundle against a fresh `bun build`, and `ci.yml` / `release.yml` used `bun-version: latest`. Bun 1.4.0 shipped different bundler codegen than 1.3.x (the version the previously committed `openclaw/index.js` was built with), so the byte comparison started failing on every PR and on `main` itself, even though no source change caused the drift. This PR pins the Bun toolchain to `1.4.0` in every workflow that references it and regenerates `openclaw/index.js` with that version, so the committed bundle and the CI baseline move together instead of drifting apart.

## Evidence

- Under Bun 1.3.14, `bun build src/openclaw/index.ts --outfile <tmp> --target=node --format=esm --external openclaw/plugin-sdk/plugin-entry` reproduced the previously committed `openclaw/index.js` byte-for-byte.
- Under Bun 1.4.0, the same rebuild differed from that bundle by 38 lines, all pure vendored codegen churn (arrow-function vs. function-expression `__commonJS` wrappers, a newly guarded `__toESM` helper) - no source file changed to produce that diff. `main` at `1e8792cb` failed the "OpenClaw bundle is in sync with sources" step identically once the toolchain resolved to 1.4.0, confirming this was toolchain drift rather than something introduced by any pending PR.
- `openclaw/index.js` in this PR is the fresh Bun 1.4.0 build, and rebuilding it locally under 1.4.0 reproduces it byte-for-byte, so the gate passes going forward.
- Full local suite under Bun 1.4.0 with a throwaway `HOME`: 11259 tests pass, 0 fail, 106713 `expect()` calls across 1153 files. Typecheck clean. Lint at the same 145 warnings / 0 errors as under 1.3.14. `fmt:check` clean.

## Notes

Future Bun upgrades should follow the same pattern: bump the `bun-version` pin and regenerate the bundle in the same PR, so the committed bundle and the CI baseline never diverge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the Bun runtime version used by automated checks and release processes for more consistent builds.

* **Bug Fixes**
  * Improved module handling to prevent errors when processing primitive values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->