### PR TITLE
fix(hermes): record context-pack receipts and explicit outcomes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.52.0",
+  "version": "1.52.1",
   "description": "Plugin-first second brain package for AI agents and humans.",
   "author": {
     "name": "Open Second Brain contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.52.0",
+  "version": "1.52.1",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "skills": "./skills",
   "hooks": "./hooks/hooks.json",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.1] - 2026-08-24
+
+The context-pack outcome ledger shipped with receipts on the read side and nothing on the Hermes side to carry them, so a deployment that injected recall on every turn still recorded zero outcomes. Contributed by [@Yori940619](https://github.com/Yori940619) ([#179](https://github.com/itechmeat/open-second-brain/pull/179)), with one course correction along the way that is worth recording: the first revision inferred success and repair from hardcoded phrase lists in a single language, and the rework removed raw-text inference entirely - the honest shape, and now the pinned one.
+
+### Fixed
+
+- **The Hermes provider closes the context-pack outcome loop - structurally, not linguistically.** `prefetch` now requests a context receipt and opt-in telemetry from the same `brain_context_pack` call and appends a small structured metadata line (sample id, tool name, `outcome: unknown_until_explicit_tool_call`) to the injected recall, so the calling agent - the party that actually understands the user's language - posts `brain_context_pack_outcome` itself when the user explicitly confirms or corrects. The provider infers nothing from raw turn text, in any language, and a regression test pins that; an unsignaled turn stays unknown rather than being guessed into a vanity metric. `brain_context_pack_outcome` joins the curated Hermes tool surface with its schema vendored against the live server.
+
 ## [1.52.0] - 2026-08-23
 
 Nine tracker cards read against the live source before anything was designed, and the reading did most of the work. One card described a feature that already shipped end to end - closed, not built. One asked for privacy by riding a predicate that is inert in every default install - refused as designed, redesigned down to the truth it can tell today. Four more had premises the source contradicted: the "localized" stamp would have touched sixty-eight writers, the counter had no chokepoint to count at, the resume half already existed on the ingest lane, and the raise-on-attach the card wanted was already there behind a documented default. What survived is one rule applied eight ways: nothing writes silently, nothing degrades silently.
@@ -7349,6 +7357,7 @@ plugin config (vault field)`, and exits with a clear
 - Sandbox vault and plugin manifest fixtures for tests.
 - GitHub release workflow for tag-based and manually dispatched releases.
 
+[1.52.1]: https://github.com/itechmeat/open-second-brain/compare/v1.52.0...v1.52.1
 [1.52.0]: https://github.com/itechmeat/open-second-brain/compare/v1.51.0...v1.52.0
 [1.51.0]: https://github.com/itechmeat/open-second-brain/compare/v1.50.3...v1.51.0
 [1.50.3]: https://github.com/itechmeat/open-second-brain/compare/v1.50.2...v1.50.3

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "open-second-brain",
   "name": "Open Second Brain",
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults.",
-  "version": "1.52.0",
+  "version": "1.52.1",
   "activation": { "onStartup": true },
   "skills": ["./skills"],
   "contracts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.52.0",
+  "version": "1.52.1",
   "private": false,
   "description": "Second brain for AI agents using Obsidian-compatible Markdown vaults. Works with Hermes, Claude Code, Codex, and OpenClaw.",
   "keywords": [

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "1.52.0"
+version: "1.52.1"
 description: "Open Second Brain - native Hermes memory provider backed by an Obsidian-compatible Markdown vault."
 author: "Open Second Brain contributors"
 memory_provider: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-second-brain",
-  "version": "1.52.0",
+  "version": "1.52.1",
   "description": "Plugin-first second brain package for Codex, Hermes, Claude Code, OpenClaw, and other agent runtimes.",
   "author": {
     "name": "Open Second Brain contributors",

--- a/plugins/hermes/_schemas.py
+++ b/plugins/hermes/_schemas.py
@@ -602,6 +602,114 @@ STATIC_TOOL_SCHEMAS: tuple[dict[str, Any], ...] = (
                      'dependentRequired': {'recall_scores': ['match_quality'],
                                            'match_quality': ['recall_scores']},
                      'additionalProperties': False}},
+    {
+        "name": "brain_context_pack_outcome",
+        "description": "Context-pack outcome loop. `post` records an outcome row for a carried sample id — first-pass/repair/retry counters plus three SEPARATE token signals (exact, modeled, observed) — calibrates the token-impact ledger, and records the kernel's on-disk evidence. `list`/`summary` read rows. Gated.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": ["post", "list", "summary"],
+                    "description": "post writes one opt-in outcome row; list/summary read the durable ledger.",
+                },
+                "sample_id": {
+                    "type": "string",
+                    "description": "post: the carried recall/context-pack quality-sample id (a context-receipt id or opaque request hash) — never a raw prompt. Also a list/summary filter.",
+                },
+                "first_pass_success": {
+                    "type": "boolean",
+                    "description": "post: whether the packed context led to a first-pass success.",
+                },
+                "repair_required": {
+                    "type": "boolean",
+                    "description": "post (optional): whether the agent had to repair the first completion.",
+                },
+                "retry_count": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "post (optional): how many retries the completion needed.",
+                },
+                "follow_up_tokens": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "post (optional): tokens spent on follow-up turns after the first pass.",
+                },
+                "exact_prompt_token_savings": {
+                    "type": "number",
+                    "minimum": 0,
+                    "description": "post (optional): EXACT tokenizer-aware prompt-token savings (a measurement). Kept separate from the modeled and observed signals.",
+                },
+                "modeled_inference_avoidance": {
+                    "type": "number",
+                    "minimum": 0,
+                    "description": "post (optional): MODELED confidence-banded inference-avoidance estimate (a model). Kept separate from the exact and observed signals.",
+                },
+                "observed_provider_tokens": {
+                    "type": "number",
+                    "minimum": 0,
+                    "description": "post (optional): OBSERVED provider-reported token usage. Kept separate from the exact and modeled signals; also calibrates the token-impact ledger.",
+                },
+                "evidence_claim": {
+                    "type": "object",
+                    "description": "post (optional): what you assert about this sample; kernel reads its receipt off disk, records match|mismatch|unclaimed|unresolved. Malformed = INVALID_PARAMS.",
+                    "properties": {
+                        "final_text_hash": {
+                            "type": "string",
+                            "description": "Claimed SHA-256 of the assembled pack text.",
+                        },
+                        "item_count": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "description": "Claimed number of artifacts the pack injected.",
+                        },
+                        "final_text_chars": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "description": "Claimed codepoint length of the assembled pack text.",
+                        },
+                    },
+                    "additionalProperties": False,
+                },
+                "host": {
+                    "type": "string",
+                    "description": "Optional host/runtime label; also a filter.",
+                },
+                "session_id": {
+                    "type": "string",
+                    "description": "Optional session id recorded on the row.",
+                },
+                "turn_id": {
+                    "type": "string",
+                    "description": "Optional turn id recorded on the row.",
+                },
+                "agent_id": {
+                    "type": "string",
+                    "description": "post (optional): the ACTING agent, recorded on all three rows this post lands. Self-asserted, never a verifier; omitted records no actor rather than a guess.",
+                },
+                "since": {
+                    "type": "string",
+                    "description": "Optional inclusive lower timestamp bound.",
+                },
+                "until": {
+                    "type": "string",
+                    "description": "Optional inclusive upper timestamp bound.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Optional maximum record count for list.",
+                },
+                "max_samples": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Optional cap on the most-recent rows aggregated by summary.",
+                },
+            },
+            "required": ["operation"],
+            "additionalProperties": False,
+        },
+    },
     {'name': 'brain_pre_compact_extract',
      'description': 'Extract typed Decision/Commitment/Outcome/Rule/Open question records from '
                     'bounded text into continuity storage.',

--- a/plugins/hermes/plugin.yaml
+++ b/plugins/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: open-second-brain
-version: "1.52.0"
+version: "1.52.1"
 description: "Open Second Brain - native Hermes memory provider backed by an Obsidian-compatible Markdown vault."
 author: "Open Second Brain contributors"
 memory_provider: true

--- a/plugins/hermes/provider.py
+++ b/plugins/hermes/provider.py
@@ -48,6 +48,7 @@ MEMORY_TOOLS: tuple[str, ...] = (
     "brain_recall_gate",
     "brain_context",
     "brain_context_pack",
+    "brain_context_pack_outcome",
     # continuity
     "brain_pre_compact_extract",
 )
@@ -144,43 +145,6 @@ SESSION_TRANSCRIPT_FILENAME = "session-transcript.jsonl"
 # Token budget for the recall slice fetched on each prefetch.
 _PREFETCH_MAX_TOKENS = 1024
 _PREFETCH_RECEIPT_HOST = "hermes"
-
-# Only explicit user acknowledgements/corrections close a quality sample. A
-# neutral next turn is deliberately left unknown; guessing success would turn
-# the outcome ledger into a vanity metric.
-_EXPLICIT_REPAIR_MARKERS = (
-    "我之前说过",
-    "我已经说过",
-    "我提醒过",
-    "你忘了",
-    "又忘了",
-    "没记住",
-    "之前已经定过",
-    "不对",
-    "错了",
-)
-_EXPLICIT_SUCCESS_MARKERS = (
-    "对的",
-    "正确",
-    "这样就行",
-    "没问题",
-    "可以了",
-    "收到，谢谢",
-    "谢谢，正是",
-    "就这样",
-)
-
-
-def _explicit_outcome(query: str) -> tuple[bool, bool] | None:
-    """Return ``(first_pass_success, repair_required)`` only for explicit signals."""
-    text = (query or "").strip()
-    if not text:
-        return None
-    if any(marker in text for marker in _EXPLICIT_REPAIR_MARKERS):
-        return False, True
-    if any(marker in text for marker in _EXPLICIT_SUCCESS_MARKERS):
-        return True, False
-    return None
 
 # A provider instance is created per AIAgent, but the MCP server is a gateway
 # resource rather than a session resource. Keep one bridge per effective server
@@ -323,7 +287,7 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
         self._lock = threading.Lock()
         self._sync_threads: list[threading.Thread] = []
         self._queued_query: str = ""
-        self._pending_receipts: dict[str, str] = {}
+
 
     # -- required surface ----------------------------------------------------
 
@@ -364,8 +328,6 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
         self._session_id = session_id or ""
         self._hermes_home = kwargs.get("hermes_home")
         self._bridge_start_error = None
-        with self._lock:
-            self._pending_receipts.clear()
         old_bridge = self._bridge
         old_bridge_shared = self._bridge_shared
         self._bridge = None
@@ -635,44 +597,12 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
 
     # -- lifecycle hooks -----------------------------------------------------
 
-    def _remember_receipt(self, session_id: str, pack: Any) -> None:
-        """Keep the latest opaque receipt id per session until the next turn."""
-        structured = self._structured(pack)
+    @staticmethod
+    def _receipt_id(pack: Any) -> str | None:
+        """Return the server-issued opaque receipt id, if this pack has one."""
+        structured = OpenSecondBrainMemoryProvider._structured(pack)
         receipt_id = structured.get("receipt_id")
-        if not receipt_id:
-            return
-        sid = session_id or self._session_id
-        if not sid:
-            return
-        with self._lock:
-            self._pending_receipts[sid] = str(receipt_id)
-
-    def _close_explicit_outcome(self, session_id: str, query: str) -> None:
-        """Consume the immediate receipt; post only an explicit outcome."""
-        sid = session_id or self._session_id
-        with self._lock:
-            receipt_id = self._pending_receipts.pop(sid, None) if sid else None
-        outcome = _explicit_outcome(query)
-        if outcome is None or receipt_id is None:
-            return
-        first_pass_success, repair_required = outcome
-        result = self._safe_call(
-            "brain_context_pack_outcome",
-            {
-                "operation": "post",
-                "sample_id": receipt_id,
-                "first_pass_success": first_pass_success,
-                "repair_required": repair_required,
-                "host": _PREFETCH_RECEIPT_HOST,
-                **({"session_id": sid} if sid else {}),
-            },
-        )
-        if self._structured(result).get("recorded") is not True:
-            logger.warning(
-                "%s: explicit context-pack outcome was not recorded for %s",
-                self.PROVIDER_NAME,
-                receipt_id,
-            )
+        return str(receipt_id) if receipt_id else None
 
     def system_prompt_block(self) -> str:
         """Static provider context: the current active-preferences body."""
@@ -688,7 +618,6 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
         """
         parts: list[str] = []
         sid = session_id or self._session_id
-        self._close_explicit_outcome(sid, query)
         gate = self._structured(self._safe_call("brain_recall_gate", {"prompt": query}))
         if gate.get("retrieve"):
             pack = self._safe_call(
@@ -702,10 +631,22 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
                     **({"session_id": sid} if sid else {}),
                 },
             )
-            self._remember_receipt(sid, pack)
             recalled = self._context_pack_text(pack)
             if recalled:
                 parts.append(recalled)
+                receipt_id = self._receipt_id(pack)
+                if receipt_id:
+                    parts.append(
+                        "[O2B context-pack metadata] "
+                        + json.dumps(
+                            {
+                                "sample_id": receipt_id,
+                                "outcome": "unknown_until_explicit_tool_call",
+                                "tool": "brain_context_pack_outcome",
+                            },
+                            ensure_ascii=False,
+                        )
+                    )
         # Skill auto-attach (Agent Surface Suite): the TS side gates on the
         # skill_auto_attach config key and returns an empty block when off,
         # so the default injection stays byte-identical. Fail-soft like every

--- a/plugins/hermes/provider.py
+++ b/plugins/hermes/provider.py
@@ -143,6 +143,44 @@ SESSION_TRANSCRIPT_FILENAME = "session-transcript.jsonl"
 
 # Token budget for the recall slice fetched on each prefetch.
 _PREFETCH_MAX_TOKENS = 1024
+_PREFETCH_RECEIPT_HOST = "hermes"
+
+# Only explicit user acknowledgements/corrections close a quality sample. A
+# neutral next turn is deliberately left unknown; guessing success would turn
+# the outcome ledger into a vanity metric.
+_EXPLICIT_REPAIR_MARKERS = (
+    "我之前说过",
+    "我已经说过",
+    "我提醒过",
+    "你忘了",
+    "又忘了",
+    "没记住",
+    "之前已经定过",
+    "不对",
+    "错了",
+)
+_EXPLICIT_SUCCESS_MARKERS = (
+    "对的",
+    "正确",
+    "这样就行",
+    "没问题",
+    "可以了",
+    "收到，谢谢",
+    "谢谢，正是",
+    "就这样",
+)
+
+
+def _explicit_outcome(query: str) -> tuple[bool, bool] | None:
+    """Return ``(first_pass_success, repair_required)`` only for explicit signals."""
+    text = (query or "").strip()
+    if not text:
+        return None
+    if any(marker in text for marker in _EXPLICIT_REPAIR_MARKERS):
+        return False, True
+    if any(marker in text for marker in _EXPLICIT_SUCCESS_MARKERS):
+        return True, False
+    return None
 
 # A provider instance is created per AIAgent, but the MCP server is a gateway
 # resource rather than a session resource. Keep one bridge per effective server
@@ -285,6 +323,7 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
         self._lock = threading.Lock()
         self._sync_threads: list[threading.Thread] = []
         self._queued_query: str = ""
+        self._pending_receipts: dict[str, list[str]] = {}
 
     # -- required surface ----------------------------------------------------
 
@@ -325,6 +364,8 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
         self._session_id = session_id or ""
         self._hermes_home = kwargs.get("hermes_home")
         self._bridge_start_error = None
+        with self._lock:
+            self._pending_receipts.clear()
         old_bridge = self._bridge
         old_bridge_shared = self._bridge_shared
         self._bridge = None
@@ -594,6 +635,50 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
 
     # -- lifecycle hooks -----------------------------------------------------
 
+    def _remember_receipt(self, session_id: str, pack: Any) -> None:
+        """Keep one opaque receipt id per session until explicit feedback arrives."""
+        structured = self._structured(pack)
+        receipt_id = structured.get("receipt_id")
+        if not receipt_id:
+            return
+        sid = session_id or self._session_id
+        if not sid:
+            return
+        with self._lock:
+            self._pending_receipts.setdefault(sid, []).append(str(receipt_id))
+
+    def _close_explicit_outcome(self, session_id: str, query: str) -> None:
+        """Post only an explicit acknowledgement/correction; neutral stays unknown."""
+        outcome = _explicit_outcome(query)
+        if outcome is None:
+            return
+        sid = session_id or self._session_id
+        with self._lock:
+            receipts = self._pending_receipts.get(sid, [])
+            receipt_id = receipts.pop() if receipts else None
+            if not receipts:
+                self._pending_receipts.pop(sid, None)
+        if receipt_id is None:
+            return
+        first_pass_success, repair_required = outcome
+        result = self._safe_call(
+            "brain_context_pack_outcome",
+            {
+                "operation": "post",
+                "sample_id": receipt_id,
+                "first_pass_success": first_pass_success,
+                "repair_required": repair_required,
+                "host": _PREFETCH_RECEIPT_HOST,
+                **({"session_id": sid} if sid else {}),
+            },
+        )
+        if self._structured(result).get("recorded") is not True:
+            logger.warning(
+                "%s: explicit context-pack outcome was not recorded for %s",
+                self.PROVIDER_NAME,
+                receipt_id,
+            )
+
     def system_prompt_block(self) -> str:
         """Static provider context: the current active-preferences body."""
         result = self._safe_call("brain_context", {})
@@ -607,9 +692,22 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
         always appended when an agent identity is configured.
         """
         parts: list[str] = []
+        sid = session_id or self._session_id
+        self._close_explicit_outcome(sid, query)
         gate = self._structured(self._safe_call("brain_recall_gate", {"prompt": query}))
         if gate.get("retrieve"):
-            pack = self._safe_call("brain_context_pack", {"max_tokens": _PREFETCH_MAX_TOKENS})
+            pack = self._safe_call(
+                "brain_context_pack",
+                {
+                    "max_tokens": _PREFETCH_MAX_TOKENS,
+                    "receipt": True,
+                    "receipt_host": _PREFETCH_RECEIPT_HOST,
+                    "telemetry": True,
+                    "telemetry_host": _PREFETCH_RECEIPT_HOST,
+                    **({"session_id": sid} if sid else {}),
+                },
+            )
+            self._remember_receipt(sid, pack)
             recalled = self._context_pack_text(pack)
             if recalled:
                 parts.append(recalled)

--- a/plugins/hermes/provider.py
+++ b/plugins/hermes/provider.py
@@ -323,7 +323,7 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
         self._lock = threading.Lock()
         self._sync_threads: list[threading.Thread] = []
         self._queued_query: str = ""
-        self._pending_receipts: dict[str, list[str]] = {}
+        self._pending_receipts: dict[str, str] = {}
 
     # -- required surface ----------------------------------------------------
 
@@ -636,7 +636,7 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
     # -- lifecycle hooks -----------------------------------------------------
 
     def _remember_receipt(self, session_id: str, pack: Any) -> None:
-        """Keep one opaque receipt id per session until explicit feedback arrives."""
+        """Keep the latest opaque receipt id per session until the next turn."""
         structured = self._structured(pack)
         receipt_id = structured.get("receipt_id")
         if not receipt_id:
@@ -645,20 +645,15 @@ class OpenSecondBrainMemoryProvider(MemoryProvider):
         if not sid:
             return
         with self._lock:
-            self._pending_receipts.setdefault(sid, []).append(str(receipt_id))
+            self._pending_receipts[sid] = str(receipt_id)
 
     def _close_explicit_outcome(self, session_id: str, query: str) -> None:
-        """Post only an explicit acknowledgement/correction; neutral stays unknown."""
-        outcome = _explicit_outcome(query)
-        if outcome is None:
-            return
+        """Consume the immediate receipt; post only an explicit outcome."""
         sid = session_id or self._session_id
         with self._lock:
-            receipts = self._pending_receipts.get(sid, [])
-            receipt_id = receipts.pop() if receipts else None
-            if not receipts:
-                self._pending_receipts.pop(sid, None)
-        if receipt_id is None:
+            receipt_id = self._pending_receipts.pop(sid, None) if sid else None
+        outcome = _explicit_outcome(query)
+        if outcome is None or receipt_id is None:
             return
         first_pass_success, repair_required = outcome
         result = self._safe_call(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 # CLI entry points (those moved to `package.json` `bin`).
 [project]
 name = "open-second-brain"
-version = "1.52.0"
+version = "1.52.1"
 description = "Hermes Python shim for Open Second Brain. Most of the project (CLI, MCP server, OpenClaw plugin) is TypeScript on Bun; see package.json."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/python/test_memory_provider.py
+++ b/tests/python/test_memory_provider.py
@@ -802,6 +802,56 @@ class ProviderLifecycleTests(unittest.TestCase):
         self.assertIn("RECALLED", out)
         self.assertIn("@pf-agent", out)
 
+    def test_prefetch_receipt_and_explicit_repair_outcome_share_sample(self):
+        bridge = FakeBrainBridge(
+            results={
+                "brain_recall_gate": {"structuredContent": {"retrieve": True}},
+                "brain_context_pack": {
+                    "structuredContent": {
+                        "receipt_id": "receipt-1",
+                        "items": [{"title": "decision", "body": "keep RRF"}],
+                    }
+                },
+                "brain_context_pack_outcome": {"structuredContent": {"recorded": True}},
+            }
+        )
+        provider = self._init(bridge, hermes_home="/tmp/hh")
+        provider.prefetch("what did we decide", session_id="sess-1")
+        provider.prefetch("我之前说过，不对", session_id="sess-1")
+
+        pack_args = next(a for n, a in bridge.calls if n == "brain_context_pack")
+        self.assertIs(pack_args["receipt"], True)
+        self.assertEqual(pack_args["receipt_host"], "hermes")
+        self.assertIs(pack_args["telemetry"], True)
+        self.assertEqual(pack_args["telemetry_host"], "hermes")
+        self.assertEqual(pack_args["session_id"], "sess-1")
+
+        outcome_args = next(a for n, a in bridge.calls if n == "brain_context_pack_outcome")
+        self.assertEqual(outcome_args["operation"], "post")
+        self.assertEqual(outcome_args["sample_id"], "receipt-1")
+        self.assertIs(outcome_args["first_pass_success"], False)
+        self.assertIs(outcome_args["repair_required"], True)
+        self.assertEqual(outcome_args["session_id"], "sess-1")
+
+    def test_prefetch_leaves_neutral_outcome_unknown(self):
+        bridge = FakeBrainBridge(
+            results={
+                "brain_recall_gate": {"structuredContent": {"retrieve": True}},
+                "brain_context_pack": {
+                    "structuredContent": {
+                        "receipt_id": "receipt-neutral",
+                        "items": [{"title": "decision", "body": "keep RRF"}],
+                    }
+                },
+            }
+        )
+        provider = self._init(bridge, hermes_home="/tmp/hh")
+        provider.prefetch("what did we decide", session_id="sess-1")
+        provider.prefetch("tell me something else", session_id="sess-1")
+        self.assertEqual(
+            [name for name, _ in bridge.calls if name == "brain_context_pack_outcome"], []
+        )
+
     def test_prefetch_uses_structured_items_bodies_and_skips_preview_envelope(self):
         # Regression: when brain_context_pack returns both structuredContent
         # items[*].body AND a content[0].text envelope carrying the

--- a/tests/python/test_memory_provider.py
+++ b/tests/python/test_memory_provider.py
@@ -802,7 +802,7 @@ class ProviderLifecycleTests(unittest.TestCase):
         self.assertIn("RECALLED", out)
         self.assertIn("@pf-agent", out)
 
-    def test_prefetch_receipt_and_explicit_repair_outcome_share_sample(self):
+    def test_prefetch_exposes_receipt_and_agent_posts_structured_outcome(self):
         bridge = FakeBrainBridge(
             results={
                 "brain_recall_gate": {"structuredContent": {"retrieve": True}},
@@ -815,10 +815,22 @@ class ProviderLifecycleTests(unittest.TestCase):
                 "brain_context_pack_outcome": {"structuredContent": {"recorded": True}},
             }
         )
-        provider = self._init(bridge, hermes_home="/tmp/hh")
-        provider.prefetch("what did we decide", session_id="sess-1")
-        provider.prefetch("我之前说过，不对", session_id="sess-1")
+        with tempfile.TemporaryDirectory() as hermes_home:
+            provider = self._init(bridge, hermes_home=hermes_home)
+            out = provider.prefetch("what did we decide", session_id="sess-1")
+            provider.handle_tool_call(
+                "brain_context_pack_outcome",
+                {
+                    "operation": "post",
+                    "sample_id": "receipt-1",
+                    "first_pass_success": False,
+                    "repair_required": True,
+                    "host": "hermes",
+                    "session_id": "sess-1",
+                },
+            )
 
+        self.assertIn('"sample_id": "receipt-1"', out)
         pack_args = next(a for n, a in bridge.calls if n == "brain_context_pack")
         self.assertIs(pack_args["receipt"], True)
         self.assertEqual(pack_args["receipt_host"], "hermes")
@@ -852,7 +864,7 @@ class ProviderLifecycleTests(unittest.TestCase):
             [name for name, _ in bridge.calls if name == "brain_context_pack_outcome"], []
         )
 
-    def test_prefetch_expires_receipt_on_neutral_turn_before_explicit_feedback(self):
+    def test_prefetch_never_infers_outcome_from_raw_turn_text(self):
         gate_calls = 0
 
         def gate(_args):
@@ -865,17 +877,17 @@ class ProviderLifecycleTests(unittest.TestCase):
                 "brain_recall_gate": gate,
                 "brain_context_pack": {
                     "structuredContent": {
-                        "receipt_id": "receipt-expired",
+                        "receipt_id": "receipt-unknown",
                         "items": [{"title": "decision", "body": "keep RRF"}],
                     }
                 },
-                "brain_context_pack_outcome": {"structuredContent": {"recorded": True}},
             }
         )
-        provider = self._init(bridge, hermes_home="/tmp/hh")
-        provider.prefetch("what did we decide", session_id="sess-1")
-        provider.prefetch("tell me something else", session_id="sess-1")
-        provider.prefetch("我之前说过，不对", session_id="sess-1")
+        with tempfile.TemporaryDirectory() as hermes_home:
+            provider = self._init(bridge, hermes_home=hermes_home)
+            provider.prefetch("what did we decide", session_id="sess-1")
+            provider.prefetch("tell me something else", session_id="sess-1")
+            provider.prefetch("我之前说过，不对", session_id="sess-1")
 
         self.assertEqual(gate_calls, 3)
         self.assertEqual(

--- a/tests/python/test_memory_provider.py
+++ b/tests/python/test_memory_provider.py
@@ -852,6 +852,40 @@ class ProviderLifecycleTests(unittest.TestCase):
             [name for name, _ in bridge.calls if name == "brain_context_pack_outcome"], []
         )
 
+    def test_prefetch_expires_receipt_on_neutral_turn_before_explicit_feedback(self):
+        gate_calls = 0
+
+        def gate(_args):
+            nonlocal gate_calls
+            gate_calls += 1
+            return {"structuredContent": {"retrieve": gate_calls == 1}}
+
+        bridge = FakeBrainBridge(
+            results={
+                "brain_recall_gate": gate,
+                "brain_context_pack": {
+                    "structuredContent": {
+                        "receipt_id": "receipt-expired",
+                        "items": [{"title": "decision", "body": "keep RRF"}],
+                    }
+                },
+                "brain_context_pack_outcome": {"structuredContent": {"recorded": True}},
+            }
+        )
+        provider = self._init(bridge, hermes_home="/tmp/hh")
+        provider.prefetch("what did we decide", session_id="sess-1")
+        provider.prefetch("tell me something else", session_id="sess-1")
+        provider.prefetch("我之前说过，不对", session_id="sess-1")
+
+        self.assertEqual(gate_calls, 3)
+        self.assertEqual(
+            [name for name, _ in bridge.calls if name == "brain_context_pack"],
+            ["brain_context_pack"],
+        )
+        self.assertEqual(
+            [name for name, _ in bridge.calls if name == "brain_context_pack_outcome"], []
+        )
+
     def test_prefetch_uses_structured_items_bodies_and_skips_preview_envelope(self):
         # Regression: when brain_context_pack returns both structuredContent
         # items[*].body AND a content[0].text envelope carrying the


### PR DESCRIPTION
## Summary

The Hermes provider currently calls `brain_recall_gate` and `brain_context_pack` during `prefetch`, but does not request a context receipt or record a later outcome. This leaves the O2B context-pack outcome ledger empty even when recall is actually injected.

This patch:

- requests an O2B context receipt and opt-in telemetry from the same `brain_context_pack` call;
- carries the receipt id per session;
- records an outcome only when the next user turn contains an explicit acknowledgement or correction;
- leaves neutral turns unknown instead of guessing first-pass success;
- keeps the existing prefetch budget and fail-soft bridge behavior unchanged.

## Verification

- `uv run python -m unittest discover -s tests/python -p 'test_memory_provider.py' -v` — 103 provider tests passed.
- `uv run python -m unittest discover -s tests/python -p 'test_memory_provider.py' -k hooks_are_exception_safe -v` — passed; bridge failures degrade to no recall.
- `uv run python -m py_compile plugins/hermes/provider.py tests/python/test_memory_provider.py` — passed.
- `bun run typecheck` — passed (also passed the pre-push hook).
- `bun run lint` — exit 0 with existing repository warnings.
- `bun run test` — 11,618 passed / 75 existing fixture/config failures; failures are outside this Python provider diff and are listed by the raw run.
- Disposable real-MCP E2E with a MOCK vault: two receipts read back (`receipt_count=2`), one explicit repair outcome read back (`total=1`, `repair_required=1`), no production vault writes.

No permanent config, injection-budget, O2B core, dream, or retirement changes are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for explicitly submitting structured outcomes for prefetched context.
  - Context responses now include receipt information when available, enabling outcome reporting tied to the relevant context.
  - Outcome submissions support success, repair, and summary details with validation for metrics and evidence.

- **Improvements**
  - Follow-up text alone no longer produces inferred outcome reports or additional context retrieval.
  - Improved tracking of pending context evaluations and outcome metadata.

- **Release**
  - Updated the plugin to version 1.52.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->